### PR TITLE
feat: add color mode toggle to app bar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { PaletteMode } from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
 import Container from "@mui/material/Container";
 import Box from "@mui/material/Box";
@@ -35,18 +36,30 @@ import Recognition from "@/components/app/Recognition";
 import ContactCTA from "@/components/app/ContactCTA";
 
 export default function Home() {
-  const defaultTheme = createTheme({
-    palette: {
-      mode: "dark",
-      primary: { main: "#00f0ff" },
-      secondary: { main: "#ff007f" },
-      background: { default: "#000914", paper: "#001e3c" },
-      text: { primary: "#e0f7ff", secondary: "#8ce2ff" },
-    },
-    typography: {
-      fontFamily: '"Roboto", sans-serif',
-    },
-  });
+  const [mode, setMode] = useState<PaletteMode>("dark");
+  const defaultTheme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode,
+          primary: { main: "#00f0ff" },
+          secondary: { main: "#ff007f" },
+          ...(mode === "light"
+            ? {
+                background: { default: "#f5f5f5", paper: "#ffffff" },
+                text: { primary: "#001e3c", secondary: "#334e68" },
+              }
+            : {
+                background: { default: "#000914", paper: "#001e3c" },
+                text: { primary: "#e0f7ff", secondary: "#8ce2ff" },
+              }),
+        },
+        typography: {
+          fontFamily: '"Roboto", sans-serif',
+        },
+      }),
+    [mode]
+  );
   const [open, setOpen] = useState(false);
   const drawerWidth = 240;
 
@@ -54,31 +67,39 @@ export default function Home() {
     setOpen(!open);
   };
 
+  const toggleColorMode = () => {
+    setMode((prevMode) => (prevMode === "light" ? "dark" : "light"));
+  };
+
   return (
     <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
       <Box sx={{ display: "flex", bgcolor: "background.default", color: "text.primary" }}>
-        <AppBar position="absolute" open={open} drawerWidth={drawerWidth}>
-          <Toolbar sx={{ pr: "24px" }}>
-            <IconButton
-              edge="start"
-              color="inherit"
-              aria-label="open drawer"
-              onClick={toggleDrawer}
-              sx={{ marginRight: "36px", ...(open && { display: "none" }) }}
-            >
-              <Menu />
-            </IconButton>
-            <Typography
-              component="h1"
-              variant="h6"
-              color="inherit"
-              noWrap
-              sx={{ flexGrow: 1 }}
-            >
-              Portfolio
-            </Typography>
-          </Toolbar>
+        <AppBar
+          position="absolute"
+          open={open}
+          drawerWidth={drawerWidth}
+          mode={mode}
+          toggleColorMode={toggleColorMode}
+        >
+          <IconButton
+            edge="start"
+            color="inherit"
+            aria-label="open drawer"
+            onClick={toggleDrawer}
+            sx={{ marginRight: "36px", ...(open && { display: "none" }) }}
+          >
+            <Menu />
+          </IconButton>
+          <Typography
+            component="h1"
+            variant="h6"
+            color="inherit"
+            noWrap
+            sx={{ flexGrow: 1 }}
+          >
+            Portfolio
+          </Typography>
         </AppBar>
         <Drawer variant="permanent" open={open} drawerWidth={drawerWidth}>
           <Toolbar

--- a/src/components/app/AppBar.tsx
+++ b/src/components/app/AppBar.tsx
@@ -1,14 +1,23 @@
-import { styled } from "@mui/material/styles";
+import { PaletteMode, Toolbar } from "@mui/material";
 import MuiAppBar, { AppBarProps as MuiAppBarProps } from "@mui/material/AppBar";
+import { styled } from "@mui/material/styles";
+import ToggleColorMode from "../bookworm/ToggleColorMode";
 
-export type AppBarProps = MuiAppBarProps & {
+export interface AppBarProps extends MuiAppBarProps {
   open?: boolean;
   drawerWidth?: number;
-};
+  mode: PaletteMode;
+  toggleColorMode: () => void;
+}
 
-export default styled(MuiAppBar, {
-  shouldForwardProp: (prop) => prop !== "open",
-})<AppBarProps>(({ theme, open, drawerWidth = 240 }) => ({
+interface StyledAppBarProps extends MuiAppBarProps {
+  open?: boolean;
+  drawerWidth?: number;
+}
+
+const StyledAppBar = styled(MuiAppBar, {
+  shouldForwardProp: (prop) => prop !== "open" && prop !== "drawerWidth",
+})<StyledAppBarProps>(({ theme, open, drawerWidth = 240 }) => ({
   zIndex: theme.zIndex.drawer + 1,
   backgroundColor: theme.palette.background.paper,
   color: theme.palette.text.primary,
@@ -27,3 +36,22 @@ export default styled(MuiAppBar, {
     }),
   }),
 }));
+
+export default function AppBar({
+  open,
+  drawerWidth,
+  mode,
+  toggleColorMode,
+  children,
+  ...other
+}: AppBarProps) {
+  return (
+    <StyledAppBar open={open} drawerWidth={drawerWidth} {...other}>
+      <Toolbar sx={{ pr: "24px" }}>
+        {children}
+        <ToggleColorMode mode={mode} toggleColorMode={toggleColorMode} />
+      </Toolbar>
+    </StyledAppBar>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add app bar component that integrates reusable ToggleColorMode
- manage palette mode state on the main page and pass toggle handlers to the app bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a94b708c108330929db4303a9fba28