### PR TITLE
Add core competencies section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import Container from "@mui/material/Container";
 import ResumeHero from "@/components/app/ResumeHero";
 import ResumeSummary from "@/components/app/ResumeSummary";
+import CoreCompetencies from "@/components/app/CoreCompetencies";
 
 export default function Home() {
   const defaultTheme = createTheme();
@@ -15,6 +16,7 @@ export default function Home() {
       <Container>
         <ResumeHero />
         <ResumeSummary />
+        <CoreCompetencies />
       </Container>
     </ThemeProvider>
   );

--- a/src/components/app/CoreCompetencies.tsx
+++ b/src/components/app/CoreCompetencies.tsx
@@ -1,0 +1,20 @@
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { coreCompetencies } from "@/consts/resumeData";
+
+export default function CoreCompetencies() {
+  return (
+    <Paper sx={{ p: 2, mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        Core Competencies
+      </Typography>
+      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        {coreCompetencies.map((competency) => (
+          <Chip key={competency} label={competency} sx={{ mb: 1 }} />
+        ))}
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/consts/resumeData.ts
+++ b/src/consts/resumeData.ts
@@ -118,6 +118,8 @@ export const competencies = {
   ],
 };
 
+export const coreCompetencies = competencies.skills;
+
 export const experience = [
   {
     company: "Commure",


### PR DESCRIPTION
## Summary
- expose `coreCompetencies` from resume data
- add `CoreCompetencies` component rendering chips
- mount core competencies on home page after summary

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a943660b9083309e509b5f069a7bb1