### PR TITLE
Make portfolio theme cleaner

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -37,18 +37,18 @@ import ContactCTA from "@/components/app/ContactCTA";
 import Grid from "@mui/material/Grid";
 
 export default function HomePageClient() {
-  const [mode, setMode] = useState<PaletteMode>("dark");
+  const [mode, setMode] = useState<PaletteMode>("light");
   const defaultTheme = useMemo(
     () =>
       createTheme({
         palette: {
           mode,
-          primary: { main: "#0969da" },
-          secondary: { main: "#8250df" },
+          primary: { main: "#0A66C2" },
+          secondary: { main: "#56687A" },
           ...(mode === "light"
             ? {
-                background: { default: "#f6f8fa", paper: "#ffffff" },
-                text: { primary: "#24292f", secondary: "#57606a" },
+                background: { default: "#ffffff", paper: "#ffffff" },
+                text: { primary: "#1f1f1f", secondary: "#5e5e5e" },
               }
             : {
                 background: { default: "#0d1117", paper: "#161b22" },
@@ -155,15 +155,7 @@ export default function HomePageClient() {
             </ListItemButton>
           </List>
         </Drawer>
-        <Box
-          component="main"
-          sx={{
-            flexGrow: 1,
-            minHeight: "100vh",
-            backgroundImage:
-              "radial-gradient(circle at 25% 0, rgba(9,105,218,0.15), transparent)",
-          }}
-        >
+        <Box component="main" sx={{ flexGrow: 1, minHeight: "100vh" }}>
           <Toolbar />
           <Container>
             <ResumeHero />

--- a/src/components/app/AppBar.tsx
+++ b/src/components/app/AppBar.tsx
@@ -21,8 +21,8 @@ const StyledAppBar = styled(MuiAppBar, {
   zIndex: theme.zIndex.drawer + 1,
   backgroundColor: theme.palette.background.paper,
   color: theme.palette.text.primary,
-  borderBottom: `1px solid ${theme.palette.primary.main}`,
-  boxShadow: `0 0 10px ${theme.palette.primary.main}`,
+  borderBottom: `1px solid ${theme.palette.divider}`,
+  boxShadow: "none",
   transition: theme.transitions.create(["width", "margin"], {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,

--- a/src/components/app/Drawer.tsx
+++ b/src/components/app/Drawer.tsx
@@ -14,8 +14,8 @@ export default styled(MuiDrawer, {
     width: drawerWidth,
     backgroundColor: theme.palette.background.paper,
     color: theme.palette.text.primary,
-    borderRight: `1px solid ${theme.palette.primary.main}`,
-    boxShadow: `0 0 10px ${theme.palette.primary.main}`,
+    borderRight: `1px solid ${theme.palette.divider}`,
+    boxShadow: "none",
     transition: theme.transitions.create("width", {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,

--- a/src/components/app/ExperienceTimeline.tsx
+++ b/src/components/app/ExperienceTimeline.tsx
@@ -27,7 +27,7 @@ export default function ExperienceTimeline() {
               <TimelineSeparator>
                 <TimelineDot color="primary" />
                 {index < experience.length - 1 && (
-                  <TimelineConnector sx={{ bgcolor: "primary.main" }} />
+                  <TimelineConnector sx={{ bgcolor: "divider" }} />
                 )}
               </TimelineSeparator>
               <TimelineContent>

--- a/src/components/app/ProjectsGrid.tsx
+++ b/src/components/app/ProjectsGrid.tsx
@@ -24,8 +24,7 @@ export default function ProjectsGrid() {
                 sx={{
                   height: "100%",
                   backgroundColor: "background.default",
-                  borderColor: "primary.main",
-                  boxShadow: "0 0 6px rgba(0,240,255,0.3)",
+                  borderColor: "divider",
                 }}
               >
                 <CardContent>

--- a/src/components/app/Recognition.tsx
+++ b/src/components/app/Recognition.tsx
@@ -20,8 +20,7 @@ export default function Recognition() {
                 variant="outlined"
                 sx={{
                   backgroundColor: "background.default",
-                  borderColor: "primary.main",
-                  boxShadow: "0 0 6px rgba(0,240,255,0.3)",
+                  borderColor: "divider",
                 }}
               >
                 <CardContent>
@@ -47,8 +46,7 @@ export default function Recognition() {
                 variant="outlined"
                 sx={{
                   backgroundColor: "background.default",
-                  borderColor: "primary.main",
-                  boxShadow: "0 0 6px rgba(0,240,255,0.3)",
+                  borderColor: "divider",
                 }}
               >
                 <CardContent>

--- a/src/components/app/ResumeHero.tsx
+++ b/src/components/app/ResumeHero.tsx
@@ -10,27 +10,15 @@ import { withBasePath } from "@/utils/basePath";
 export default function ResumeHero() {
   return (
     <FadeInSection>
-      <Box
-        sx={{
-          textAlign: "center",
-          py: 8,
-          backgroundImage:
-            "radial-gradient(circle, rgba(0,240,255,0.15) 0%, transparent 70%)",
-        }}
-      >
-        <Typography
-          component="h1"
-          variant="h3"
-          gutterBottom
-          sx={{ color: "primary.main", textShadow: "0 0 10px #00f0ff" }}
-        >
+      <Box sx={{ textAlign: "center", py: 8 }}>
+        <Typography component="h1" variant="h3" gutterBottom>
           {summary.name}
         </Typography>
         <Typography
           component="h2"
           variant="h5"
           gutterBottom
-          sx={{ color: "secondary.main", textShadow: "0 0 6px #ff007f" }}
+          color="text.secondary"
         >
           {summary.title}
         </Typography>

--- a/src/components/app/TronPaper.tsx
+++ b/src/components/app/TronPaper.tsx
@@ -5,8 +5,8 @@ const TronPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(2),
   marginBottom: theme.spacing(4),
   backgroundColor: theme.palette.background.paper,
-  border: `1px solid ${theme.palette.primary.main}`,
-  boxShadow: `0 0 10px ${theme.palette.primary.main}`,
+  border: `1px solid ${theme.palette.divider}`,
+  boxShadow: "none",
 }));
 
 export default TronPaper;


### PR DESCRIPTION
## Summary
- Default to a light, white-centered palette with LinkedIn-style blue accents
- Simplify hero section and navigation components for a cleaner look
- Remove glowing card accents and use subtle dividers in timelines and grids

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68a99c0303188330bc94426fcd6f3c53