### PR TITLE
Scale lightgun games relative to base screen size

### DIFF
--- a/src/consts/lightgun-web/dimensions.ts
+++ b/src/consts/lightgun-web/dimensions.ts
@@ -1,0 +1,4 @@
+export const BASE_GAME_WIDTH = 1728; // CSS width of 16" MacBook Pro
+export const BASE_GAME_HEIGHT = 1117; // CSS height of 16" MacBook Pro
+
+export const BASE_DIMS = { width: BASE_GAME_WIDTH, height: BASE_GAME_HEIGHT } as const;

--- a/src/games/warbirds/components/GameUI.tsx
+++ b/src/games/warbirds/components/GameUI.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/consts/lightgun-web/ui";
 import { ENEMY_COLORS } from "@/consts/lightgun-web/vehicles";
 import { MAX_AMMO, DEFAULT_CURSOR } from "../constants";
+import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
+import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
 import { withBasePath } from "@/utils/basePath";
 import { GameUIState } from "../types";
 
@@ -58,14 +60,16 @@ export function GameUI({
   } = ui;
 
   const medalFrames = getImg("medalFrames") as HTMLImageElement[][];
+  const screenDims = useWindowSize();
+  const scale = screenDims.width / BASE_DIMS.width || 1;
 
   return (
     <Box position="relative" width="100vw" height="100dvh">
       {/* Ammo icons */}
       <Box
         position="absolute"
-        top={16}
-        left={16}
+        top={16 * scale}
+        left={16 * scale}
         display="flex"
         zIndex={1}
         onClick={handleContext}
@@ -79,9 +83,9 @@ export function GameUI({
                 ? withBasePath("/assets/tanks/PNG/Retina/tank_bullet5.png")
                 : withBasePath("/assets/tanks/PNG/Retina/tank_bullet1.png")
             }
-            width={64}
-            height={64}
-            sx={{ mr: 1.5, rotate: "-90deg", cursor: DEFAULT_CURSOR }}
+            width={64 * scale}
+            height={64 * scale}
+            sx={{ mr: 1.5 * scale, rotate: "-90deg", cursor: DEFAULT_CURSOR }}
           />
         ))}
       </Box>
@@ -89,8 +93,8 @@ export function GameUI({
       {medalCount > 0 && (
         <Box
           position="absolute"
-          top={16 + 32 + 8}
-          left={16}
+          top={16 * scale + 32 * scale + 8 * scale}
+          left={16 * scale}
           display="flex"
           alignItems="center"
           zIndex={1}
@@ -102,13 +106,13 @@ export function GameUI({
               medalFrames[0]?.[0]?.src ||
               withBasePath("/assets/medals/PNG/flat_medal1.png")
             }
-            width={48}
-            height={48}
-            sx={{ mr: 2 }}
+            width={48 * scale}
+            height={48 * scale}
+            sx={{ mr: 2 * scale }}
           />
           <Box
             component="span"
-            sx={{ fontSize: 48, color: "white", fontWeight: "bold" }}
+            sx={{ fontSize: 48 * scale, color: "white", fontWeight: "bold" }}
           >
             x{medalCount}
           </Box>
@@ -119,8 +123,8 @@ export function GameUI({
       {duckCount > 0 && (
         <Box
           position="absolute"
-          top={16 + 32 + 8 + (48 + 8)}
-          left={16}
+          top={16 * scale + 32 * scale + 8 * scale + (48 * scale + 8 * scale)}
+          left={16 * scale}
           display="flex"
           alignItems="center"
           zIndex={1}
@@ -131,11 +135,11 @@ export function GameUI({
             src={withBasePath(
               "/assets/shooting-gallery/PNG/Objects/duck_brown.png"
             )}
-            width={48}
-            height={48}
-            sx={{ mr: 2 }}
+            width={48 * scale}
+            height={48 * scale}
+            sx={{ mr: 2 * scale }}
           />
-          <Box sx={{ fontSize: 48, color: "white", fontWeight: "bold" }}>
+          <Box sx={{ fontSize: 48 * scale, color: "white", fontWeight: "bold" }}>
             x{duckCount}
           </Box>
         </Box>
@@ -145,8 +149,8 @@ export function GameUI({
       {enemyCount > 0 && (
         <Box
           position="absolute"
-          top={16 + 32 + 8 + 2 * (48 + 8)}
-          left={16}
+          top={16 * scale + 32 * scale + 8 * scale + 2 * (48 * scale + 8 * scale)}
+          left={16 * scale}
           display="flex"
           alignItems="center"
           zIndex={1}
@@ -155,11 +159,11 @@ export function GameUI({
           <Box
             component="img"
             src={withBasePath(ENEMY_COLORS[0])}
-            width={48}
-            height={48}
-            sx={{ mr: 2 }}
+            width={48 * scale}
+            height={48 * scale}
+            sx={{ mr: 2 * scale }}
           />
-          <Box sx={{ fontSize: 48, color: "white", fontWeight: "bold" }}>
+          <Box sx={{ fontSize: 48 * scale, color: "white", fontWeight: "bold" }}>
             x{enemyCount}
           </Box>
         </Box>
@@ -167,8 +171,8 @@ export function GameUI({
       {/* Score display */}
       <Box
         position="absolute"
-        top={16}
-        right={16}
+        top={16 * scale}
+        right={16 * scale}
         display="flex"
         alignItems="center"
         zIndex={1}
@@ -177,7 +181,7 @@ export function GameUI({
           component="img"
           src={withBasePath(SCORE_LABEL_SRC)}
           alt="Score"
-          sx={{ mr: 1 }}
+          sx={{ mr: 1 * scale }}
         />
         {String(score)
           .split("")
@@ -187,9 +191,9 @@ export function GameUI({
               component="img"
               src={withBasePath(`${SCORE_DIGIT_PATH}${d}.png`)}
               alt={d}
-              width={SCORE_DIGIT_WIDTH}
-              height={SCORE_DIGIT_HEIGHT}
-              sx={{ mr: 0.5 }}
+              width={SCORE_DIGIT_WIDTH * scale}
+              height={SCORE_DIGIT_HEIGHT * scale}
+              sx={{ mr: 0.5 * scale }}
             />
           ))}
       </Box>
@@ -226,7 +230,7 @@ export function GameUI({
             top: "50%",
             left: "50%",
             transform: "translate(-50%,-50%)",
-            width: 450,
+            width: 450 * scale,
             height: "auto",
             cursor: DEFAULT_CURSOR,
           }}
@@ -236,10 +240,10 @@ export function GameUI({
       {!crashed && (
         <Box
           position="absolute"
-          bottom={16}
-          right={16}
+          bottom={16 * scale}
+          right={16 * scale}
           display="flex"
-          gap={1}
+          gap={1 * scale}
           zIndex={2}
         >
           {(Object.keys(activePowerups) as PowerupType[])
@@ -258,8 +262,8 @@ export function GameUI({
                   key={t}
                   component="img"
                   src={imgSrc}
-                  width={64}
-                  height={64}
+                  width={64 * scale}
+                  height={64 * scale}
                   sx={{ opacity: flash ? 0.3 : 1 }}
                 />
               );

--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -112,6 +112,7 @@ import {
   ENEMY_DENSITY_STEP,
   SHOT_CURSOR,
 } from "../constants";
+import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
 import { GameState, GameUIState } from "../types";
 import { initState } from "../utils";
 import { useGameAssets } from "./useGameAssets";
@@ -137,17 +138,10 @@ export function useGameEngine() {
   const { getImg, ready } = assetMgr;
 
   // ─── WINDOW RESIZE ────────────────────────────────────────────────────────
-  const dims = useWindowSize();
+  const screenDims = useWindowSize();
+  const dims = BASE_DIMS;
 
-  const initialDims =
-    dims.width > 0 && dims.height > 0
-      ? dims
-      : {
-          width: typeof window !== "undefined" ? window.innerWidth : 0,
-          height: typeof window !== "undefined" ? window.innerHeight : 0,
-        };
-
-  const state = useRef<GameState>(initState(initialDims, assetMgr, audioMgr));
+  const state = useRef<GameState>(initState(dims, assetMgr, audioMgr));
 
   const loopStartedRef = useRef(false);
 
@@ -1018,13 +1012,16 @@ export function useGameEngine() {
     if (!ctx) return;
 
     const { width, height } = dims;
+    const { width: screenW, height: screenH } = screenDims;
     const dpr =
       typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
-    canvas.width = width * dpr;
-    canvas.height = height * dpr;
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
-    ctx.scale(dpr, dpr);
+    const scaleX = screenW / width;
+    const scaleY = screenH / height;
+    canvas.width = screenW * dpr;
+    canvas.height = screenH * dpr;
+    canvas.style.width = `${screenW}px`;
+    canvas.style.height = `${screenH}px`;
+    ctx.scale(scaleX * dpr, scaleY * dpr);
 
     resetState();
     // ensure we stay in the playing phase after resetting state
@@ -3280,6 +3277,7 @@ export function useGameEngine() {
   }, [
     getImg,
     dims,
+    screenDims,
     resetState,
     play,
     syncUIFromState,
@@ -3315,14 +3313,17 @@ export function useGameEngine() {
       const canvas = canvasRef.current;
       const ctx = canvas?.getContext("2d");
       if (!canvas || !ctx) return;
+      const { width: screenW, height: screenH } = screenDims;
       const { width, height } = dims;
       const dpr =
         typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
-      canvas.width = width * dpr;
-      canvas.height = height * dpr;
-      canvas.style.width = `${width}px`;
-      canvas.style.height = `${height}px`;
-      ctx.scale(dpr, dpr);
+      const scaleX = screenW / width;
+      const scaleY = screenH / height;
+      canvas.width = screenW * dpr;
+      canvas.height = screenH * dpr;
+      canvas.style.width = `${screenW}px`;
+      canvas.style.height = `${screenH}px`;
+      ctx.scale(scaleX * dpr, scaleY * dpr);
       let raf: number;
       const render = () => {
         ctx.fillStyle = SKY_COLOR;
@@ -3337,7 +3338,7 @@ export function useGameEngine() {
       render();
       return () => cancelAnimationFrame(raf);
     }
-  }, [ui.phase, dims, canvasRef]);
+  }, [ui.phase, screenDims, canvasRef, dims]);
 
   // ─── CLICK TO FLAP & FIRE ─────────────────────────────────────────────────
   const handleClick = (e: ClickEvent) => {
@@ -3386,8 +3387,10 @@ export function useGameEngine() {
 
     // compute base click coords
     const rect = canvasRef.current!.getBoundingClientRect();
-    const baseX = e.clientX - rect.left,
-      baseY = e.clientY - rect.top;
+    const scaleX = dims.width / rect.width;
+    const scaleY = dims.height / rect.height;
+    const baseX = (e.clientX - rect.left) * scaleX,
+      baseY = (e.clientY - rect.top) * scaleY;
 
     if (isSpray) {
       // fire that many pellets, each random‐offset & delayed

--- a/src/games/zombiefish/components/GameUI.tsx
+++ b/src/games/zombiefish/components/GameUI.tsx
@@ -3,6 +3,8 @@ import Box from "@mui/material/Box";
 import { withBasePath } from "@/utils/basePath";
 import type { ClickEvent } from "@/types/lightgun-web/events";
 import type { GameUIState } from "../types";
+import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
+import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
 
 export interface GameUIProps {
   ui: GameUIState;
@@ -21,6 +23,8 @@ export function GameUI({
   handleMouseMove,
 }: GameUIProps) {
   const { phase, cursor } = ui;
+  const screenDims = useWindowSize();
+  const scale = screenDims.width / BASE_DIMS.width || 1;
 
   return (
     <Box position="relative" width="100vw" height="100dvh">
@@ -51,7 +55,7 @@ export function GameUI({
             top: "50%",
             left: "50%",
             transform: "translate(-50%, -50%)",
-            width: 300,
+            width: 300 * scale,
             height: "auto",
             pointerEvents: "none",
           }}

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
+import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
 import { useGameAssets } from "./useGameAssets";
 import { useGameAudio } from "./useGameAudio";
 import { drawTextLabels, newTextLabel } from "@/utils/lightgun-web/ui";
@@ -109,7 +110,8 @@ export default function useGameEngine() {
   const audio: AudioMgr = useGameAudio();
 
   // window dimensions
-  const dims = useWindowSize();
+  const screenDims = useWindowSize();
+  const dims = BASE_DIMS;
 
   // main game state stored in a ref so we can mutate without re-render
   const state = useRef<GameState>({
@@ -177,10 +179,26 @@ export default function useGameEngine() {
     cursor: DEFAULT_CURSOR,
   });
 
-  // sync dims when window size changes
+  // sync base dims once and resize canvas on window changes
   useEffect(() => {
     state.current.dims = dims;
-  }, [dims]);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return;
+    const { width: screenW, height: screenH } = screenDims;
+    const dpr =
+      typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+    const scaleX = screenW / dims.width;
+    const scaleY = screenH / dims.height;
+    canvas.width = screenW * dpr;
+    canvas.height = screenH * dpr;
+    canvas.style.width = `${screenW}px`;
+    canvas.style.height = `${screenH}px`;
+    ctx.setTransform(scaleX * dpr, 0, 0, scaleY * dpr, 0, 0);
+  }, [screenDims, dims]);
 
   const syncCursor = useCallback((cursor: string) => {
     state.current.cursor = cursor;
@@ -281,7 +299,7 @@ export default function useGameEngine() {
 
   useEffect(() => {
     updateScoreLabel(scoreLabel.current, state.current.score);
-  }, [dims, updateScoreLabel]);
+  }, [updateScoreLabel]);
 
   const updateFish = useCallback(() => {
     const cur = state.current;
@@ -773,14 +791,12 @@ export default function useGameEngine() {
 
     // draw bubbles, fish and text labels
     if (canvas && ctx) {
-      canvas.width = cur.dims.width;
-      canvas.height = cur.dims.height;
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.clearRect(0, 0, cur.dims.width, cur.dims.height);
 
       drawBackground(ctx);
 
       // draw timer bar at top of screen
-      const barWidth = (cur.timer / GAME_TIME) * canvas.width;
+      const barWidth = (cur.timer / GAME_TIME) * cur.dims.width;
       ctx.fillStyle = "rgba(0,0,0,0.5)";
       ctx.fillRect(0, 0, barWidth, 8);
 


### PR DESCRIPTION
## Summary
- add reusable base dimension constants for lightgun-web games
- scale Warbirds and ZombieFish engines and UI relative to base 16" MacBook Pro size
- adjust event handling for scaled canvases so clicks map correctly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ba29e38b308330b9073ec372678e08