### PR TITLE
feat: add responsive grid layout for key sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,7 @@ import ProjectsGrid from "@/components/app/ProjectsGrid";
 import Education from "@/components/app/Education";
 import Recognition from "@/components/app/Recognition";
 import ContactCTA from "@/components/app/ContactCTA";
+import Grid from "@mui/material/Grid";
 
 export default function Home() {
   const [mode, setMode] = useState<PaletteMode>("dark");
@@ -166,10 +167,18 @@ export default function Home() {
           <Toolbar />
           <Container>
             <ResumeHero />
-            <ResumeSummary />
-            <CoreCompetencies />
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={12} md={6} lg={6}>
+                <ResumeSummary />
+              </Grid>
+              <Grid item xs={12} sm={12} md={6} lg={6}>
+                <CoreCompetencies />
+              </Grid>
+              <Grid item xs={12} sm={12} md={12} lg={12}>
+                <ProjectsGrid />
+              </Grid>
+            </Grid>
             <ExperienceTimeline />
-            <ProjectsGrid />
             <Education />
             <Recognition />
             <ContactCTA />

--- a/src/components/app/ProjectsGrid.tsx
+++ b/src/components/app/ProjectsGrid.tsx
@@ -15,7 +15,7 @@ export default function ProjectsGrid() {
       </Typography>
       <Grid container spacing={2}>
         {resumeData.projects.map((project) => (
-          <Grid item xs={12} sm={6} md={4} key={project.href}>
+          <Grid item xs={12} sm={6} md={4} lg={3} key={project.href}>
             <Card
               variant="outlined"
               sx={{


### PR DESCRIPTION
## Summary
- wrap Summary, Core Competencies, and Projects sections in MUI Grid containers
- use xs/sm/md/lg breakpoints for mobile-friendly layout
- include large-screen breakpoint for project cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a94c4b24c88330b17e3d144953ff4e