### PR TITLE
Add project cards grid

### DIFF
--- a/src/components/app/ProjectsGrid.tsx
+++ b/src/components/app/ProjectsGrid.tsx
@@ -1,0 +1,37 @@
+import * as resumeData from "@/consts/resumeData";
+import Paper from "@mui/material/Paper";
+import Grid from "@mui/material/Grid";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardActions from "@mui/material/CardActions";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+
+export default function ProjectsGrid() {
+  return (
+    <Paper sx={{ p: 2, mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        Projects
+      </Typography>
+      <Grid container spacing={2}>
+        {resumeData.projects.map((project) => (
+          <Grid item xs={12} sm={6} md={4} key={project.href}>
+            <Card variant="outlined">
+              <CardContent>
+                <Typography variant="subtitle1">{project.name}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {project.description}
+                </Typography>
+              </CardContent>
+              <CardActions>
+                <Button size="small" href={project.href}>
+                  Launch
+                </Button>
+              </CardActions>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Paper>
+  );
+}

--- a/src/consts/resumeData.ts
+++ b/src/consts/resumeData.ts
@@ -187,16 +187,29 @@ export const experience = [
 
 export const projects = [
   {
-    name: "patient-list-app",
-    description: "Java-based Patient List powering EHR full-stack workflows.",
+    name: "Warbirds",
+    description: "Dogfight through the skies in this arcade shooter.",
+    href: "/warbirds",
   },
   {
-    name: "pk-cloud-functions",
-    description: "Python/Azure RAG + CRUD APIs with Next.js UI.",
+    name: "ZombieFish",
+    description: "Hook undead fish before they bite.",
+    href: "/zombiefish",
   },
   {
-    name: "pk-common-ui",
-    description: "Reusable React/TypeScript component library supporting enterprise adoption.",
+    name: "Blackjack",
+    description: "Classic twenty-one card game against the dealer.",
+    href: "/blackjack",
+  },
+  {
+    name: "GeneBoard",
+    description: "Interactive tools for exploring DNA sequences.",
+    href: "/dna",
+  },
+  {
+    name: "Bookworm",
+    description: "Word puzzle game built with React.",
+    href: "/bookworm",
   },
 ];
 


### PR DESCRIPTION
## Summary
- define portfolio project metadata for Warbirds, ZombieFish, Blackjack, GeneBoard, and Bookworm
- display a ProjectsGrid component mapping metadata to Material UI cards with Launch buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9454a0e7883309d27c84f35a615c9