### PR TITLE
Use base path for DNA sample assets

### DIFF
--- a/src/components/dna/AddSequenceCard.tsx
+++ b/src/components/dna/AddSequenceCard.tsx
@@ -11,6 +11,7 @@ import { parseSequence } from "@/utils/dna/sequenceUtils";
 import { blue, grey } from "./colors";
 import Title from "../app/Title";
 import { Science } from "@mui/icons-material";
+import { withBasePath } from "@/utils/basePath";
 
 const Textarea = styled(TextareaAutosize)(
   ({ theme }) => `
@@ -64,7 +65,7 @@ export default function AddSequenceCard({
 
   const loadSample = async (sample: string) => {
     const rawSequenceContent = await (
-      await fetch(`/assets/dna/examples/${sample}`)
+      await fetch(withBasePath(`/assets/dna/examples/${sample}`))
     ).text();
 
     parseSequence(rawSequenceContent, sample, (parsedSequence) => {


### PR DESCRIPTION
## Summary
- prefix DNA sample example fetches with `withBasePath` so assets resolve under a GitHub Pages subpath

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/components/dna/AddSequenceCard.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a8e0565e988330a0b96ab922511f81