### PR TITLE
Fix project links for base path deployments

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -35,6 +35,7 @@ import Education from "@/components/app/Education";
 import Recognition from "@/components/app/Recognition";
 import ContactCTA from "@/components/app/ContactCTA";
 import Grid from "@mui/material/Grid";
+import { withBasePath } from "@/utils/basePath";
 
 export default function HomePageClient() {
   const [mode, setMode] = useState<PaletteMode>("light");
@@ -117,37 +118,37 @@ export default function HomePageClient() {
           </Toolbar>
           <Divider />
           <List component="nav">
-            <ListItemButton component="a" href="/">
+            <ListItemButton component="a" href={withBasePath("/")}>
               <ListItemIcon>
                 <HomeIcon />
               </ListItemIcon>
               <ListItemText primary="Home" />
             </ListItemButton>
-            <ListItemButton component="a" href="/dna">
+            <ListItemButton component="a" href={withBasePath("/dna")}>
               <ListItemIcon>
                 <Science />
               </ListItemIcon>
               <ListItemText primary="GeneBoard" />
             </ListItemButton>
-            <ListItemButton component="a" href="/bookworm">
+            <ListItemButton component="a" href={withBasePath("/bookworm")}>
               <ListItemIcon>
                 <MenuBook />
               </ListItemIcon>
               <ListItemText primary="Bookworm" />
             </ListItemButton>
-            <ListItemButton component="a" href="/blackjack">
+            <ListItemButton component="a" href={withBasePath("/blackjack")}>
               <ListItemIcon>
                 <Casino />
               </ListItemIcon>
               <ListItemText primary="Blackjack" />
             </ListItemButton>
-            <ListItemButton component="a" href="/warbirds">
+            <ListItemButton component="a" href={withBasePath("/warbirds")}>
               <ListItemIcon>
                 <Flight />
               </ListItemIcon>
               <ListItemText primary="Warbirds" />
             </ListItemButton>
-            <ListItemButton component="a" href="/zombiefish">
+            <ListItemButton component="a" href={withBasePath("/zombiefish")}>
               <ListItemIcon>
                 <BugReport />
               </ListItemIcon>

--- a/src/components/app/ProjectsGrid.tsx
+++ b/src/components/app/ProjectsGrid.tsx
@@ -8,6 +8,7 @@ import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import TronPaper from "@/components/app/TronPaper";
 import FadeInSection from "@/components/app/FadeInSection";
+import { withBasePath } from "@/utils/basePath";
 
 export default function ProjectsGrid() {
   return (
@@ -44,7 +45,7 @@ export default function ProjectsGrid() {
                   </Typography>
                 </CardContent>
                 <CardActions>
-                  <Button size="small" href={project.href} color="secondary">
+                  <Button size="small" href={withBasePath(project.href)} color="secondary">
                     Launch
                   </Button>
                 </CardActions>


### PR DESCRIPTION
## Summary
- use withBasePath for HomePage navigation links
- wrap project grid launch links with withBasePath

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2b9264a08330a7d8e33c9ad11b15