### PR TITLE
feat: add wow factor to AISummary

### DIFF
--- a/src/app/aisummary/AISummaryPageClient.tsx
+++ b/src/app/aisummary/AISummaryPageClient.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
-import ProjectPresentation, { ProjectData } from "@/components/showcase/ProjectPresentation";
+import Typography from "@mui/material/Typography";
+import ProjectPresentation, {
+  ProjectData,
+} from "@/components/showcase/ProjectPresentation";
 
 interface AISummaryPageClientProps {
   project: ProjectData;
@@ -9,9 +13,31 @@ interface AISummaryPageClientProps {
 
 export default function AISummaryPageClient({ project }: AISummaryPageClientProps) {
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
-      <ProjectPresentation project={project} />
-    </Container>
+    <Box
+      sx={{
+        minHeight: "100vh",
+        background: "linear-gradient(135deg, #e0e7ff 0%, #fdf2f8 100%)",
+        py: 8,
+      }}
+    >
+      <Container maxWidth="lg">
+        <Typography
+          variant="h3"
+          align="center"
+          sx={{
+            fontWeight: 700,
+            mb: 6,
+            background: "linear-gradient(90deg, #1976d2, #21cbf3)",
+            backgroundClip: "text",
+            WebkitBackgroundClip: "text",
+            color: "transparent",
+          }}
+        >
+          Physician-Focused AI Summaries
+        </Typography>
+        <ProjectPresentation project={project} />
+      </Container>
+    </Box>
   );
 }
 

--- a/src/app/aisummary/project.ts
+++ b/src/app/aisummary/project.ts
@@ -4,6 +4,8 @@ export const projectData: ProjectData = {
   project: "pk-cloud-functions — AISummary (patientPromptEnum page)",
   description:
     "AISummary is implemented as the Next.js route /patientPromptEnum/page.tsx. It renders physician-facing patient summaries by: (1) resolving URL params (siteId, patientId, userId, promptEnum, chatUri, etc.), (2) fetching Prompt and Category metadata via Refine’s DataProvider (which calls Azure Functions → Cosmos DB), (3) rendering one or more PatientPrompt widgets, and (4) posting the physician’s typed question or selected prompt(s) to the Python Flask AI service at chatUri (/v1/chat_patient). The page accumulates and scores ChatAnswer parts (via chatAudits) and displays content with categories and citations.",
+  wowFactor:
+    "Delivers concise, citation-backed patient insights in seconds so physicians can spend more time caring and less time scrolling charts.",
   demoGifUrl: "/demogifs/ai_summary.gif",
   specifications: {
     "Routing & URL Params (useAISummaryParams.ts)": {

--- a/src/components/showcase/ProjectPresentation.tsx
+++ b/src/components/showcase/ProjectPresentation.tsx
@@ -24,6 +24,12 @@ export interface Technology {
 export interface ProjectData {
   project: string;
   description: string;
+  /**
+   * Brief punchline that highlights the value proposition of the
+   * project. Rendered prominently to give the presentation a bit of
+   * "wow" for viewers such as physicians evaluating the tooling.
+   */
+  wowFactor?: string;
   demoGifUrl: string;
   specifications: Record<string, unknown>;
   technologiesUsed: Technology[];
@@ -47,6 +53,21 @@ export default function ProjectPresentation({ project }: ProjectPresentationProp
           <Typography variant="body1" color="text.secondary" paragraph>
             {project.description}
           </Typography>
+          {project.wowFactor && (
+            <Typography
+              variant="h6"
+              sx={{
+                fontWeight: 700,
+                background: "linear-gradient(90deg, #1976d2, #21cbf3)",
+                backgroundClip: "text",
+                WebkitBackgroundClip: "text",
+                color: "transparent",
+                mb: 2,
+              }}
+            >
+              {project.wowFactor}
+            </Typography>
+          )}
           <Box sx={{ display: "flex", justifyContent: "center" }}>
             <Image
               src={withBasePath(project.demoGifUrl)}


### PR DESCRIPTION
## Summary
- showcase optional `wowFactor` tagline in project presentations
- add physician-focused hero and gradient background to AISummary page
- highlight AISummary's value proposition for physicians

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae776140ec8330bc4994774caae5be