### PR TITLE
feat: log frame metrics in lightgun games

### DIFF
--- a/src/games/warbirds/constants.ts
+++ b/src/games/warbirds/constants.ts
@@ -5,6 +5,7 @@ import { BASE_PATH } from "@/utils/basePath";
 export const DEBUG_PLAYER_CRASH = false; // when true, player never actually “dies”
 export const TEST_SLOW_FALL = false;
 export const POWERUP_DEBUG = [] as PowerupType[]; // force a specific powerup type, or leave empty for random
+export const DEBUG_FPS_SCALE = false; // log frame metrics when true
 
 export const ENABLE_AUTO_FLAP = true; // auto‐flap toggle: when true, player will flap randomly
 export const AUTO_FLAP_PROB = 0.025;

--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -69,7 +69,10 @@ import {
   AIRSHIP_MAX_SPEED,
 } from "@/consts/lightgun-web/vehicles";
 import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
-import useFrameRate, { scaleRef } from "@/hooks/lightgun-web/useFrameRate";
+import useFrameRate, {
+  fpsRef,
+  scaleRef,
+} from "@/hooks/lightgun-web/useFrameRate";
 import { AudioMgr } from "@/types/lightgun-web/audio";
 import { Puff } from "@/types/lightgun-web/effects";
 import { PowerupType, AntiPowerupType, Duck } from "@/types/lightgun-web/objects";
@@ -112,6 +115,7 @@ import {
   INITIAL_ENEMY_DENSITY,
   ENEMY_DENSITY_STEP,
   SHOT_CURSOR,
+  DEBUG_FPS_SCALE,
 } from "../constants";
 import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
 import { GameState, GameUIState } from "../types";
@@ -145,11 +149,22 @@ export function useGameEngine() {
   const state = useRef<GameState>(initState(dims, assetMgr, audioMgr));
 
   const loopStartedRef = useRef(false);
-  const frameRate = useFrameRate();
+  const reportIntervalMs = 500;
+  const frameRate = useFrameRate(60, reportIntervalMs);
 
   const [ui, setUI] = useState<GameUIState>({
     ...state.current,
   } as GameUIState);
+
+  useEffect(() => {
+    if (!DEBUG_FPS_SCALE) return;
+    const id = setInterval(() => {
+      console.debug(
+        `[warbirds] fps: ${fpsRef.current.toFixed(1)} scale: ${scaleRef.current.toFixed(2)}`
+      );
+    }, reportIntervalMs);
+    return () => clearInterval(id);
+  }, [reportIntervalMs]);
 
   // --- Helper Functions ---
 

--- a/src/games/zombiefish/constants.ts
+++ b/src/games/zombiefish/constants.ts
@@ -4,6 +4,9 @@ import { BASE_PATH } from "@/utils/basePath";
  * Game-wide constants for the Zombiefish game.
  */
 
+// Debug flag for logging frame metrics
+export const DEBUG_FPS_SCALE = false;
+
 // Cursor styles
 export const DEFAULT_CURSOR =
   `url('${BASE_PATH}/assets/shooting-gallery/PNG/HUD/crosshair_blue_small.png') 16 16, auto`;

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
-import useFrameRate, { scaleRef } from "@/hooks/lightgun-web/useFrameRate";
+import useFrameRate, { fpsRef, scaleRef } from "@/hooks/lightgun-web/useFrameRate";
 import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
 import { useGameAssets } from "./useGameAssets";
 import { useGameAudio } from "./useGameAudio";
@@ -28,6 +28,7 @@ import {
   DEFAULT_CURSOR,
   SHOT_CURSOR,
   TARGET_CURSOR,
+  DEBUG_FPS_SCALE,
 } from "../constants";
 import type { AssetMgr } from "@/types/lightgun-web/ui";
 import type { TextLabel } from "@/types/lightgun-web/ui";
@@ -147,7 +148,8 @@ export default function useGameEngine() {
   const cursorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const frameRef = useRef(0); // track frames for one-second ticks
   const fishSpawnTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const frameRate = useFrameRate();
+  const reportIntervalMs = 500;
+  const frameRate = useFrameRate(60, reportIntervalMs);
   const backgroundSeed = useRef(Math.random() * 1000);
   const backgroundCanvas = useRef<HTMLCanvasElement | null>(null);
   const accuracyLabel = useRef<TextLabel | null>(null);
@@ -180,6 +182,16 @@ export default function useGameEngine() {
     accuracy: 0,
     cursor: DEFAULT_CURSOR,
   });
+
+  useEffect(() => {
+    if (!DEBUG_FPS_SCALE) return;
+    const id = setInterval(() => {
+      console.debug(
+        `[zombiefish] fps: ${fpsRef.current.toFixed(1)} scale: ${scaleRef.current.toFixed(2)}`
+      );
+      }, reportIntervalMs);
+    return () => clearInterval(id);
+  }, [reportIntervalMs]);
 
   // sync base dims once and resize canvas on window changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add DEBUG_FPS_SCALE flag to warbirds and zombiefish
- log fps and scale from useFrameRate hook when debugging

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba8feb47548330a7afa5a0e5e8932c