### PR TITLE
Fix PDF.js worker version mismatch

### DIFF
--- a/src/utils/bookworm/utils.ts
+++ b/src/utils/bookworm/utils.ts
@@ -138,7 +138,7 @@ window.Buffer = window.Buffer || Buffer;
 export async function pdfToMarkdown(file: File): Promise<string> {
   const reader = new FileReader();
   const workerSrc =
-    "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.1.392/pdf.worker.min.mjs";
+    `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`;
 
   pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 


### PR DESCRIPTION
## Summary
- Ensure pdf.js worker matches the library version by dynamically referencing `pdfjs.version`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a81080f3e883308a5b7897f59214de