### PR TITLE
Add resume hero banner using MUI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,95 +1,19 @@
-import Image from "next/image";
-import styles from "./page.module.css";
+"use client";
+
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
+import Container from "@mui/material/Container";
+import ResumeHero from "@/components/app/ResumeHero";
 
 export default function Home() {
-  return (
-    <div className={styles.page}>
-      <main className={styles.main}>
-        <Image
-          className={styles.logo}
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol>
-          <li>
-            Get started by editing <code>src/app/page.tsx</code>.
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
+  const defaultTheme = createTheme();
 
-        <div className={styles.ctas}>
-          <a
-            className={styles.primary}
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className={styles.logo}
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.secondary}
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className={styles.footer}>
-        <a
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+  return (
+    <ThemeProvider theme={defaultTheme}>
+      <CssBaseline />
+      <Container>
+        <ResumeHero />
+      </Container>
+    </ThemeProvider>
   );
 }

--- a/src/components/app/ResumeHero.tsx
+++ b/src/components/app/ResumeHero.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+
+export default function ResumeHero() {
+  return (
+    <Box sx={{ textAlign: "center", py: 8 }}>
+      <Typography component="h1" variant="h3" gutterBottom>
+        R. Franks
+      </Typography>
+      <Typography component="h2" variant="h5" color="text.secondary" gutterBottom>
+        Software Engineer
+      </Typography>
+      <Typography sx={{ mb: 4 }}>
+        Looking for my next opportunity
+      </Typography>
+      <Button variant="contained" color="primary">
+        Contact Me
+      </Button>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- use MUI `ThemeProvider` and `Container` on home page
- add `ResumeHero` component with name, title, and tagline

## Testing
- `npm run lint src/app/page.tsx src/components/app/ResumeHero.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a93eab336c8330b39e92c6972ac056