### PR TITLE
fix: ensure warbirds render loop initializes correctly

### DIFF
--- a/src/games/warbirds/hooks/useGameEngine.ts
+++ b/src/games/warbirds/hooks/useGameEngine.ts
@@ -3317,7 +3317,7 @@ export function useGameEngine() {
       // sync ui state
       syncUIFromState();
     };
-    render();
+    animationFrameRef.current = requestAnimationFrame(render);
   }, [
     getImg,
     dims,


### PR DESCRIPTION
## Summary
- schedule the first game frame with `requestAnimationFrame` so the warbirds engine advances time before checking `frameCount`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bab35057348330bf07b926240a6da9