### PR TITLE
feat(bookworm): add API key prompt

### DIFF
--- a/src/app/bookworm/page.tsx
+++ b/src/app/bookworm/page.tsx
@@ -6,6 +6,10 @@ import CssBaseline from "@mui/material/CssBaseline";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
+import Container from "@mui/material/Container";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
 import AppAppBar from "@/components/bookworm/AppAppBar";
 import Hero from "@/components/bookworm/Hero";
 import Highlights from "@/components/bookworm/Highlights";
@@ -22,14 +26,58 @@ import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 
 import "./page.css"; // Ensure global styles are applied
+import { hasOpenAIKey, setOpenAIKey } from "@/utils/bookworm/utils";
 
 export default function BookwormPage() {
   const [mode, setMode] = React.useState<PaletteMode>("light");
   const defaultTheme = createTheme({ palette: { mode } });
+  const [apiKeyReady, setApiKeyReady] = React.useState(hasOpenAIKey());
 
   const toggleColorMode = () => {
     setMode((prev) => (prev === "dark" ? "light" : "dark"));
   };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const key = String(formData.get("apiKey"))?.trim();
+    if (key) {
+      setOpenAIKey(key);
+      setApiKeyReady(true);
+    }
+  };
+
+  if (!apiKeyReady) {
+    return (
+      <ThemeProvider theme={defaultTheme}>
+        <CssBaseline />
+        <Container component="main" maxWidth="sm" sx={{ mt: 8, mb: 4 }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Welcome to Bookworm
+          </Typography>
+          <Typography variant="body1" paragraph>
+            Bookworm needs an OpenAI API key to talk with OpenAI. The key you
+            type here goes straight from your browser to OpenAI and stays
+            between you and OpenAI. Bookworm does not store your key anywhere
+            and does not send it anywhere else. If you do not fully trust
+            Bookworm, do not enter your key.
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit}>
+            <TextField
+              label="OpenAI API Key"
+              name="apiKey"
+              type="password"
+              fullWidth
+              required
+            />
+            <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+              Continue
+            </Button>
+          </Box>
+        </Container>
+      </ThemeProvider>
+    );
+  }
 
   return (
     <ThemeProvider theme={defaultTheme}>

--- a/src/utils/bookworm/utils.ts
+++ b/src/utils/bookworm/utils.ts
@@ -7,9 +7,13 @@ import { aiBufferSize } from "@/consts/bookworm/consts";
 
 import { Buffer } from "buffer";
 
-const apiKey =
-  process.env.NEXT_PUBLIC_OPENAI_API_KEY ||
-  "";
+let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || "";
+
+export const setOpenAIKey = (key: string) => {
+  apiKey = key;
+};
+
+export const hasOpenAIKey = () => apiKey.trim().length > 0;
 
 const requestCompletion = async (systemMessage: string) => {
   const response = await fetch("https://api.openai.com/v1/chat/completions", {


### PR DESCRIPTION
## Summary
- prompt users for an OpenAI API key before launching Bookworm when no key is set
- allow runtime setting of the OpenAI API key via helper utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba9e6348cc83308dcc31a618587a65