### PR TITLE
Add resume experience timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fontsource/roboto": "^5.0.13",
     "@mui/icons-material": "^6.5.0",
     "@mui/material": "^6.5.0",
+    "@mui/lab": "^6.5.0",
     "bio-parsers": "^9.3.6",
     "dnaviz": "^1.1.1",
     "lodash": "^4.17.21",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Container from "@mui/material/Container";
 import ResumeHero from "@/components/app/ResumeHero";
 import ResumeSummary from "@/components/app/ResumeSummary";
 import CoreCompetencies from "@/components/app/CoreCompetencies";
+import ExperienceTimeline from "@/components/app/ExperienceTimeline";
 
 export default function Home() {
   const defaultTheme = createTheme();
@@ -17,6 +18,7 @@ export default function Home() {
         <ResumeHero />
         <ResumeSummary />
         <CoreCompetencies />
+        <ExperienceTimeline />
       </Container>
     </ThemeProvider>
   );

--- a/src/components/app/ExperienceTimeline.tsx
+++ b/src/components/app/ExperienceTimeline.tsx
@@ -1,0 +1,56 @@
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import Timeline from "@mui/lab/Timeline";
+import TimelineItem from "@mui/lab/TimelineItem";
+import TimelineSeparator from "@mui/lab/TimelineSeparator";
+import TimelineConnector from "@mui/lab/TimelineConnector";
+import TimelineContent from "@mui/lab/TimelineContent";
+import TimelineDot from "@mui/lab/TimelineDot";
+import TimelineOppositeContent from "@mui/lab/TimelineOppositeContent";
+import { experience } from "@/consts/resumeData";
+
+export default function ExperienceTimeline() {
+  return (
+    <Paper sx={{ p: 2, mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        Experience
+      </Typography>
+      <Timeline>
+        {experience.map((exp, index) => (
+          <TimelineItem key={`${exp.company}-${index}`}>
+            <TimelineOppositeContent color="text.secondary">
+              {exp.start}
+              {exp.end ? ` - ${exp.end}` : ""}
+            </TimelineOppositeContent>
+            <TimelineSeparator>
+              <TimelineDot />
+              {index < experience.length - 1 && <TimelineConnector />}
+            </TimelineSeparator>
+            <TimelineContent>
+              <Typography variant="subtitle1">{exp.company}</Typography>
+              <Typography variant="body2" color="text.secondary">
+                {exp.position}
+                {exp.location ? `, ${exp.location}` : ""}
+              </Typography>
+              {exp.details && (
+                <ul style={{ margin: 0 }}>
+                  {exp.details.map((detail) => (
+                    <li key={detail}>{detail}</li>
+                  ))}
+                </ul>
+              )}
+              {exp.achievements && (
+                <ul style={{ margin: 0 }}>
+                  {exp.achievements.map((ach) => (
+                    <li key={ach}>{ach}</li>
+                  ))}
+                </ul>
+              )}
+            </TimelineContent>
+          </TimelineItem>
+        ))}
+      </Timeline>
+    </Paper>
+  );
+}
+


### PR DESCRIPTION
## Summary
- integrate MUI Lab dependency for timeline components
- implement `ExperienceTimeline` component to render work history
- display timeline beneath core competencies on the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Can't resolve '@mui/lab/TimelineConnector' due to missing package)*

------
https://chatgpt.com/codex/tasks/task_e_68a94429ab808330aeff42640584a8d3