### PR TITLE
Add scaled clock hook and integrate into lightgun engines

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -69,10 +69,11 @@ import {
   AIRSHIP_MAX_SPEED,
 } from "@/consts/lightgun-web/vehicles";
 import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
-import useFrameRate, {
-  fpsRef,
-  scaleRef,
-} from "@/hooks/lightgun-web/useFrameRate";
+import useScaledClock, {
+  clockRef,
+  setScaledTimeout,
+  clearScaledTimeout,
+} from "@/hooks/lightgun-web/useScaledClock";
 import { AudioMgr } from "@/types/lightgun-web/audio";
 import { Puff } from "@/types/lightgun-web/effects";
 import { PowerupType, AntiPowerupType, Duck } from "@/types/lightgun-web/objects";
@@ -150,7 +151,7 @@ export function useGameEngine() {
 
   const loopStartedRef = useRef(false);
   const reportIntervalMs = 500;
-  const frameRate = useFrameRate(60, reportIntervalMs);
+  useScaledClock();
 
   const [ui, setUI] = useState<GameUIState>({
     ...state.current,
@@ -159,8 +160,10 @@ export function useGameEngine() {
   useEffect(() => {
     if (!DEBUG_FPS_SCALE) return;
     const id = setInterval(() => {
+      const { deltaMs, scale } = clockRef.current;
+      const fps = 1000 / deltaMs;
       console.debug(
-        `[warbirds] fps: ${fpsRef.current.toFixed(1)} scale: ${scaleRef.current.toFixed(2)}`
+        `[warbirds] fps: ${fps.toFixed(1)} scale: ${scale.toFixed(2)}`
       );
     }, reportIntervalMs);
     return () => clearInterval(id);
@@ -414,7 +417,7 @@ export function useGameEngine() {
           age: 0,
           maxAge: 20,
         });
-        setTimeout(() => {
+        setScaledTimeout(() => {
           state.current.puffs.push({
             x: cx - 16,
             y: cy - 16,
@@ -767,7 +770,7 @@ export function useGameEngine() {
               frames,
               frameIndex: 0,
               frameCounter: 0,
-              frameRate: 8,
+              frameDuration: 8 * (1000 / 60),
               id: medalId + 1,
             });
           } else if (Math.random() < 0.5) {
@@ -817,11 +820,11 @@ export function useGameEngine() {
           const effect = Math.floor(Math.random() * 3);
           if (effect === 0) {
             for (let i = 0; i < SMOKE_TRAIL_COUNT; i++)
-              setTimeout(() => spawnCrashSmokeOne(cxE, cyE), i * 100);
+              setScaledTimeout(() => spawnCrashSmokeOne(cxE, cyE), i * 100);
           } else if (effect === 1) {
             const size = 32 * 3;
             explosionImgs.forEach((img, idx) =>
-              setTimeout(
+              setScaledTimeout(
                 () =>
                   state.current.puffs.push({
                     x: cxE - 16,
@@ -907,7 +910,7 @@ export function useGameEngine() {
     if (animationFrameRef.current)
       cancelAnimationFrame(animationFrameRef.current);
 
-    state.current.countdownTimeouts.forEach(clearTimeout);
+    state.current.countdownTimeouts.forEach(clearScaledTimeout);
     state.current.countdownTimeouts = [];
 
     // Fallback for cases where window size hasn't initialized yet
@@ -957,21 +960,21 @@ export function useGameEngine() {
     spawnCountdown(3);
 
     state.current.countdownTimeouts.push(
-      window.setTimeout(() => {
+      setScaledTimeout(() => {
         state.current.countdown = 2;
         setUI((u) => ({ ...u, countdown: 2 }));
         spawnCountdown(2);
       }, 1000),
-      window.setTimeout(() => {
+      setScaledTimeout(() => {
         state.current.countdown = 1;
         setUI((u) => ({ ...u, countdown: 1 }));
         spawnCountdown(1);
       }, 2000),
-      window.setTimeout(() => {
+      setScaledTimeout(() => {
         state.current.countdown = null;
         setUI((u) => ({ ...u, countdown: null }));
       }, 3000),
-      window.setTimeout(() => {
+      setScaledTimeout(() => {
         const goLabel = newTextLabel(
           {
             text: "GO",
@@ -990,7 +993,7 @@ export function useGameEngine() {
         state.current.phase = phase;
         setUI((u) => ({ ...u, phase }));
       }, 3000),
-      window.setTimeout(() => {
+      setScaledTimeout(() => {
         const phase = "playing";
 
         // Do your full game state reset **here**
@@ -1054,10 +1057,10 @@ export function useGameEngine() {
     let blindfoldWasActive = false;
     let blindfoldPrevCursor = DEFAULT_CURSOR;
 
-    const render = (time: number) => {
-        frameRate(time);
-        const scale = scaleRef.current;
-        state.current.speedScale = scale;
+    const render = () => {
+        const { deltaMs } = clockRef.current;
+        const deltaFrames = deltaMs / (1000 / 60);
+        state.current.speedScale = deltaFrames;
       const blindActive = state.current.isActive(
         "blindfold",
         state.current.frameCount
@@ -1327,7 +1330,7 @@ export function useGameEngine() {
           // point to the chosen frame set
           frames: enemyFrames[colorIdx],
           propFrame: Math.floor(Math.random() * 3),
-          frameRate: 6, // advance propeller every 6 game frames
+          frameDuration: 6 * (1000 / 60), // advance propeller every 6 game frames
           frameCounter: 0,
           alive: true,
           glide: ENEMY_CAN_FLAP ? Math.random() < ENEMY_GLIDE_PROB : true,
@@ -1444,7 +1447,7 @@ export function useGameEngine() {
           )[color],
           frameIndex: Math.floor(Math.random() * 3),
           frameCounter: 0,
-          frameRate: 10,
+          frameDuration: 10 * (1000 / 60),
           speed,
           color,
           bobOffset: Math.random() * Math.PI * 2,
@@ -1461,8 +1464,8 @@ export function useGameEngine() {
         const drawY = a.baseY + bob;
 
         // advance propeller frame
-        a.frameCounter += state.current.speedScale;
-        if (a.frameCounter >= a.frameRate) {
+        a.frameCounter += deltaMs;
+        if (a.frameCounter >= a.frameDuration) {
           a.frameCounter = 0;
           a.frameIndex = (a.frameIndex + 1) % a.frames.length;
         }
@@ -1650,8 +1653,8 @@ export function useGameEngine() {
 
         // draw flipped horizontally *around its center*
         // advance propeller
-        e.frameCounter += state.current.speedScale;
-        if (e.frameCounter >= e.frameRate) {
+        e.frameCounter += deltaMs;
+        if (e.frameCounter >= e.frameDuration) {
           e.frameCounter = 0;
           e.propFrame = (e.propFrame + 1) % e.frames.length;
         }
@@ -1721,7 +1724,7 @@ export function useGameEngine() {
           age: 0,
           maxAge: 20,
         });
-        setTimeout(
+        setScaledTimeout(
           () =>
             state.current.puffs.push({
               x: cx - 16,
@@ -1890,8 +1893,8 @@ export function useGameEngine() {
       // ─── draw medals ─────────────────────────────────────────────────
       state.current.medals.forEach((m, idx) => {
         // advance spin
-        m.frameCounter += state.current.speedScale;
-        if (m.frameCounter >= m.frameRate) {
+        m.frameCounter += deltaMs;
+        if (m.frameCounter >= m.frameDuration) {
           m.frameCounter = 0;
           m.frameIndex = (m.frameIndex + 1) % m.frames.length;
         }
@@ -2214,7 +2217,7 @@ export function useGameEngine() {
             if (!hitWater) {
               // explode on ground
               explosionImgs.forEach((img, i) =>
-                setTimeout(() => {
+                setScaledTimeout(() => {
                   state.current.puffs.push({
                     x: shell.x - 16,
                     y: groundY - 16,
@@ -2263,7 +2266,7 @@ export function useGameEngine() {
 
               // 3) Explosion effect & SFX
               explosionImgs.forEach((img, i) =>
-                setTimeout(() => {
+                setScaledTimeout(() => {
                   state.current.puffs.push({
                     x: e.x,
                     y: e.y,
@@ -2318,7 +2321,7 @@ export function useGameEngine() {
 
               // 3) Explosion effect & SFX
               explosionImgs.forEach((img, i) =>
-                setTimeout(() => {
+                setScaledTimeout(() => {
                   state.current.puffs.push({
                     x: d.x,
                     y: d.y,
@@ -2748,7 +2751,7 @@ export function useGameEngine() {
               // 2) Fire explosion frames
               const explosionSize = 32 * 3;
               explosionImgs.forEach((img, idx) =>
-                setTimeout(() => {
+                setScaledTimeout(() => {
                   state.current.puffs.push({
                     x: m.x + PLANE_HEIGHT / 2,
                     y: m.y + PLANE_WIDTH / 2,
@@ -2802,7 +2805,7 @@ export function useGameEngine() {
           e.alive = false;
           // spawn a puff or explosion at e.x,e.y…
           for (let i = 0; i < SMOKE_TRAIL_COUNT; i++) {
-            setTimeout(
+            setScaledTimeout(
               () =>
                 spawnCrashSmokeOne(
                   e.x + ENEMY_WIDTH / 2,
@@ -2840,7 +2843,7 @@ export function useGameEngine() {
         // once it hits ground, spawn a puff cloud and remove
         if (f.y + ENEMY_HEIGHT >= groundY) {
           for (let i = 0; i < SMOKE_TRAIL_COUNT; i++) {
-            setTimeout(() => spawnCrashSmokeOne(cxF, groundY), i * 100);
+            setScaledTimeout(() => spawnCrashSmokeOne(cxF, groundY), i * 100);
           }
           state.current.falling.splice(idx, 1);
         }
@@ -2866,7 +2869,7 @@ export function useGameEngine() {
             // 2) Fire explosion frames
             const explosionSize = 32 * 3;
             explosionImgs.forEach((img, idx) =>
-              setTimeout(() => {
+              setScaledTimeout(() => {
                 state.current.puffs.push({
                   x: cb.x - 16,
                   y: cb.y - 16,
@@ -2904,8 +2907,8 @@ export function useGameEngine() {
       const laserImgs = getImg("laserBeamImgs") as HTMLImageElement[];
       state.current.laserBeams = state.current.laserBeams.filter((b) => {
         b.x += LASER_BEAM_SPEED;
-        b.frameCounter += state.current.speedScale;
-        if (b.frameCounter >= 4) {
+        b.frameCounter += deltaMs;
+        if (b.frameCounter >= 4 * (1000 / 60)) {
           b.frameCounter = 0;
           b.frame = ((b.frame + 1) % laserImgs.length) as 0 | 1;
         }
@@ -3087,8 +3090,8 @@ export function useGameEngine() {
       // draw + animate water tiles
       state.current.waters.forEach((w, idx) => {
         // advance animation
-        w.frameCounter += state.current.speedScale;
-        if (w.frameCounter >= w.frameRate) {
+        w.frameCounter += deltaMs;
+        if (w.frameCounter >= w.frameDuration) {
           w.frameCounter = 0;
           w.frameIndex = w.frameIndex === 0 ? 1 : 0;
         }
@@ -3316,7 +3319,6 @@ export function useGameEngine() {
     spawnCrashSmokeOne,
     makeText,
     spawnNapalmEllipse,
-    frameRate,
   ]);
 
   // ─── START LOOP ON "playing" ─────────────────────────────────────────────
@@ -3376,7 +3378,7 @@ export function useGameEngine() {
         const x = 100,
           y = dims.height / 2;
         for (let i = 0; i < 3; i++) {
-          window.setTimeout(
+          setScaledTimeout(
             () => makeText("RELOAD", 2, true, true, x, y, 30),
             i * 200
           );
@@ -3406,7 +3408,7 @@ export function useGameEngine() {
       state.current.cursor = SHOT_CURSOR;
 
       // reset cursor after a short delay
-      setTimeout(() => {
+      setScaledTimeout(() => {
         if (!state.current.isActive("blindfold", state.current.frameCount)) {
           state.current.cursor = DEFAULT_CURSOR;
         }
@@ -3425,7 +3427,7 @@ export function useGameEngine() {
       for (let i = 0; i < SPRAY_COUNT; i++) {
         const dx = (Math.random() * 2 - 1) * SPRAY_SPREAD;
         const dy = (Math.random() * 2 - 1) * SPRAY_SPREAD;
-        window.setTimeout(
+        setScaledTimeout(
           () => doSingleShot(baseX + dx, baseY + dy),
           i * SPRAY_INTERVAL
         );

--- a/src/games/warbirds/types.ts
+++ b/src/games/warbirds/types.ts
@@ -24,6 +24,7 @@ import type {
   Duck,
 } from "@/types/lightgun-web/objects";
 import { AudioMgr } from "@/types/lightgun-web/audio";
+import type { ScaledTimeoutHandle } from "@/hooks/lightgun-web/useScaledClock";
 
 export type GamePhase = "title" | "ready" | "go" | "playing";
 
@@ -133,11 +134,11 @@ export interface GameState extends GameUIState {
   ouchExplodeIdx: number;
 
   // (splash) timers — you may choose to drop these once splash logic moves out
-  readyTimeout: number;
-  goTimeout: number;
-  beepTimeouts: number[];
+  readyTimeout: ScaledTimeoutHandle | null;
+  goTimeout: ScaledTimeoutHandle | null;
+  beepTimeouts: ScaledTimeoutHandle[];
   /** Timeout handles for resetting the countdown */
-  countdownTimeouts: number[];
+  countdownTimeouts: ScaledTimeoutHandle[];
 
   isActive: (t: PowerupType, frameCount: number) => boolean;
   enemySpeed: (frameCount: number) => number;

--- a/src/games/warbirds/utils.ts
+++ b/src/games/warbirds/utils.ts
@@ -137,8 +137,8 @@ export function initState(
     ouchFrames: 0,
     ouchExplodeIdx: 0,
 
-    readyTimeout: 0,
-    goTimeout: 0,
+    readyTimeout: null,
+    goTimeout: null,
     beepTimeouts: [],
     countdown: null,
     countdownTimeouts: [],

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -1,6 +1,11 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { useWindowSize } from "@/hooks/lightgun-web/useWindowSize";
-import useFrameRate, { fpsRef, scaleRef } from "@/hooks/lightgun-web/useFrameRate";
+import useScaledClock, {
+  clockRef,
+  setScaledTimeout,
+  clearScaledTimeout,
+  type ScaledTimeoutHandle,
+} from "@/hooks/lightgun-web/useScaledClock";
 import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
 import { useGameAssets } from "./useGameAssets";
 import { useGameAudio } from "./useGameAudio";
@@ -40,9 +45,11 @@ import type { ClickEvent } from "@/types/lightgun-web/events";
 // Initial timer value (in seconds)
 const GAME_TIME = 99;
 const FPS = 60; // assumed frame rate for requestAnimationFrame
+const FRAME_MS = 1000 / FPS;
 
 const FISH_SIZE = 128;
 const FISH_FRAME_DELAY = 6;
+const FISH_FRAME_DURATION = FISH_FRAME_DELAY * FRAME_MS;
 const MAX_SCHOOL_SIZE = 4;
 
 // NES-style jingle sequence for background music
@@ -144,12 +151,12 @@ export default function useGameEngine() {
   const inactiveFish = useRef<Fish[]>([]);
   const inactiveBubbles = useRef<Bubble[]>([]);
   const bubbleSpawnRef = useRef(0);
-  const spawnTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cursorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const frameRef = useRef(0); // track frames for one-second ticks
-  const fishSpawnTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const spawnTimeoutRef = useRef<ScaledTimeoutHandle | null>(null);
+  const cursorTimeoutRef = useRef<ScaledTimeoutHandle | null>(null);
+  const frameRef = useRef(0); // track milliseconds for one-second ticks
+  const fishSpawnTimeout = useRef<ScaledTimeoutHandle | null>(null);
   const reportIntervalMs = 500;
-  const frameRate = useFrameRate(60, reportIntervalMs);
+  useScaledClock();
   const backgroundSeed = useRef(Math.random() * 1000);
   const backgroundCanvas = useRef<HTMLCanvasElement | null>(null);
   const accuracyLabel = useRef<TextLabel | null>(null);
@@ -186,10 +193,12 @@ export default function useGameEngine() {
   useEffect(() => {
     if (!DEBUG_FPS_SCALE) return;
     const id = setInterval(() => {
+      const { deltaMs, scale } = clockRef.current;
+      const fps = 1000 / deltaMs;
       console.debug(
-        `[zombiefish] fps: ${fpsRef.current.toFixed(1)} scale: ${scaleRef.current.toFixed(2)}`
+        `[zombiefish] fps: ${fps.toFixed(1)} scale: ${scale.toFixed(2)}`
       );
-      }, reportIntervalMs);
+    }, reportIntervalMs);
     return () => clearInterval(id);
   }, [reportIntervalMs]);
 
@@ -315,7 +324,7 @@ export default function useGameEngine() {
     updateScoreLabel(scoreLabel.current, state.current.score);
   }, [updateScoreLabel]);
 
-  const updateFish = useCallback((scale: number) => {
+  const updateFish = useCallback((deltaMs: number, scale: number) => {
     const cur = state.current;
     const { width, height } = cur.dims;
 
@@ -329,8 +338,8 @@ export default function useGameEngine() {
       ) as Record<string, HTMLImageElement[]>;
       const frames = frameMap[f.kind as keyof typeof frameMap];
       if (frames && frames.length > 0) {
-        f.frameCounter += scale;
-        if (f.frameCounter >= FISH_FRAME_DELAY) {
+        f.frameCounter += deltaMs;
+        if (f.frameCounter >= FISH_FRAME_DURATION) {
           f.frameCounter = 0;
           f.frame = (f.frame + 1) % frames.length;
         }
@@ -517,7 +526,7 @@ export default function useGameEngine() {
     // move fish with a slight oscillation and update their angle
     cur.fish.forEach((f) => {
       if (f.hurtTimer > 0) f.hurtTimer -= scale;
-      const osc = Math.sin((frameRef.current + f.id) / 20) * 0.5;
+      const osc = Math.sin((frameRef.current / FRAME_MS + f.id) / 20) * 0.5;
       const limited = clampIncline(f.vx, f.vy + osc);
       f.x += limited.vx * scale;
       f.y += limited.vy * scale;
@@ -557,10 +566,8 @@ export default function useGameEngine() {
   }, []);
 
   // main loop updates timer and fish
-  const loop = useCallback(
-    (time: number) => {
-      frameRate(time);
-      const scale = scaleRef.current;
+  const loop = useCallback(() => {
+      const { deltaMs, scale } = clockRef.current;
       const cur = state.current;
       if (timerLabel.current) {
       const lbl = timerLabel.current;
@@ -589,17 +596,20 @@ export default function useGameEngine() {
     }
 
     if (cur.phase === "playing") {
-      updateFish(scale);
+      updateFish(deltaMs, scale);
 
       // spawn and animate bubbles
-      bubbleSpawnRef.current -= scale;
+      bubbleSpawnRef.current -= deltaMs;
       if (bubbleSpawnRef.current <= 0) {
         spawnBubble();
-        bubbleSpawnRef.current = Math.floor(Math.random() * 60) + 30;
+        bubbleSpawnRef.current =
+          (Math.floor(Math.random() * 60) + 30) * FRAME_MS;
       }
       cur.bubbles.forEach((b) => {
         // Update position using velocity and per-bubble wiggle
-        b.x += (b.vx + Math.sin(frameRef.current * b.freq) * b.amp) * scale;
+        b.x +=
+          (b.vx + Math.sin((frameRef.current / FRAME_MS) * b.freq) * b.amp) *
+          scale;
         b.y += b.vy * scale;
       });
       cur.bubbles = cur.bubbles.filter((b) => {
@@ -610,9 +620,9 @@ export default function useGameEngine() {
       });
 
       // track frames and decrement the timer once per second
-      frameRef.current += scale;
-      if (frameRef.current >= FPS) {
-        frameRef.current -= FPS;
+      frameRef.current += deltaMs;
+      if (frameRef.current >= 1000) {
+        frameRef.current -= 1000;
         cur.timer = Math.max(0, cur.timer - 1);
         audio.play("tick");
         updateDigitLabel(timerLabel.current, cur.timer, 2);
@@ -768,7 +778,7 @@ export default function useGameEngine() {
       }
 
       // pulse the accuracy label slightly each frame
-      lbl.scale = 1 + 0.05 * Math.sin(frameRef.current * 0.1);
+      lbl.scale = 1 + 0.05 * Math.sin((frameRef.current / FRAME_MS) * 0.1);
       const totalWidth = lbl.imgs.reduce(
         (w, img) => w + (img?.width || 0) * lbl.scale + 2,
         0
@@ -867,7 +877,8 @@ export default function useGameEngine() {
           const outline =
             fishImgs[`${f.kind}_outline` as keyof typeof fishImgs];
           if (outline) {
-            ctx.globalAlpha = (Math.sin(frameRef.current / 10) + 1) / 2;
+            ctx.globalAlpha =
+              (Math.sin((frameRef.current / FRAME_MS) / 10) + 1) / 2;
             ctx.drawImage(outline, drawX, drawY, FISH_SIZE, FISH_SIZE);
             ctx.globalAlpha = 1;
           }
@@ -922,7 +933,7 @@ export default function useGameEngine() {
     });
 
     animationFrameRef.current = requestAnimationFrame(loop);
-  }, [updateFish, getImg, assetMgr, spawnBubble, updateDigitLabel, frameRate]);
+  }, [updateFish, getImg, assetMgr, spawnBubble, updateDigitLabel]);
 
   // start the game
   const startSplash = useCallback(() => {
@@ -1052,7 +1063,7 @@ export default function useGameEngine() {
     const cur = state.current;
 
     if (fishSpawnTimeout.current) {
-      clearTimeout(fishSpawnTimeout.current);
+      clearScaledTimeout(fishSpawnTimeout.current);
       fishSpawnTimeout.current = null;
     }
 
@@ -1106,11 +1117,11 @@ export default function useGameEngine() {
     if (animationFrameRef.current)
       cancelAnimationFrame(animationFrameRef.current);
     if (spawnTimeoutRef.current) {
-      clearTimeout(spawnTimeoutRef.current);
+      clearScaledTimeout(spawnTimeoutRef.current);
       spawnTimeoutRef.current = null;
     }
     if (cursorTimeoutRef.current) {
-      clearTimeout(cursorTimeoutRef.current);
+      clearScaledTimeout(cursorTimeoutRef.current);
       cursorTimeoutRef.current = null;
     }
     audio.pauseAll();
@@ -1225,8 +1236,8 @@ export default function useGameEngine() {
       if (cur.phase !== "playing") return;
 
       syncCursor(SHOT_CURSOR);
-      if (cursorTimeoutRef.current) clearTimeout(cursorTimeoutRef.current);
-      cursorTimeoutRef.current = setTimeout(() => {
+      if (cursorTimeoutRef.current) clearScaledTimeout(cursorTimeoutRef.current);
+      cursorTimeoutRef.current = setScaledTimeout(() => {
         syncCursor(DEFAULT_CURSOR);
       }, 100);
 
@@ -1541,7 +1552,7 @@ export default function useGameEngine() {
       const baseDelay = min + Math.random() * (max - min);
       const delay = Math.max(baseDelay / difficultyFactor, 250);
 
-      fishSpawnTimeout.current = setTimeout(() => {
+      fishSpawnTimeout.current = setScaledTimeout(() => {
         if (state.current.phase !== "playing") return;
         const kind = basicKinds[Math.floor(Math.random() * basicKinds.length)];
         const count = Math.floor(Math.random() * 5) + 1;
@@ -1559,7 +1570,7 @@ export default function useGameEngine() {
     schedule();
     return () => {
       if (fishSpawnTimeout.current) {
-        clearTimeout(fishSpawnTimeout.current);
+        clearScaledTimeout(fishSpawnTimeout.current);
         fishSpawnTimeout.current = null;
       }
     };

--- a/src/hooks/lightgun-web/useScaledClock.ts
+++ b/src/hooks/lightgun-web/useScaledClock.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef, type MutableRefObject } from "react";
+
+const FRAME_MS = 1000 / 60;
+
+interface TimeoutHandle {
+  remaining: number;
+  cb: () => void;
+  cancelled: boolean;
+}
+
+export interface ClockState {
+  deltaMs: number;
+  scale: number;
+}
+
+export let clockRef: MutableRefObject<ClockState>;
+export let setScaledTimeout: (
+  cb: () => void,
+  ms: number
+) => TimeoutHandle;
+export let clearScaledTimeout: (handle: TimeoutHandle | null) => void;
+
+export type ScaledTimeoutHandle = TimeoutHandle;
+
+export default function useScaledClock() {
+  const last = useRef<number | null>(null);
+  const timeouts = useRef<TimeoutHandle[]>([]);
+  clockRef = useRef<ClockState>({ deltaMs: FRAME_MS, scale: 1 });
+
+  setScaledTimeout = (cb: () => void, ms: number) => {
+    const handle: TimeoutHandle = { remaining: ms, cb, cancelled: false };
+    timeouts.current.push(handle);
+    return handle;
+  };
+
+  clearScaledTimeout = (handle: TimeoutHandle | null) => {
+    if (handle) {
+      handle.cancelled = true;
+    }
+  };
+
+  useEffect(() => {
+    let running = true;
+    const loop = (time: number) => {
+      if (!running) return;
+      if (last.current === null) last.current = time;
+      const delta = time - last.current!;
+      last.current = time;
+      const scale = delta / FRAME_MS;
+      clockRef.current = { deltaMs: delta, scale };
+
+      for (let i = timeouts.current.length - 1; i >= 0; i--) {
+        const t = timeouts.current[i];
+        if (t.cancelled) {
+          timeouts.current.splice(i, 1);
+          continue;
+        }
+        t.remaining -= delta;
+        if (t.remaining <= 0) {
+          t.cb();
+          timeouts.current.splice(i, 1);
+        }
+      }
+
+      requestAnimationFrame(loop);
+    };
+    const id = requestAnimationFrame(loop);
+    return () => {
+      running = false;
+      cancelAnimationFrame(id);
+    };
+  }, []);
+}
+

--- a/src/types/lightgun-web/environment.ts
+++ b/src/types/lightgun-web/environment.ts
@@ -44,10 +44,10 @@ export interface Water {
   size: number;
   /** Animation frame index (toggle for animated water) */
   frameIndex: 0 | 1;
-  /** Frames elapsed for animation timing */
+  /** Milliseconds elapsed for animation timing */
   frameCounter: number;
-  /** How many frames to wait before switching animation frame */
-  frameRate: number;
+  /** How many milliseconds to wait before switching animation frame */
+  frameDuration: number;
 }
 
 /**

--- a/src/types/lightgun-web/objects.ts
+++ b/src/types/lightgun-web/objects.ts
@@ -80,8 +80,10 @@ export interface Medal {
   /** Animation frames for medal spin */
   frames: HTMLImageElement[];
   frameIndex: number;
+  /** Milliseconds elapsed for animation timing */
   frameCounter: number;
-  frameRate: number;
+  /** Duration in milliseconds for each animation frame */
+  frameDuration: number;
   /** Medal ID (1–9) */
   id: number;
 }

--- a/src/types/lightgun-web/vehicles.ts
+++ b/src/types/lightgun-web/vehicles.ts
@@ -9,7 +9,9 @@ export interface Enemy {
   /** Array of animation frames */
   frames: HTMLImageElement[];
   propFrame: number;
-  frameRate: number;
+  /** Duration in milliseconds for propeller animation */
+  frameDuration: number;
+  /** Milliseconds elapsed for animation timing */
   frameCounter: number;
   alive: boolean;
   glide: boolean;
@@ -52,8 +54,10 @@ export interface Airship {
   baseY: number;
   frames: HTMLImageElement[];
   frameIndex: number;
+  /** Milliseconds elapsed for animation timing */
   frameCounter: number;
-  frameRate: number;
+  /** Duration in milliseconds for each frame */
+  frameDuration: number;
   speed: number;
   color: AirshipColor;
   /** Used for vertical bobbing offset */

--- a/src/utils/lightgun-web/environment.ts
+++ b/src/utils/lightgun-web/environment.ts
@@ -126,6 +126,6 @@ export function randomWater(
     size: lakeSize,
     frameIndex: 0,
     frameCounter: 0,
-    frameRate: 30,
+    frameDuration: 30 * (1000 / 60),
   };
 }


### PR DESCRIPTION
## Summary
- Introduce `useScaledClock` hook providing frame delta and scaled timeouts
- Replace old frame rate logic in Warbirds and Zombiefish engines with `useScaledClock`
- Normalize animations and timers to use delta-based countdowns

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ba942c4c848330921303e032f79a39