### PR TITLE
fix: guard Buffer polyfill for server environments

### DIFF
--- a/src/utils/bookworm/utils.ts
+++ b/src/utils/bookworm/utils.ts
@@ -133,7 +133,15 @@ export const askOpenAI = async ({
   return newChatHistory[newChatIndex];
 };
 
-window.Buffer = window.Buffer || Buffer;
+declare global {
+  interface Window {
+    Buffer: typeof Buffer;
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.Buffer = window.Buffer || Buffer;
+}
 
 export async function pdfToMarkdown(file: File): Promise<string> {
   const reader = new FileReader();


### PR DESCRIPTION
## Summary
- avoid referencing `window` on the server by guarding Buffer polyfill with a `typeof window` check
- declare `Window.Buffer` globally for type safety

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a81069081c83308d8a79e82a25f4c0