### PR TITLE
fix: correct dna sample asset paths

### DIFF
--- a/src/components/dna/AddSequenceCard.tsx
+++ b/src/components/dna/AddSequenceCard.tsx
@@ -63,17 +63,9 @@ export default function AddSequenceCard({
   const loadSampleMenuOpen = Boolean(loadSampleMenuEl);
 
   const loadSample = async (sample: string) => {
-    let rawSequenceContent = await (
-      await fetch(`${window.location.pathname}/assets/dna/examples/${sample}`)
+    const rawSequenceContent = await (
+      await fetch(`/assets/dna/examples/${sample}`)
     ).text();
-
-    const isError = rawSequenceContent.startsWith("<!DOCTYPE html>");
-    isError &&
-      (rawSequenceContent = await (
-        await fetch(
-          `${window.location.pathname}/public/assets/dna/examples/${sample}`
-        )
-      ).text());
 
     parseSequence(rawSequenceContent, sample, (parsedSequence) => {
       parsedSequence.sequence = parsedSequence.sequence.trim();
@@ -162,6 +154,7 @@ export default function AddSequenceCard({
             .sort()
             .map((sample) => (
               <MenuItem
+                key={sample}
                 onClick={() => {
                   loadSample(sample);
                   setLoadSampleMenuEl(null);


### PR DESCRIPTION
## Summary
- fetch DNA sample files from the public assets root
- add a key to sample menu items for React

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @next/next/no-sync-scripts and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a877233dc8833084420b402c8ab678