### PR TITLE
feat: average frame rate over interval

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -69,7 +69,7 @@ import {
   AIRSHIP_MAX_SPEED,
 } from "@/consts/lightgun-web/vehicles";
 import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
-import useFrameRate from "@/hooks/lightgun-web/useFrameRate";
+import useFrameRate, { scaleRef } from "@/hooks/lightgun-web/useFrameRate";
 import { AudioMgr } from "@/types/lightgun-web/audio";
 import { Puff } from "@/types/lightgun-web/effects";
 import { PowerupType, AntiPowerupType, Duck } from "@/types/lightgun-web/objects";
@@ -1040,8 +1040,9 @@ export function useGameEngine() {
     let blindfoldPrevCursor = DEFAULT_CURSOR;
 
     const render = (time: number) => {
-      const { scale } = frameRate(time);
-      state.current.speedScale = scale;
+        frameRate(time);
+        const scale = scaleRef.current;
+        state.current.speedScale = scale;
       const blindActive = state.current.isActive(
         "blindfold",
         state.current.frameCount

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
-import useFrameRate from "@/hooks/lightgun-web/useFrameRate";
+import useFrameRate, { scaleRef } from "@/hooks/lightgun-web/useFrameRate";
 import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
 import { useGameAssets } from "./useGameAssets";
 import { useGameAudio } from "./useGameAudio";
@@ -547,7 +547,8 @@ export default function useGameEngine() {
   // main loop updates timer and fish
   const loop = useCallback(
     (time: number) => {
-      const { scale } = frameRate(time);
+      frameRate(time);
+      const scale = scaleRef.current;
       const cur = state.current;
       if (timerLabel.current) {
       const lbl = timerLabel.current;

--- a/src/hooks/lightgun-web/useFrameRate.ts
+++ b/src/hooks/lightgun-web/useFrameRate.ts
@@ -1,25 +1,42 @@
-import { useRef } from "react";
+import { useEffect, useRef, type MutableRefObject } from "react";
 
 /**
  * Provides a callback to compute frame timing information.
  * Returns { fps, scale } where `scale` is the ratio of the
  * actual frame duration to the target 60 FPS frame duration.
  */
-export default function useFrameRate(targetFps = 60) {
+export let fpsRef: MutableRefObject<number>;
+export let scaleRef: MutableRefObject<number>;
+
+export default function useFrameRate(targetFps = 60, intervalMs = 500) {
   const lastTime = useRef<number | null>(null);
-  const fpsRef = useRef(targetFps);
-  const scaleRef = useRef(1);
+  const deltaSum = useRef(0);
+  const frameCount = useRef(0);
+  fpsRef = useRef(targetFps);
+  scaleRef = useRef(1);
   const frameMs = 1000 / targetFps;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (frameCount.current > 0) {
+        const avgDelta = deltaSum.current / frameCount.current;
+        fpsRef.current = 1000 / avgDelta;
+        scaleRef.current = avgDelta / frameMs;
+        deltaSum.current = 0;
+        frameCount.current = 0;
+      }
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs, frameMs]);
 
   return (time: number) => {
     if (lastTime.current !== null) {
       const delta = time - lastTime.current;
       if (delta > 0) {
-        fpsRef.current = 1000 / delta;
-        scaleRef.current = delta / frameMs;
+        deltaSum.current += delta;
+        frameCount.current += 1;
       }
     }
     lastTime.current = time;
-    return { fps: fpsRef.current, scale: scaleRef.current };
   };
 }


### PR DESCRIPTION
## Summary
- average frame rate and speed scale over configurable interval
- expose refs to latest FPS and scale snapshots
- update game engine hooks to read new frame-rate refs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba8ed0f0908330b76eb653a25954f2