### PR TITLE
refactor: externalize scaled clock loop

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -73,6 +73,7 @@ import useScaledClock, {
   clockRef,
   setScaledTimeout,
   clearScaledTimeout,
+  advanceClock,
 } from "@/hooks/lightgun-web/useScaledClock";
 import { AudioMgr } from "@/types/lightgun-web/audio";
 import { Puff } from "@/types/lightgun-web/effects";
@@ -1054,12 +1055,17 @@ export function useGameEngine() {
     const groundImgs = getImg("groundImgs") as HTMLImageElement[];
     const tileW = groundImgs[0].width;
 
-    let blindfoldWasActive = false;
-    let blindfoldPrevCursor = DEFAULT_CURSOR;
+      let blindfoldWasActive = false;
+      let blindfoldPrevCursor = DEFAULT_CURSOR;
 
-    const render = () => {
-        const { deltaMs } = clockRef.current;
-        const deltaFrames = deltaMs / (1000 / 60);
+      let lastTime = performance.now();
+      const render = () => {
+        const now = performance.now();
+        const deltaMs = now - lastTime;
+        lastTime = now;
+        advanceClock(deltaMs);
+        const { deltaMs: scaledMs } = clockRef.current;
+        const deltaFrames = scaledMs / (1000 / 60);
         state.current.speedScale = deltaFrames;
       const blindActive = state.current.isActive(
         "blindfold",
@@ -3354,19 +3360,24 @@ export function useGameEngine() {
       canvas.style.width = `${screenW}px`;
       canvas.style.height = `${screenH}px`;
       ctx.scale(scaleX * dpr, scaleY * dpr);
-      let raf: number;
-      const render = () => {
-        ctx.fillStyle = SKY_COLOR;
-        ctx.fillRect(0, 0, width, height);
-        state.current.textLabels = drawTextLabels({
-          textLabels: state.current.textLabels,
-          ctx,
-          cull: true,
-        });
-        raf = requestAnimationFrame(render);
-      };
-      render();
-      return () => cancelAnimationFrame(raf);
+        let raf: number;
+        let lastTime = performance.now();
+        const render = () => {
+          const now = performance.now();
+          const deltaMs = now - lastTime;
+          lastTime = now;
+          advanceClock(deltaMs);
+          ctx.fillStyle = SKY_COLOR;
+          ctx.fillRect(0, 0, width, height);
+          state.current.textLabels = drawTextLabels({
+            textLabels: state.current.textLabels,
+            ctx,
+            cull: true,
+          });
+          raf = requestAnimationFrame(render);
+        };
+        render();
+        return () => cancelAnimationFrame(raf);
     }
   }, [ui.phase, screenDims, canvasRef, dims]);
 

--- a/src/games/zombiefish/hooks/useGameEngine.ts
+++ b/src/games/zombiefish/hooks/useGameEngine.ts
@@ -4,6 +4,7 @@ import useScaledClock, {
   clockRef,
   setScaledTimeout,
   clearScaledTimeout,
+  advanceClock,
   type ScaledTimeoutHandle,
 } from "@/hooks/lightgun-web/useScaledClock";
 import { BASE_DIMS } from "@/consts/lightgun-web/dimensions";
@@ -112,6 +113,7 @@ export default function useGameEngine() {
   // canvas and animation frame refs
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationFrameRef = useRef<number | null>(null);
+  const lastTimeRef = useRef(performance.now());
 
   // assets
   const assetMgr = useGameAssets();
@@ -567,6 +569,10 @@ export default function useGameEngine() {
 
   // main loop updates timer and fish
   const loop = useCallback(() => {
+      const now = performance.now();
+      const deltaMsRaw = now - lastTimeRef.current;
+      lastTimeRef.current = now;
+      advanceClock(deltaMsRaw);
       const { deltaMs, scale } = clockRef.current;
       const cur = state.current;
       if (timerLabel.current) {
@@ -1055,6 +1061,7 @@ export default function useGameEngine() {
 
     if (animationFrameRef.current)
       cancelAnimationFrame(animationFrameRef.current);
+    lastTimeRef.current = performance.now();
     animationFrameRef.current = requestAnimationFrame(loop);
   }, [loop, assetMgr, getImg, updateDigitLabel]);
 

--- a/src/hooks/lightgun-web/useScaledClock.ts
+++ b/src/hooks/lightgun-web/useScaledClock.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type MutableRefObject } from "react";
+import { useRef, type MutableRefObject } from "react";
 
 const FRAME_MS = 1000 / 60;
 
@@ -19,11 +19,11 @@ export let setScaledTimeout: (
   ms: number
 ) => TimeoutHandle;
 export let clearScaledTimeout: (handle: TimeoutHandle | null) => void;
+export let advanceClock: (deltaMs: number) => void;
 
 export type ScaledTimeoutHandle = TimeoutHandle;
 
 export default function useScaledClock() {
-  const last = useRef<number | null>(null);
   const timeouts = useRef<TimeoutHandle[]>([]);
   clockRef = useRef<ClockState>({ deltaMs: FRAME_MS, scale: 1 });
 
@@ -39,36 +39,22 @@ export default function useScaledClock() {
     }
   };
 
-  useEffect(() => {
-    let running = true;
-    const loop = (time: number) => {
-      if (!running) return;
-      if (last.current === null) last.current = time;
-      const delta = time - last.current!;
-      last.current = time;
-      const scale = delta / FRAME_MS;
-      clockRef.current = { deltaMs: delta, scale };
+  advanceClock = (deltaMs: number) => {
+    const scale = deltaMs / FRAME_MS;
+    clockRef.current = { deltaMs, scale };
 
-      for (let i = timeouts.current.length - 1; i >= 0; i--) {
-        const t = timeouts.current[i];
-        if (t.cancelled) {
-          timeouts.current.splice(i, 1);
-          continue;
-        }
-        t.remaining -= delta;
-        if (t.remaining <= 0) {
-          t.cb();
-          timeouts.current.splice(i, 1);
-        }
+    for (let i = timeouts.current.length - 1; i >= 0; i--) {
+      const t = timeouts.current[i];
+      if (t.cancelled) {
+        timeouts.current.splice(i, 1);
+        continue;
       }
-
-      requestAnimationFrame(loop);
-    };
-    const id = requestAnimationFrame(loop);
-    return () => {
-      running = false;
-      cancelAnimationFrame(id);
-    };
-  }, []);
+      t.remaining -= deltaMs;
+      if (t.remaining <= 0) {
+        t.cb();
+        timeouts.current.splice(i, 1);
+      }
+    }
+  };
 }
 


### PR DESCRIPTION
## Summary
- decouple scaled clock from internal animation loop
- update warbirds and zombiefish engines to drive scaled clock with delta timing

## Testing
- `npm test` *(fails: command not found: npm)*
- `bunx eslint`


------
https://chatgpt.com/codex/tasks/task_e_68baa8a57dd083308be14e612d3cb650