### PR TITLE
feat: refresh homepage theme

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -43,16 +43,16 @@ export default function HomePageClient() {
       createTheme({
         palette: {
           mode,
-          primary: { main: "#00f0ff" },
-          secondary: { main: "#ff007f" },
+          primary: { main: "#0969da" },
+          secondary: { main: "#8250df" },
           ...(mode === "light"
             ? {
-                background: { default: "#f5f5f5", paper: "#ffffff" },
-                text: { primary: "#001e3c", secondary: "#334e68" },
+                background: { default: "#f6f8fa", paper: "#ffffff" },
+                text: { primary: "#24292f", secondary: "#57606a" },
               }
             : {
-                background: { default: "#000914", paper: "#001e3c" },
-                text: { primary: "#e0f7ff", secondary: "#8ce2ff" },
+                background: { default: "#0d1117", paper: "#161b22" },
+                text: { primary: "#c9d1d9", secondary: "#8b949e" },
               }),
         },
         typography: {
@@ -161,7 +161,7 @@ export default function HomePageClient() {
             flexGrow: 1,
             minHeight: "100vh",
             backgroundImage:
-              "radial-gradient(circle at 25% 0, rgba(0,240,255,0.15), transparent)",
+              "radial-gradient(circle at 25% 0, rgba(9,105,218,0.15), transparent)",
           }}
         >
           <Toolbar />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,12 +1,12 @@
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f6f8fa;
+  --foreground: #24292f;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #0d1117;
+    --foreground: #c9d1d9;
   }
 }
 


### PR DESCRIPTION
## Summary
- adopt GitHub-inspired palette for a calmer 2025 look
- tweak background gradient to match new accent color
- sync global light/dark colors with updated theme

## Testing
- `npm install` *(fails: 403 Forbidden for @mui/lab)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a95a441a7c83308be7ce82639e1c71