### PR TITLE
Add ResumeSummary component to display resume summary

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider, createTheme } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import Container from "@mui/material/Container";
 import ResumeHero from "@/components/app/ResumeHero";
+import ResumeSummary from "@/components/app/ResumeSummary";
 
 export default function Home() {
   const defaultTheme = createTheme();
@@ -13,6 +14,7 @@ export default function Home() {
       <CssBaseline />
       <Container>
         <ResumeHero />
+        <ResumeSummary />
       </Container>
     </ThemeProvider>
   );

--- a/src/components/app/ResumeSummary.tsx
+++ b/src/components/app/ResumeSummary.tsx
@@ -1,0 +1,14 @@
+import Typography from "@mui/material/Typography";
+import Paper from "@mui/material/Paper";
+import { summary } from "@/consts/resumeData";
+
+export default function ResumeSummary() {
+  return (
+    <Paper sx={{ p: 2, mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        Summary
+      </Typography>
+      <Typography>{summary.blurb}</Typography>
+    </Paper>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ResumeSummary` component using Material UI Paper and Typography to show resume summary
- render `ResumeSummary` below `ResumeHero` on homepage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a942b3fccc83308396ef5b99cdb57c