### PR TITLE
feat: add resume download button

### DIFF
--- a/src/components/app/ResumeHero.tsx
+++ b/src/components/app/ResumeHero.tsx
@@ -4,6 +4,7 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import { summary } from "@/consts/resumeData";
+import { withBasePath } from "@/utils/basePath";
 
 export default function ResumeHero() {
   return (
@@ -50,6 +51,9 @@ export default function ResumeHero() {
           rel="noopener"
         >
           LinkedIn
+        </Button>
+        <Button variant="outlined" href={withBasePath("/resume.pdf")} download>
+          Resume
         </Button>
       </Stack>
     </Box>


### PR DESCRIPTION
## Summary
- add button linking to resume PDF
- ensure link respects deployment base path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68a94f27aa508330ba2923c74607d7e4