### PR TITLE
feat: add blasteroids page and project accolades carousel

### DIFF
--- a/src/app/blasteroids/page.tsx
+++ b/src/app/blasteroids/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function BlasteroidsPage() {
+  const { setDocumentTitle } = useDocumentTitle();
+
+  useEffect(() => {
+    setDocumentTitle("Blasteroids");
+  }, [setDocumentTitle]);
+
+  return (
+    <iframe
+      src="https://rfranks.github.io/blasteroids"
+      style={{ border: "none", width: "100vw", height: "100vh" }}
+      title="Blasteroids"
+    />
+  );
+}
+

--- a/src/components/app/AccoladesCarousel.tsx
+++ b/src/components/app/AccoladesCarousel.tsx
@@ -1,0 +1,102 @@
+import Image from "next/image";
+import { Card, CardActions, CardContent, Button, Typography, Box, Link } from "@mui/material";
+import { withBasePath } from "@/utils/basePath";
+
+export interface Accolade {
+  name: string;
+  source: string;
+  sourceUrl: string;
+  description?: string;
+  comment?: string;
+  launchUrl?: string;
+  githubUrl?: string;
+  imageSrcUrl?: string;
+  date?: string;
+}
+
+export default function AccoladesCarousel({ accolades }: { accolades: Accolade[] }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        overflowX: "auto",
+        gap: 2,
+        py: 1,
+        scrollSnapType: "x mandatory",
+      }}
+    >
+      {accolades.map((acc, idx) => (
+        <Card
+          key={idx}
+          variant="outlined"
+          sx={{ minWidth: 280, flex: "0 0 auto", scrollSnapAlign: "start" }}
+        >
+          {acc.imageSrcUrl && (
+            <Image
+              src={withBasePath(acc.imageSrcUrl)}
+              alt={acc.name}
+              width={300}
+              height={200}
+              style={{ width: "100%", height: "auto" }}
+            />
+          )}
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              {acc.name}
+            </Typography>
+            <Typography variant="subtitle2" color="text.secondary">
+              <Link
+                href={acc.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+              >
+                {acc.source}
+              </Link>
+            </Typography>
+            {acc.date && (
+              <Typography variant="caption" color="text.secondary" display="block">
+                {acc.date}
+              </Typography>
+            )}
+            {acc.description && (
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                {acc.description}
+              </Typography>
+            )}
+            {acc.comment && (
+              <Typography variant="body2" sx={{ mt: 1, fontStyle: "italic" }}>
+                {acc.comment}
+              </Typography>
+            )}
+          </CardContent>
+          {(acc.launchUrl || acc.githubUrl) && (
+            <CardActions>
+              {acc.launchUrl && (
+                <Button
+                  size="small"
+                  href={withBasePath(acc.launchUrl)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Launch
+                </Button>
+              )}
+              {acc.githubUrl && (
+                <Button
+                  size="small"
+                  href={acc.githubUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  GitHub
+                </Button>
+              )}
+            </CardActions>
+          )}
+        </Card>
+      ))}
+    </Box>
+  );
+}
+

--- a/src/components/app/ProjectsGrid.tsx
+++ b/src/components/app/ProjectsGrid.tsx
@@ -10,6 +10,7 @@ import TronPaper from "@/components/app/TronPaper";
 import FadeInSection from "@/components/app/FadeInSection";
 import { withBasePath } from "@/utils/basePath";
 import { CardHeader, Chip } from "@mui/material";
+import AccoladesCarousel from "@/components/app/AccoladesCarousel";
 
 export default function ProjectsGrid() {
   return (
@@ -66,6 +67,12 @@ export default function ProjectsGrid() {
                     size="small"
                     href={withBasePath(project.href)}
                     color="secondary"
+                    target={project.href === "/blasteroids" ? "_blank" : undefined}
+                    rel={
+                      project.href === "/blasteroids"
+                        ? "noopener noreferrer"
+                        : undefined
+                    }
                   >
                     Launch
                   </Button>
@@ -74,6 +81,19 @@ export default function ProjectsGrid() {
             </Grid>
           ))}
         </Grid>
+        {(() => {
+          const accolades = resumeData.projects.flatMap(
+            (p) => p.accolades ?? []
+          );
+          return accolades.length > 0 ? (
+            <>
+              <Typography variant="h6" gutterBottom sx={{ mt: 4 }}>
+                Accolades
+              </Typography>
+              <AccoladesCarousel accolades={accolades} />
+            </>
+          ) : null;
+        })()}
       </TronPaper>
     </FadeInSection>
   );


### PR DESCRIPTION
## Summary
- add `/blasteroids` page embedding the external game in a full-screen iframe
- show project accolades in a horizontal card carousel and open Blasteroids launch in a new tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d71871c833086c81378f4d449fd