### PR TITLE
docs: document resume home page and apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Résumé-Driven Home Page
+
+The landing page presents a résumé-focused portfolio with sections for summary,
+competencies, projects, experience, education, recognition, and contact. A
+drawer menu links to several demos and games:
+
+- [GeneBoard](http://localhost:3000/dna)
+- [Bookworm](http://localhost:3000/bookworm)
+- [Blackjack](http://localhost:3000/blackjack)
+- [Warbirds](http://localhost:3000/warbirds)
+- [ZombieFish](http://localhost:3000/zombiefish)
+
+### Build Instructions
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+During development, run `npm run dev` to start the local server.
+
 ## Getting Started
 
 First, run the development server:


### PR DESCRIPTION
## Summary
- describe the new résumé-focused landing page
- list navigation links to sample apps
- add build instructions for production runs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc'; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a94f411c6c8330abeb30c4262c7c49