### PR TITLE
Add contact call-to-action component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import ExperienceTimeline from "@/components/app/ExperienceTimeline";
 import ProjectsGrid from "@/components/app/ProjectsGrid";
 import Education from "@/components/app/Education";
 import Recognition from "@/components/app/Recognition";
+import ContactCTA from "@/components/app/ContactCTA";
 
 export default function Home() {
   const defaultTheme = createTheme();
@@ -25,6 +26,7 @@ export default function Home() {
         <ProjectsGrid />
         <Education />
         <Recognition />
+        <ContactCTA />
       </Container>
     </ThemeProvider>
   );

--- a/src/components/app/ContactCTA.tsx
+++ b/src/components/app/ContactCTA.tsx
@@ -1,0 +1,32 @@
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import Stack from "@mui/material/Stack";
+import Button from "@mui/material/Button";
+import { summary } from "@/consts/resumeData";
+
+export default function ContactCTA() {
+  return (
+    <Paper sx={{ p: 2, mb: 4, textAlign: "center" }}>
+      <Typography variant="h6" gutterBottom>
+        Contact
+      </Typography>
+      <Stack direction="row" spacing={2} justifyContent="center">
+        <Button
+          variant="contained"
+          color="primary"
+          href={`mailto:${summary.contact.email}`}
+        >
+          Email
+        </Button>
+        <Button
+          variant="outlined"
+          href={summary.contact.linkedin}
+          target="_blank"
+          rel="noopener"
+        >
+          LinkedIn
+        </Button>
+      </Stack>
+    </Paper>
+  );
+}


### PR DESCRIPTION
## Summary
- add ContactCTA component with email and LinkedIn buttons
- render ContactCTA at bottom of homepage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a947c36b348330b6de286256032a1e