### PR TITLE
fix: prevent image dragging in lightgun games

### DIFF
--- a/src/games/warbirds/index.tsx
+++ b/src/games/warbirds/index.tsx
@@ -6,9 +6,11 @@ import { withBasePath } from "@/utils/basePath";
 import { TitleSplash } from "./components/TitleSplash";
 import GameUI from "./components/GameUI";
 import useGameEngine from "./hooks/useGameEngine";
+import useDisableDrag from "@/hooks/lightgun-web/useDisableDrag";
 
 export default function Game() {
   const engine = useGameEngine();
+  useDisableDrag();
 
   const {
     ui,

--- a/src/games/zombiefish/index.tsx
+++ b/src/games/zombiefish/index.tsx
@@ -6,9 +6,11 @@ import { withBasePath } from "@/utils/basePath";
 import { TitleSplash } from "./components/TitleSplash";
 import GameUI from "./components/GameUI";
 import useZombiefishEngine from "./hooks/useGameEngine";
+import useDisableDrag from "@/hooks/lightgun-web/useDisableDrag";
 
 export default function Game() {
   const engine = useZombiefishEngine();
+  useDisableDrag();
 
   const {
     ui,

--- a/src/hooks/lightgun-web/useDisableDrag.ts
+++ b/src/hooks/lightgun-web/useDisableDrag.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Prevents default drag behaviour on images and other elements.
+ * Useful for lightgun setups where the pointer should never initiate a drag
+ * operation (e.g. Sinden lightgun).
+ */
+export function useDisableDrag() {
+  useEffect(() => {
+    const handleDragStart = (e: DragEvent) => {
+      e.preventDefault();
+    };
+    document.addEventListener('dragstart', handleDragStart);
+    return () => {
+      document.removeEventListener('dragstart', handleDragStart);
+    };
+  }, []);
+}
+
+export default useDisableDrag;


### PR DESCRIPTION
## Summary
- disable drag behavior when lightgun games mount
- share hook across games so Sinden clicks trigger properly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba2c0d0658833082a212faa8be104e