### PR TITLE
Fix nested paragraph tags in chat messages

### DIFF
--- a/src/components/bookworm/Hero.tsx
+++ b/src/components/bookworm/Hero.tsx
@@ -300,6 +300,7 @@ export default function Hero() {
                 )}
                 <Typography
                   variant="body2"
+                  component="div"
                   sx={{
                     whiteSpace: "pre-wrap",
                     color:


### PR DESCRIPTION
## Summary
- avoid nested `<p>` tags when rendering Markdown in Hero

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a81098c7b48330897b7c7df679d783