### PR TITLE
fix: correct ARIA attribute in newsletter field

### DIFF
--- a/src/components/bookworm/Footer.tsx
+++ b/src/components/bookworm/Footer.tsx
@@ -163,8 +163,8 @@ export default function Footer() {
                 aria-label="Enter your email address"
                 placeholder="Your email address"
                 inputProps={{
-                  autocomplete: "off",
-                  ariaLabel: "Enter your email address",
+                  autoComplete: "off",
+                  "aria-label": "Enter your email address",
                 }}
               />
               <Button


### PR DESCRIPTION
## Summary
- use `aria-label` and correct `autoComplete` on newsletter TextField

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8102a55ec8330b10098f4052b4b9e