### PR TITLE
feat: add document title hook

### DIFF
--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { PaletteMode } from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
@@ -36,6 +36,7 @@ import Recognition from "@/components/app/Recognition";
 import ContactCTA from "@/components/app/ContactCTA";
 import Grid from "@mui/material/Grid";
 import { withBasePath } from "@/utils/basePath";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function HomePageClient() {
   const [mode, setMode] = useState<PaletteMode>("light");
@@ -64,6 +65,11 @@ export default function HomePageClient() {
   );
   const [open, setOpen] = useState(false);
   const drawerWidth = 240;
+
+  const { setDocumentTitle } = useDocumentTitle();
+  useEffect(() => {
+    setDocumentTitle("Richard Franks | Résumé");
+  }, [setDocumentTitle]);
 
   const toggleDrawer = () => {
     setOpen(!open);

--- a/src/app/aisummary/AISummaryPageClient.tsx
+++ b/src/app/aisummary/AISummaryPageClient.tsx
@@ -7,6 +7,8 @@ import ProjectPresentation, {
   ProjectData,
 } from "@/components/showcase/ProjectPresentation";
 import { Divider } from "@mui/material";
+import { useEffect } from "react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 interface AISummaryPageClientProps {
   project: ProjectData;
@@ -15,6 +17,10 @@ interface AISummaryPageClientProps {
 export default function AISummaryPageClient({
   project,
 }: AISummaryPageClientProps) {
+  const { setDocumentTitle } = useDocumentTitle();
+  useEffect(() => {
+    setDocumentTitle("AISummary");
+  }, [setDocumentTitle]);
   return (
     <Box
       sx={{

--- a/src/app/assignmentlist/PageClient.tsx
+++ b/src/app/assignmentlist/PageClient.tsx
@@ -7,12 +7,18 @@ import ProjectPresentation, {
   ProjectData,
 } from "@/components/showcase/ProjectPresentation";
 import { Divider } from "@mui/material";
+import { useEffect } from "react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 interface PageClientProps {
   project: ProjectData;
 }
 
 export default function PageClient({ project }: PageClientProps) {
+  const { setDocumentTitle } = useDocumentTitle();
+  useEffect(() => {
+    setDocumentTitle("Assignment List");
+  }, [setDocumentTitle]);
   return (
     <Box
       sx={{

--- a/src/app/blackjack/page.tsx
+++ b/src/app/blackjack/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import * as React from "react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import "./page.css";
 
 export default function BlackjackPage() {
+  const { setDocumentTitle } = useDocumentTitle();
+  React.useEffect(() => {
+    setDocumentTitle("Blackjack");
+  }, [setDocumentTitle]);
   return (
     <>
       <div id="progressives">

--- a/src/app/bookworm/page.tsx
+++ b/src/app/bookworm/page.tsx
@@ -28,11 +28,17 @@ import "@fontsource/roboto/700.css";
 import "./page.css"; // Ensure global styles are applied
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/bookworm/utils";
 import Image from "next/image";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function BookwormPage() {
   const [mode, setMode] = React.useState<PaletteMode>("light");
   const defaultTheme = createTheme({ palette: { mode } });
   const [apiKeyReady, setApiKeyReady] = React.useState(hasOpenAIKey());
+  const { setDocumentTitle } = useDocumentTitle();
+
+  React.useEffect(() => {
+    setDocumentTitle("Bookworm");
+  }, [setDocumentTitle]);
 
   const toggleColorMode = () => {
     setMode((prev) => (prev === "dark" ? "light" : "dark"));

--- a/src/app/dna/page.tsx
+++ b/src/app/dna/page.tsx
@@ -9,10 +9,15 @@ import "@fontsource/roboto/700.css";
 
 import "./page.css"; // Ensure global styles are applied
 import { CssBaseline, ThemeProvider, createTheme } from "@mui/material";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 const defaultTheme = createTheme();
 
 export default function DnaPage() {
+  const { setDocumentTitle } = useDocumentTitle();
+  React.useEffect(() => {
+    setDocumentTitle("GeneBoard");
+  }, [setDocumentTitle]);
   return (
     <ThemeProvider theme={defaultTheme}>
       <CssBaseline />

--- a/src/app/patientlist/PageClient.tsx
+++ b/src/app/patientlist/PageClient.tsx
@@ -7,12 +7,18 @@ import ProjectPresentation, {
   ProjectData,
 } from "@/components/showcase/ProjectPresentation";
 import { Divider } from "@mui/material";
+import { useEffect } from "react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 interface PageClientProps {
   project: ProjectData;
 }
 
 export default function PageClient({ project }: PageClientProps) {
+  const { setDocumentTitle } = useDocumentTitle();
+  useEffect(() => {
+    setDocumentTitle("Patient List");
+  }, [setDocumentTitle]);
   return (
     <Box
       sx={{

--- a/src/app/patientlistpodcasts/PageClient.tsx
+++ b/src/app/patientlistpodcasts/PageClient.tsx
@@ -7,6 +7,8 @@ import ProjectPresentation, {
   ProjectData,
 } from "@/components/showcase/ProjectPresentation";
 import { Divider } from "@mui/material";
+import { useEffect } from "react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 interface PageClientProps {
   project: ProjectData;
@@ -15,6 +17,10 @@ interface PageClientProps {
 export default function PageClient({
   project,
 }: PageClientProps) {
+  const { setDocumentTitle } = useDocumentTitle();
+  useEffect(() => {
+    setDocumentTitle("Patient List Podcasts");
+  }, [setDocumentTitle]);
   return (
     <Box
       sx={{

--- a/src/app/warbirds/page.tsx
+++ b/src/app/warbirds/page.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Container } from "@mui/material";
 import Game from "@/games/warbirds";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import "./page.css";
 
 export default function WarbirdsPage() {
+  const { setDocumentTitle } = useDocumentTitle();
+  useEffect(() => {
+    setDocumentTitle("Warbirds");
+  }, [setDocumentTitle]);
+
   return (
     <Container
       sx={{

--- a/src/app/zombiefish/page.tsx
+++ b/src/app/zombiefish/page.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { Container } from "@mui/material";
 import Game from "@/games/zombiefish";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import "./page.css";
 
 export default function ZombieFishPage() {
+  const { setDocumentTitle } = useDocumentTitle();
+  useEffect(() => {
+    setDocumentTitle("ZombieFish");
+  }, [setDocumentTitle]);
+
   return (
     <Container
       sx={{

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,12 +1,22 @@
-/**
- * Sets the title of the document.
- *
- * @returns the `document`'s current title
- */
-export function useDocumentTitle(documentTitle?: string): string {
-  if (documentTitle) {
-    document.title = documentTitle;
-  }
+import { useCallback } from "react";
 
-  return document.title;
+/**
+ * React hook providing helpers to get and set the document's title.
+ *
+ * @returns `getDocumentTitle` - returns the current document title
+ *          `setDocumentTitle` - sets the document title
+ */
+export function useDocumentTitle() {
+  const getDocumentTitle = useCallback((): string => {
+    return typeof document === "undefined" ? "" : document.title;
+  }, []);
+
+  const setDocumentTitle = useCallback((title: string): void => {
+    if (typeof document !== "undefined") {
+      document.title = title;
+    }
+  }, []);
+
+  return { getDocumentTitle, setDocumentTitle };
 }
+


### PR DESCRIPTION
## Summary
- add `useDocumentTitle` hook returning get and set helpers
- apply hook across all pages to set appropriate document titles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb3927eb1c8330a25e594511c81123