### PR TITLE
Add recognition component with recommendations

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,8 @@ import ResumeHero from "@/components/app/ResumeHero";
 import ResumeSummary from "@/components/app/ResumeSummary";
 import CoreCompetencies from "@/components/app/CoreCompetencies";
 import ExperienceTimeline from "@/components/app/ExperienceTimeline";
+import ProjectsGrid from "@/components/app/ProjectsGrid";
+import Recognition from "@/components/app/Recognition";
 
 export default function Home() {
   const defaultTheme = createTheme();
@@ -19,6 +21,8 @@ export default function Home() {
         <ResumeSummary />
         <CoreCompetencies />
         <ExperienceTimeline />
+        <ProjectsGrid />
+        <Recognition />
       </Container>
     </ThemeProvider>
   );

--- a/src/components/app/Recognition.tsx
+++ b/src/components/app/Recognition.tsx
@@ -1,0 +1,59 @@
+import * as resumeData from "@/consts/resumeData";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import Grid from "@mui/material/Grid";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+
+export default function Recognition() {
+  return (
+    <Paper sx={{ p: 2, mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        Recognition
+      </Typography>
+      <Grid container spacing={2} sx={{ mb: 2 }}>
+        {resumeData.recognition.snippets.map((snippet, idx) => (
+          <Grid item xs={12} sm={4} key={idx}>
+            <Card variant="outlined">
+              <CardContent>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ fontStyle: "italic" }}
+                >
+                  {snippet}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+      <Typography variant="h6" gutterBottom>
+        Recommendations
+      </Typography>
+      <Grid container spacing={2}>
+        {resumeData.recognition.recommendations.map((rec) => (
+          <Grid item xs={12} key={`${rec.name}-${rec.date}`}>
+            <Card variant="outlined">
+              <CardContent>
+                <Typography variant="subtitle1" fontWeight="bold" color="primary">
+                  {rec.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {rec.title} · {rec.date}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {rec.relationship}
+                </Typography>
+                <Typography variant="body1" sx={{ mt: 1, fontStyle: "italic" }}>
+                  {rec.text}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Paper>
+  );
+}
+


### PR DESCRIPTION
## Summary
- display recognition snippets and peer recommendations from resume data
- show projects and new recognition sections on main page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a94652166883309e38b98cf5fe8deb