### PR TITLE
fix: avoid nested paragraphs in chat messages

### DIFF
--- a/src/components/bookworm/Hero.tsx
+++ b/src/components/bookworm/Hero.tsx
@@ -300,6 +300,7 @@ export default function Hero() {
                 )}
                 <Typography
                   variant="body2"
+                  component="div"
                   sx={{
                     whiteSpace: "pre-wrap",
                     color:


### PR DESCRIPTION
## Summary
- prevent nested `<p>` tags when rendering chat messages by rendering the Typography as a `div`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a810aaa9f08330913c941c104fec8c