### PR TITLE
Add scroll-triggered section animations

### DIFF
--- a/src/components/app/ContactCTA.tsx
+++ b/src/components/app/ContactCTA.tsx
@@ -3,31 +3,34 @@ import Stack from "@mui/material/Stack";
 import Button from "@mui/material/Button";
 import { summary } from "@/consts/resumeData";
 import TronPaper from "@/components/app/TronPaper";
+import FadeInSection from "@/components/app/FadeInSection";
 
 export default function ContactCTA() {
   return (
-    <TronPaper sx={{ textAlign: "center" }}>
-      <Typography variant="h6" gutterBottom>
-        Contact
-      </Typography>
-      <Stack direction="row" spacing={2} justifyContent="center">
-        <Button
-          variant="contained"
-          color="primary"
-          href={`mailto:${summary.contact.email}`}
-        >
-          Email
-        </Button>
-        <Button
-          variant="outlined"
-          href={summary.contact.linkedin}
-          target="_blank"
-          rel="noopener"
-          color="secondary"
-        >
-          LinkedIn
-        </Button>
-      </Stack>
-    </TronPaper>
+    <FadeInSection>
+      <TronPaper sx={{ textAlign: "center" }}>
+        <Typography variant="h6" gutterBottom>
+          Contact
+        </Typography>
+        <Stack direction="row" spacing={2} justifyContent="center">
+          <Button
+            variant="contained"
+            color="primary"
+            href={`mailto:${summary.contact.email}`}
+          >
+            Email
+          </Button>
+          <Button
+            variant="outlined"
+            href={summary.contact.linkedin}
+            target="_blank"
+            rel="noopener"
+            color="secondary"
+          >
+            LinkedIn
+          </Button>
+        </Stack>
+      </TronPaper>
+    </FadeInSection>
   );
 }

--- a/src/components/app/CoreCompetencies.tsx
+++ b/src/components/app/CoreCompetencies.tsx
@@ -3,24 +3,27 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { coreCompetencies } from "@/consts/resumeData";
 import TronPaper from "@/components/app/TronPaper";
+import FadeInSection from "@/components/app/FadeInSection";
 
 export default function CoreCompetencies() {
   return (
-    <TronPaper>
-      <Typography variant="h6" gutterBottom>
-        Core Competencies
-      </Typography>
-      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-        {coreCompetencies.map((competency) => (
-          <Chip
-            key={competency}
-            label={competency}
-            variant="outlined"
-            color="primary"
-            sx={{ mb: 1, bgcolor: "transparent" }}
-          />
-        ))}
-      </Stack>
-    </TronPaper>
+    <FadeInSection>
+      <TronPaper>
+        <Typography variant="h6" gutterBottom>
+          Core Competencies
+        </Typography>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {coreCompetencies.map((competency) => (
+            <Chip
+              key={competency}
+              label={competency}
+              variant="outlined"
+              color="primary"
+              sx={{ mb: 1, bgcolor: "transparent" }}
+            />
+          ))}
+        </Stack>
+      </TronPaper>
+    </FadeInSection>
   );
 }

--- a/src/components/app/Education.tsx
+++ b/src/components/app/Education.tsx
@@ -4,20 +4,23 @@ import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import { education } from "@/consts/resumeData";
 import TronPaper from "@/components/app/TronPaper";
+import FadeInSection from "@/components/app/FadeInSection";
 
 export default function Education() {
   return (
-    <TronPaper>
-      <Typography variant="h6" gutterBottom>
-        Education
-      </Typography>
-      <List>
-        {education.map((edu, index) => (
-          <ListItem key={`${edu.school}-${index}`}>
-            <ListItemText primary={edu.school} secondary={edu.degree} />
-          </ListItem>
-        ))}
-      </List>
-    </TronPaper>
+    <FadeInSection>
+      <TronPaper>
+        <Typography variant="h6" gutterBottom>
+          Education
+        </Typography>
+        <List>
+          {education.map((edu, index) => (
+            <ListItem key={`${edu.school}-${index}`}>
+              <ListItemText primary={edu.school} secondary={edu.degree} />
+            </ListItem>
+          ))}
+        </List>
+      </TronPaper>
+    </FadeInSection>
   );
 }

--- a/src/components/app/ExperienceTimeline.tsx
+++ b/src/components/app/ExperienceTimeline.tsx
@@ -8,51 +8,54 @@ import TimelineDot from "@mui/lab/TimelineDot";
 import TimelineOppositeContent from "@mui/lab/TimelineOppositeContent";
 import { experience } from "@/consts/resumeData";
 import TronPaper from "@/components/app/TronPaper";
+import FadeInSection from "@/components/app/FadeInSection";
 
 export default function ExperienceTimeline() {
   return (
-    <TronPaper>
-      <Typography variant="h6" gutterBottom>
-        Experience
-      </Typography>
-      <Timeline>
-        {experience.map((exp, index) => (
-          <TimelineItem key={`${exp.company}-${index}`}>
-            <TimelineOppositeContent color="text.secondary">
-              {exp.start}
-              {exp.end ? ` - ${exp.end}` : ""}
-            </TimelineOppositeContent>
-            <TimelineSeparator>
-              <TimelineDot color="primary" />
-              {index < experience.length - 1 && (
-                <TimelineConnector sx={{ bgcolor: "primary.main" }} />
-              )}
-            </TimelineSeparator>
-            <TimelineContent>
-              <Typography variant="subtitle1">{exp.company}</Typography>
-              <Typography variant="body2" color="text.secondary">
-                {exp.position}
-                {exp.location ? `, ${exp.location}` : ""}
-              </Typography>
-              {exp.details && (
-                <ul style={{ margin: 0 }}>
-                  {exp.details.map((detail) => (
-                    <li key={detail}>{detail}</li>
-                  ))}
-                </ul>
-              )}
-              {exp.achievements && (
-                <ul style={{ margin: 0 }}>
-                  {exp.achievements.map((ach) => (
-                    <li key={ach}>{ach}</li>
-                  ))}
-                </ul>
-              )}
-            </TimelineContent>
-          </TimelineItem>
-        ))}
-      </Timeline>
-    </TronPaper>
+    <FadeInSection>
+      <TronPaper>
+        <Typography variant="h6" gutterBottom>
+          Experience
+        </Typography>
+        <Timeline>
+          {experience.map((exp, index) => (
+            <TimelineItem key={`${exp.company}-${index}`}>
+              <TimelineOppositeContent color="text.secondary">
+                {exp.start}
+                {exp.end ? ` - ${exp.end}` : ""}
+              </TimelineOppositeContent>
+              <TimelineSeparator>
+                <TimelineDot color="primary" />
+                {index < experience.length - 1 && (
+                  <TimelineConnector sx={{ bgcolor: "primary.main" }} />
+                )}
+              </TimelineSeparator>
+              <TimelineContent>
+                <Typography variant="subtitle1">{exp.company}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {exp.position}
+                  {exp.location ? `, ${exp.location}` : ""}
+                </Typography>
+                {exp.details && (
+                  <ul style={{ margin: 0 }}>
+                    {exp.details.map((detail) => (
+                      <li key={detail}>{detail}</li>
+                    ))}
+                  </ul>
+                )}
+                {exp.achievements && (
+                  <ul style={{ margin: 0 }}>
+                    {exp.achievements.map((ach) => (
+                      <li key={ach}>{ach}</li>
+                    ))}
+                  </ul>
+                )}
+              </TimelineContent>
+            </TimelineItem>
+          ))}
+        </Timeline>
+      </TronPaper>
+    </FadeInSection>
   );
 }
 

--- a/src/components/app/FadeInSection.tsx
+++ b/src/components/app/FadeInSection.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ReactNode } from "react";
+import Fade from "@mui/material/Fade";
+import Box from "@mui/material/Box";
+import useInView from "@/hooks/useInView";
+
+interface FadeInSectionProps {
+  children: ReactNode;
+}
+
+export default function FadeInSection({ children }: FadeInSectionProps) {
+  const { ref, inView } = useInView<HTMLDivElement>({ threshold: 0.2 });
+
+  return (
+    <Fade in={inView} timeout={1000}>
+      <Box ref={ref}>{children}</Box>
+    </Fade>
+  );
+}

--- a/src/components/app/ProjectsGrid.tsx
+++ b/src/components/app/ProjectsGrid.tsx
@@ -6,42 +6,45 @@ import CardActions from "@mui/material/CardActions";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import TronPaper from "@/components/app/TronPaper";
+import FadeInSection from "@/components/app/FadeInSection";
 
 export default function ProjectsGrid() {
   return (
-    <TronPaper>
-      <Typography variant="h6" gutterBottom>
-        Projects
-      </Typography>
-      <Grid container spacing={2}>
-        {resumeData.projects.map((project) => (
-          <Grid item xs={12} sm={6} md={4} lg={3} key={project.href}>
-            <Card
-              variant="outlined"
-              sx={{
-                height: "100%",
-                backgroundColor: "background.default",
-                borderColor: "primary.main",
-                boxShadow: "0 0 6px rgba(0,240,255,0.3)",
-              }}
-            >
-              <CardContent>
-                <Typography variant="subtitle1" color="primary.main">
-                  {project.name}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {project.description}
-                </Typography>
-              </CardContent>
-              <CardActions>
-                <Button size="small" href={project.href} color="secondary">
-                  Launch
-                </Button>
-              </CardActions>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
-    </TronPaper>
+    <FadeInSection>
+      <TronPaper>
+        <Typography variant="h6" gutterBottom>
+          Projects
+        </Typography>
+        <Grid container spacing={2}>
+          {resumeData.projects.map((project) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={project.href}>
+              <Card
+                variant="outlined"
+                sx={{
+                  height: "100%",
+                  backgroundColor: "background.default",
+                  borderColor: "primary.main",
+                  boxShadow: "0 0 6px rgba(0,240,255,0.3)",
+                }}
+              >
+                <CardContent>
+                  <Typography variant="subtitle1" color="primary.main">
+                    {project.name}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {project.description}
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button size="small" href={project.href} color="secondary">
+                    Launch
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </TronPaper>
+    </FadeInSection>
   );
 }

--- a/src/components/app/Recognition.tsx
+++ b/src/components/app/Recognition.tsx
@@ -4,70 +4,73 @@ import Grid from "@mui/material/Grid";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import TronPaper from "@/components/app/TronPaper";
+import FadeInSection from "@/components/app/FadeInSection";
 
 export default function Recognition() {
   return (
-    <TronPaper>
-      <Typography variant="h6" gutterBottom>
-        Recognition
-      </Typography>
-      <Grid container spacing={2} sx={{ mb: 2 }}>
-        {resumeData.recognition.snippets.map((snippet, idx) => (
-          <Grid item xs={12} sm={4} key={idx}>
-            <Card
-              variant="outlined"
-              sx={{
-                backgroundColor: "background.default",
-                borderColor: "primary.main",
-                boxShadow: "0 0 6px rgba(0,240,255,0.3)",
-              }}
-            >
-              <CardContent>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ fontStyle: "italic" }}
-                >
-                  {snippet}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
-      <Typography variant="h6" gutterBottom>
-        Recommendations
-      </Typography>
-      <Grid container spacing={2}>
-        {resumeData.recognition.recommendations.map((rec) => (
-          <Grid item xs={12} key={`${rec.name}-${rec.date}`}>
-            <Card
-              variant="outlined"
-              sx={{
-                backgroundColor: "background.default",
-                borderColor: "primary.main",
-                boxShadow: "0 0 6px rgba(0,240,255,0.3)",
-              }}
-            >
-              <CardContent>
-                <Typography variant="subtitle1" fontWeight="bold" color="primary">
-                  {rec.name}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {rec.title} · {rec.date}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {rec.relationship}
-                </Typography>
-                <Typography variant="body1" sx={{ mt: 1, fontStyle: "italic" }}>
-                  {rec.text}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
-    </TronPaper>
+    <FadeInSection>
+      <TronPaper>
+        <Typography variant="h6" gutterBottom>
+          Recognition
+        </Typography>
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          {resumeData.recognition.snippets.map((snippet, idx) => (
+            <Grid item xs={12} sm={4} key={idx}>
+              <Card
+                variant="outlined"
+                sx={{
+                  backgroundColor: "background.default",
+                  borderColor: "primary.main",
+                  boxShadow: "0 0 6px rgba(0,240,255,0.3)",
+                }}
+              >
+                <CardContent>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ fontStyle: "italic" }}
+                  >
+                    {snippet}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+        <Typography variant="h6" gutterBottom>
+          Recommendations
+        </Typography>
+        <Grid container spacing={2}>
+          {resumeData.recognition.recommendations.map((rec) => (
+            <Grid item xs={12} key={`${rec.name}-${rec.date}`}>
+              <Card
+                variant="outlined"
+                sx={{
+                  backgroundColor: "background.default",
+                  borderColor: "primary.main",
+                  boxShadow: "0 0 6px rgba(0,240,255,0.3)",
+                }}
+              >
+                <CardContent>
+                  <Typography variant="subtitle1" fontWeight="bold" color="primary">
+                    {rec.name}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {rec.title} · {rec.date}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {rec.relationship}
+                  </Typography>
+                  <Typography variant="body1" sx={{ mt: 1, fontStyle: "italic" }}>
+                    {rec.text}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </TronPaper>
+    </FadeInSection>
   );
 }
 

--- a/src/components/app/ResumeHero.tsx
+++ b/src/components/app/ResumeHero.tsx
@@ -3,59 +3,62 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import FadeInSection from "@/components/app/FadeInSection";
 import { summary } from "@/consts/resumeData";
 import { withBasePath } from "@/utils/basePath";
 
 export default function ResumeHero() {
   return (
-    <Box
-      sx={{
-        textAlign: "center",
-        py: 8,
-        backgroundImage:
-          "radial-gradient(circle, rgba(0,240,255,0.15) 0%, transparent 70%)",
-      }}
-    >
-      <Typography
-        component="h1"
-        variant="h3"
-        gutterBottom
-        sx={{ color: "primary.main", textShadow: "0 0 10px #00f0ff" }}
+    <FadeInSection>
+      <Box
+        sx={{
+          textAlign: "center",
+          py: 8,
+          backgroundImage:
+            "radial-gradient(circle, rgba(0,240,255,0.15) 0%, transparent 70%)",
+        }}
       >
-        {summary.name}
-      </Typography>
-      <Typography
-        component="h2"
-        variant="h5"
-        gutterBottom
-        sx={{ color: "secondary.main", textShadow: "0 0 6px #ff007f" }}
-      >
-        {summary.title}
-      </Typography>
-      <Typography color="text.secondary" gutterBottom>
-        {summary.location}
-      </Typography>
-      <Typography sx={{ mb: 4 }}>{summary.blurb}</Typography>
-      <Stack direction="row" spacing={2} justifyContent="center">
-        <Button
-          variant="contained"
-          color="primary"
-          href={`mailto:${summary.contact.email}`}
+        <Typography
+          component="h1"
+          variant="h3"
+          gutterBottom
+          sx={{ color: "primary.main", textShadow: "0 0 10px #00f0ff" }}
         >
-          Email
-        </Button>
-        <Button
-          variant="outlined"
-          href={summary.contact.linkedin}
-          target="_blank"
-          rel="noopener"
+          {summary.name}
+        </Typography>
+        <Typography
+          component="h2"
+          variant="h5"
+          gutterBottom
+          sx={{ color: "secondary.main", textShadow: "0 0 6px #ff007f" }}
         >
-          LinkedIn
-        </Button>
-        <Button variant="outlined" href={withBasePath("/resume.pdf")} download>
-          Resume
-        </Button>
-      </Stack>
-    </Box>
+          {summary.title}
+        </Typography>
+        <Typography color="text.secondary" gutterBottom>
+          {summary.location}
+        </Typography>
+        <Typography sx={{ mb: 4 }}>{summary.blurb}</Typography>
+        <Stack direction="row" spacing={2} justifyContent="center">
+          <Button
+            variant="contained"
+            color="primary"
+            href={`mailto:${summary.contact.email}`}
+          >
+            Email
+          </Button>
+          <Button
+            variant="outlined"
+            href={summary.contact.linkedin}
+            target="_blank"
+            rel="noopener"
+          >
+            LinkedIn
+          </Button>
+          <Button variant="outlined" href={withBasePath("/resume.pdf")} download>
+            Resume
+          </Button>
+        </Stack>
+      </Box>
+    </FadeInSection>
   );
 }

--- a/src/components/app/ResumeSummary.tsx
+++ b/src/components/app/ResumeSummary.tsx
@@ -1,14 +1,17 @@
 import Typography from "@mui/material/Typography";
 import { summary } from "@/consts/resumeData";
 import TronPaper from "@/components/app/TronPaper";
+import FadeInSection from "@/components/app/FadeInSection";
 
 export default function ResumeSummary() {
   return (
-    <TronPaper>
-      <Typography variant="h6" gutterBottom>
-        Summary
-      </Typography>
-      <Typography>{summary.blurb}</Typography>
-    </TronPaper>
+    <FadeInSection>
+      <TronPaper>
+        <Typography variant="h6" gutterBottom>
+          Summary
+        </Typography>
+        <Typography>{summary.blurb}</Typography>
+      </TronPaper>
+    </FadeInSection>
   );
 }

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function useInView<T extends HTMLElement = HTMLElement>(
+  options?: IntersectionObserverInit
+) {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setInView(true);
+        observer.unobserve(entry.target);
+      }
+    }, options);
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [options]);
+
+  return { ref, inView };
+}


### PR DESCRIPTION
## Summary
- add a reusable `FadeInSection` component powered by an IntersectionObserver hook
- animate major resume sections with MUI fade transitions when they enter the viewport

## Testing
- `npm install` *(fails: 403 Forbidden for @mui/lab)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68a9505c76a08330833515589c0d97f8