### PR TITLE
feat: add AISummary project presentation page

### DIFF
--- a/src/app/aisummary/AISummaryPageClient.tsx
+++ b/src/app/aisummary/AISummaryPageClient.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import Container from "@mui/material/Container";
+import ProjectPresentation, { ProjectData } from "@/components/showcase/ProjectPresentation";
+
+interface AISummaryPageClientProps {
+  project: ProjectData;
+}
+
+export default function AISummaryPageClient({ project }: AISummaryPageClientProps) {
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <ProjectPresentation project={project} />
+    </Container>
+  );
+}
+

--- a/src/app/aisummary/page.tsx
+++ b/src/app/aisummary/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import AISummaryPageClient from "./AISummaryPageClient";
+import { projectData } from "./project";
+
+export const metadata: Metadata = {
+  title: "AISummary Project",
+  description: "Powerpoint-style presentation for the AISummary page",
+};
+
+export default function AISummaryPage() {
+  return <AISummaryPageClient project={projectData} />;
+}
+

--- a/src/app/aisummary/project.ts
+++ b/src/app/aisummary/project.ts
@@ -1,0 +1,309 @@
+import { ProjectData } from "@/components/showcase/ProjectPresentation";
+
+export const projectData: ProjectData = {
+  project: "pk-cloud-functions — AISummary (patientPromptEnum page)",
+  description:
+    "AISummary is implemented as the Next.js route /patientPromptEnum/page.tsx. It renders physician-facing patient summaries by: (1) resolving URL params (siteId, patientId, userId, promptEnum, chatUri, etc.), (2) fetching Prompt and Category metadata via Refine’s DataProvider (which calls Azure Functions → Cosmos DB), (3) rendering one or more PatientPrompt widgets, and (4) posting the physician’s typed question or selected prompt(s) to the Python Flask AI service at chatUri (/v1/chat_patient). The page accumulates and scores ChatAnswer parts (via chatAudits) and displays content with categories and citations.",
+  demoGifUrl: "/demogifs/ai_summary.gif",
+  specifications: {
+    "Routing & URL Params (useAISummaryParams.ts)": {
+      params: {
+        siteId: "string | undefined",
+        patientId: "string | undefined (parsed to number in page)",
+        userId: "string | undefined",
+        promptEnumParam: "string | undefined (disabled when interactive=false)",
+        chatUri:
+          "string | undefined — absolute URL for Flask /v1/chat_patient",
+        aiPatientIsPrimed: "boolean — from ?aiPatientIsPrimed=true",
+        fetchAnswerOnLoad: "boolean — auto-run on first render",
+        comboPromptEnum: "string — default 'summarizeComboPrompts'",
+        moduleToStopLoadingForParam:
+          "string | undefined — name for parent postMessage loading events",
+        initialErrorText: "string — seed error banner",
+        interactiveMode:
+          "boolean — default true; set false with ?interactive=false",
+      },
+    },
+    "Auth & Environment": {
+      auth:
+        "useAuth() reads a bearer token from parent window via postMessage and injects it on all Refine/Azure calls (axios interceptor) and forwards it to chatUri when present.",
+      env: {
+        API_URL:
+          "Base for Azure Functions (ui/aicopilot/src/providers/data-provider).",
+        API_ROOT: "Optional prefix (joined to API_URL).",
+      },
+      originGate:
+        "If no auth and origin is not localhost, the page returns notFound().",
+    },
+    "Data Access (Refine DataProvider)": {
+      resources: [
+        "v1/clients (resource: 'clients') — used to derive clientType for category filtering.",
+        "v1/categories (resource: 'categories') — select options filtered by clientType.",
+        "v1/prompts (resource: 'prompts') — fetches Prompt records by site/clientType/promptEnum/text.",
+        "v1/chatAudits (resource: 'chatAudits') — polled to retrieve score/validity for an answerId.",
+      ],
+      filtering:
+        "Simple eq filters mapped to query string (e.g., { field: 'siteId', operator: 'eq', value: siteId }).",
+    },
+    "Core Components & Hooks": {
+      page: "/patientPromptEnum/page.tsx (client component)",
+      dynamicImports: [
+        "PatientPrompt (no SSR, skeleton during load)",
+        "AISummaryModal (no SSR)",
+        "PromptRenderer (no SSR)",
+        "ModalTriggerTextField (no SSR)",
+        "PromptChips, BackToTopFab (no SSR)",
+      ],
+      hooks: [
+        "useAISummaryParams — parse URL params.",
+        "useAISummaryInit — bootstrap: fetch combo prompts, honor fetchAnswerOnLoad, hydrate localStorage (model, guardrails, recent questions, initial prompt).",
+        "usePromptResources — get Prompt[] by enum/text via DataProvider.",
+        "useSubPrompts — expand a combo prompt's fullText by '<new_question>' into multiple questions.",
+        "useAnswer — orchestrate selection (enum vs free-text), post parent startLoading, clear state, then set prompts list.",
+        "usePromptVisibility — chip visibility rules based on content/citations/completion.",
+        "usePromptTitle — derive section title from first answer's markdown header if present.",
+        "useModalFocus — bottom sheet open/close and focus management.",
+        "useAuth, useOrigin — bearer and origin awareness.",
+      ],
+    },
+    "AI Interface (PatientPrompt → chatUri)": {
+      http:
+        "POST {chatUri} (Flask /v1/chat_patient); also supports OPTIONS CORS preflight.",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer {auth} (if available)",
+      },
+      requestBodyShape: {
+        auth:
+          "string | null — forwarded bearer for downstream services (optional).",
+        siteID: "string",
+        patientID:
+          "number | number[] — single or multi-patient; special case: -1 triggers generic chat flow.",
+        userID: "number",
+        queryText:
+          "string — the physician's typed question or one sub-prompt from a combo.",
+        model: "string — e.g., 'gemini2' (default from localStorage).",
+        context:
+          "object — key/value placeholder inputs captured by PatientPrompt.",
+        category:
+          "string[] | string — selected categories (from Settings menu or prompt defaults).",
+        data:
+          "PatientRecord | PatientRecord[] | null — EHR payload if provided via postMessage.",
+        format:
+          "optional 'text' | 'audio' — if 'audio', returns audio/mpeg.",
+      },
+      responseBodyShape: {
+        answerId: "number",
+        content:
+          "string — possibly a fallback single blob if parts are empty or for errors.",
+        parts:
+          "string[] — each entry is usually JSON (stringified); UI attempts JSON.parse; fallback to plain text.",
+        context:
+          "object — may include merged placeholder values the UI stores back into state.",
+      },
+      uiParsing:
+        "Each part, if parsable JSON, conforms to UI ChatAnswer { content, categories: string[], citationsMap: Record<string,(string|number)[]>, score?, scoreReasoning? }.",
+    },
+    "Scoring / Guardrails (chatAudits)": {
+      toggle: "SettingsMenu toggles 'isUsingGuardrails'.",
+      flow:
+        "For each returned answer part that has answerId, when scoreAnswer=true, the UI polls GET v1/chatAudits?answerId=… until a record exists; then copies score, scoreReasoning, valid, invalidReason.",
+      retryLogic:
+        "If !valid OR score < 7 (MINIMUM_SCORE_THRESHOLD) and retryCount < 3 (MAX_RETRY_ON_LOW_SCORE), PatientPrompt re-calls chatUri for that prompt; otherwise continues. Defaults when scoring disabled: score=10 and valid=true.",
+    },
+    "UX Behavior": {
+      chips:
+        "When multiple prompts, PromptChips render; visibility changes once content+citations exist and prompt is completed.",
+      modal:
+        "AISummaryModal provides free-text ask, recent questions (localStorage), suggested combo prompts, model picker, categories multiselect, and guardrails toggle.",
+      postMessage:
+        "Parent ↔ IFrame integration: startLoading/stopLoading with { module }, fetchAnswer events carrying { promptEnum | question, data, model, patientId }.",
+      scroll: "Back-to-top FAB via useScrollTrigger on the prompts container.",
+      errorBanners:
+        "HTTP 401/403/404/500 specific messages; 413/context-length guidance; generic catch-all lists troubleshooting steps.",
+    },
+    "Persistence (localStorage keys)": [
+      "page.patientPromptEnum.initialPromptEnum",
+      "page.patientPromptEnum.userFreeTextQuestions",
+      "page.patientPromptEnum.model",
+      "page.patientPromptEnum.isUsingGuardrails",
+      "page.patientPromptEnum.categories",
+    ],
+    "Performance / Resilience": [
+      "Dynamic import of heavy client widgets; SSR disabled.",
+      "Single DataProvider instance; axios interceptor injects bearer.",
+      "Minimal prompt lookups via usePromptResources and useSubPrompts.",
+      "Polling chatAudits with 5s delay until record is present.",
+      "Merges response.context to persist dynamic placeholder values across retries.",
+    ],
+    "Primary Types (ui/interfaces & aichat/models)": {
+      "UI.ChatAnswer":
+        "{ answerId?, prompt?, content?, categories?, citationsMap?, score?, scoreReasoning? }",
+      "UI.PatientRecord": "Minimal EHR snapshot interface used by UI.",
+      "UI.Prompt": "{ id, promptEnum, text, fullText, title?, categories? }",
+      "API.ChatRequest":
+        "{ queryText, patientID, siteID, userID, model?, category?, categoryAttributes?, referenceID?, auth?, subcategories?, currentDateTime?, questions?, filters?, context?, data?, format?, noCache?, nudges? }",
+      "API.ChatAnswer": "{ answerId, content, parts: string[], context?: object }",
+    },
+    "Exact Endpoints Involved": [
+      "GET v1/clients?siteId=…",
+      "GET v1/categories?clientType=…",
+      "GET v1/prompts?siteId=…&promptEnum=… OR text=…",
+      "POST v1/chat_patient (chatUri from URL param)",
+      "GET v1/chatAudits?answerId=…",
+    ],
+  },
+  technologiesUsed: [
+    { name: "Next.js (App Router)", url: "https://nextjs.org/" },
+    { name: "React 18", url: "https://react.dev/" },
+    { name: "TypeScript", url: "https://www.typescriptlang.org/" },
+    { name: "Refine (headless)", url: "https://refine.dev/" },
+    { name: "Material UI (MUI)", url: "https://mui.com/" },
+    { name: "Axios", url: "https://axios-http.com/" },
+    {
+      name: "Azure Functions (TypeScript)",
+      url: "https://learn.microsoft.com/azure/azure-functions/",
+    },
+    {
+      name: "Azure Cosmos DB",
+      url: "https://learn.microsoft.com/azure/cosmos-db/",
+    },
+    { name: "Python Flask", url: "https://flask.palletsprojects.com/" },
+    { name: "LangChain", url: "https://python.langchain.com/" },
+    { name: "OpenAI / Azure OpenAI (LLM)", url: "https://platform.openai.com/" },
+    { name: "gTTS (optional audio synthesis)", url: "https://pypi.org/project/gTTS/" },
+  ],
+  blockDiagram: `graph TD
+  subgraph Browser[Physician Browser]
+    U[/URL with siteId, patientId, userId, chatUri/]
+    Page[Next.js /patientPromptEnum]
+  end
+
+  U --> Page
+  subgraph UI[Next.js App (aicopilot)]
+    Page --> Params[useAISummaryParams]
+    Page --> Init[useAISummaryInit]
+    Page --> PR[usePromptResources]
+    Page --> Sub[useSubPrompts]
+    Page --> Ans[useAnswer]
+    Page --> Chips[PromptChips]
+    Page --> Modal[AISummaryModal]
+    Page --> Renderer[PromptRenderer]
+    Renderer --> PP[PatientPrompt]
+  end
+
+  subgraph AF[Azure Functions (TypeScript)]
+    Clients[/GET v1/clients/]:::fn
+    Cats[/GET v1/categories/]:::fn
+    Prompts[/GET v1/prompts/]:::fn
+    Audits[/GET v1/chatAudits/]:::fn
+    DB[(Cosmos DB)]:::db
+    Clients --> DB
+    Cats --> DB
+    Prompts --> DB
+    Audits --> DB
+  end
+
+  subgraph PY[AI Chat Service (Flask)]
+    Chat[/POST v1/chat_patient/]:::fn
+    LC[LangChain + LLM]
+    Chat --> LC
+  end
+
+  PR -- load prompts --> Prompts
+  Page -- clientType lookup --> Clients
+  Page -- category options --> Cats
+  PP -- POST question/context/data --> Chat
+  Chat -- ChatAnswer(parts,context) --> PP
+  PP -- poll score --> Audits
+
+  classDef fn fill:#eef,stroke:#335,stroke-width:1px;
+  classDef db fill:#efe,stroke:#393,stroke-width:1px;`,
+  componentDiagram: `graph TB
+  A[/patientPromptEnum/page.tsx/]
+  subgraph Hooks
+    P1[useAISummaryParams]
+    P2[useAISummaryInit]
+    P3[usePromptResources]
+    P4[useSubPrompts]
+    P5[useAnswer]
+    P6[usePromptVisibility]
+    P7[usePromptTitle]
+    P8[useModalFocus]
+    P9[useAuth]
+    P10[useOrigin]
+  end
+
+  subgraph UI Components
+    C1[PromptRenderer]
+    C2[PatientPrompt]
+    C3[AISummaryModal]
+    C4[ModalTriggerTextField]
+    C5[PromptChips]
+    C6[BackToTopFab]
+    C7[Loading]
+    C8[SettingsMenu]
+  end
+
+  A --> P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10
+  A --> C1 & C3 & C4 & C5 & C6 & C7 & C8
+  C1 --> C2
+  C2 -.->|onPromptFetching/onPromptFetched| A
+  A -.->|postMessage start/stopLoading| ParentApp`,
+  sequenceDiagram: `sequenceDiagram
+  autonumber
+  actor Physician
+  participant Parent as Parent App (optional)
+  participant UI as Next.js /patientPromptEnum
+  participant Hooks as use* hooks
+  participant DP as Refine DataProvider
+  participant AF as Azure Functions (v1/clients, v1/categories, v1/prompts, v1/chatAudits)
+  participant DB as Cosmos DB
+  participant PP as PatientPrompt
+  participant PY as Flask aichat (/v1/chat_patient)
+  participant LLM as LangChain + LLM
+
+  Physician->>UI: Open with ?siteId&patientId&userId&chatUri[=&promptEnum|&interactive]
+  UI->>Hooks: useAISummaryParams() parse flags
+  Note over UI: If no auth and not localhost → notFound()
+  UI->>DP: list('clients', filter: siteId)
+  DP->>AF: GET /v1/clients?siteId=...
+  AF->>DB: query Clients
+  DB-->>AF: Client[] (clientType)
+  AF-->>DP: Client[]
+  UI->>DP: list('categories', filter: clientType)
+  DP->>AF: GET /v1/categories?clientType=...
+  AF->>DB: query Categories
+  DB-->>AF: Category[]
+  AF-->>DP: Category[]
+  UI->>DP: list('prompts', filters: siteId + promptEnum or text)
+  DP->>AF: GET /v1/prompts?siteId=...&promptEnum=...|text=...
+  AF->>DB: query Prompts
+  DB-->>AF: Prompt[]
+  AF-->>DP: Prompt[]
+  DP-->>UI: Prompt[]
+  UI->>UI: useSubPrompts split '<new_question>' → prompts[]
+  UI->>PP: Render for each prompt (or free-text)
+
+  loop For each question
+    PP->>Parent: postMessage startLoading{module}
+    PP->>PY: POST { chatUri=/v1/chat_patient }\\n{ siteID, patientID, userID, queryText, model, category[], context{}, data }
+    PY->>LLM: Build chain and fetch
+    LLM-->>PY: ChatAnswer(parts[], context)
+    PY-->>PP: 200 { answerId, content, parts[], context }
+    PP->>AF: Poll GET /v1/chatAudits?answerId=… (if guardrails on)
+    AF->>DB: Find ChatAudit
+    DB-->>AF: score, valid, reason
+    AF-->>PP: ChatAudit
+    alt score < 7 or !valid and retries < 3
+      PP->>PY: retry POST /v1/chat_patient
+    else success
+      PP->>UI: onPromptFetched(prompt, parts)
+      PP->>Parent: postMessage stopLoading{module}
+    end
+  end
+
+  Physician->>UI: Adjust model/categories/guardrails; ask again
+  UI->>PP: Re-run with updated settings`,
+};
+

--- a/src/components/showcase/ProjectPresentation.tsx
+++ b/src/components/showcase/ProjectPresentation.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Image from "next/image";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import Link from "@mui/material/Link";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+
+import TronPaper from "@/components/app/TronPaper";
+import FadeInSection from "@/components/app/FadeInSection";
+import { Diagram } from "@/components/showcase/Diagram";
+import { withBasePath } from "@/utils/basePath";
+
+export interface Technology {
+  name: string;
+  url?: string;
+}
+
+export interface ProjectData {
+  project: string;
+  description: string;
+  demoGifUrl: string;
+  specifications: Record<string, unknown>;
+  technologiesUsed: Technology[];
+  blockDiagram: string;
+  componentDiagram: string;
+  sequenceDiagram: string;
+}
+
+interface ProjectPresentationProps {
+  project: ProjectData;
+}
+
+export default function ProjectPresentation({ project }: ProjectPresentationProps) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <FadeInSection>
+        <TronPaper>
+          <Typography variant="h4" gutterBottom>
+            {project.project}
+          </Typography>
+          <Typography variant="body1" color="text.secondary" paragraph>
+            {project.description}
+          </Typography>
+          <Box sx={{ display: "flex", justifyContent: "center" }}>
+            <Image
+              src={withBasePath(project.demoGifUrl)}
+              alt={`${project.project} demo`}
+              width={800}
+              height={450}
+              style={{ width: "100%", height: "auto" }}
+            />
+          </Box>
+        </TronPaper>
+      </FadeInSection>
+
+      <FadeInSection>
+        <TronPaper>
+          <Typography variant="h5" gutterBottom>
+            Technologies Used
+          </Typography>
+          <List dense>
+            {project.technologiesUsed.map((tech) => (
+              <ListItem key={tech.name}>
+                {tech.url ? (
+                  <Link href={tech.url} target="_blank" rel="noopener noreferrer">
+                    {tech.name}
+                  </Link>
+                ) : (
+                  tech.name
+                )}
+              </ListItem>
+            ))}
+          </List>
+        </TronPaper>
+      </FadeInSection>
+
+      <FadeInSection>
+        <TronPaper>
+          <Typography variant="h5" gutterBottom>
+            Specifications
+          </Typography>
+          {Object.entries(project.specifications).map(([key, value]) => (
+            <Accordion key={key} sx={{ backgroundColor: "transparent" }}>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography variant="subtitle1">{key}</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <pre style={{ whiteSpace: "pre-wrap", fontSize: "0.85rem" }}>
+                  {JSON.stringify(value, null, 2)}
+                </pre>
+              </AccordionDetails>
+            </Accordion>
+          ))}
+        </TronPaper>
+      </FadeInSection>
+
+      <FadeInSection>
+        <TronPaper>
+          <Typography variant="h5" gutterBottom>
+            Block Diagram
+          </Typography>
+          <Diagram diagram={project.blockDiagram} type="graph" height="400px" />
+        </TronPaper>
+      </FadeInSection>
+
+      <FadeInSection>
+        <TronPaper>
+          <Typography variant="h5" gutterBottom>
+            Component Diagram
+          </Typography>
+          <Diagram diagram={project.componentDiagram} type="graph" height="400px" />
+        </TronPaper>
+      </FadeInSection>
+
+      <FadeInSection>
+        <TronPaper>
+          <Typography variant="h5" gutterBottom>
+            Sequence Diagram
+          </Typography>
+          <Diagram
+            diagram={project.sequenceDiagram}
+            type="sequenceDiagram"
+            height="400px"
+          />
+        </TronPaper>
+      </FadeInSection>
+    </Box>
+  );
+}
+

--- a/src/components/showcase/Timeline/Timeline.test.tsx
+++ b/src/components/showcase/Timeline/Timeline.test.tsx
@@ -47,7 +47,7 @@ describe("Timeline component", () => {
       expect(screen.getByText(title)).toBeInTheDocument();
       // content is <div>Eggs</div>, <div>Salad</div>, etc.
       expect(
-        screen.getByText((content as any).props.children),
+        screen.getByText((content as React.ReactElement).props.children),
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- add reusable ProjectPresentation component with mermaid diagrams
- create /aisummary route to showcase AISummary project
- fix Timeline test typing for eslint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae6cd366288330a1d657a3b805ff7a