### PR TITLE
Add education section to home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import ResumeSummary from "@/components/app/ResumeSummary";
 import CoreCompetencies from "@/components/app/CoreCompetencies";
 import ExperienceTimeline from "@/components/app/ExperienceTimeline";
 import ProjectsGrid from "@/components/app/ProjectsGrid";
+import Education from "@/components/app/Education";
 import Recognition from "@/components/app/Recognition";
 
 export default function Home() {
@@ -22,6 +23,7 @@ export default function Home() {
         <CoreCompetencies />
         <ExperienceTimeline />
         <ProjectsGrid />
+        <Education />
         <Recognition />
       </Container>
     </ThemeProvider>

--- a/src/components/app/Education.tsx
+++ b/src/components/app/Education.tsx
@@ -1,0 +1,23 @@
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import { education } from "@/consts/resumeData";
+
+export default function Education() {
+  return (
+    <Paper sx={{ p: 2, mb: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        Education
+      </Typography>
+      <List>
+        {education.map((edu, index) => (
+          <ListItem key={`${edu.school}-${index}`}>
+            <ListItemText primary={edu.school} secondary={edu.degree} />
+          </ListItem>
+        ))}
+      </List>
+    </Paper>
+  );
+}


### PR DESCRIPTION
## Summary
- add education component listing degrees
- include education section on home page after projects

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a94719582083308d075eceed1643f4