### PR TITLE
Display accolades within each project card

### DIFF
--- a/src/components/app/ProjectsGrid.tsx
+++ b/src/components/app/ProjectsGrid.tsx
@@ -11,6 +11,7 @@ import FadeInSection from "@/components/app/FadeInSection";
 import { withBasePath } from "@/utils/basePath";
 import { CardHeader, Chip } from "@mui/material";
 import AccoladesCarousel from "@/components/app/AccoladesCarousel";
+import Box from "@mui/material/Box";
 
 export default function ProjectsGrid() {
   return (
@@ -78,22 +79,17 @@ export default function ProjectsGrid() {
                   </Button>
                 </CardActions>
               </Card>
+              {project.accolades && project.accolades.length > 0 && (
+                <Box sx={{ mt: 2 }}>
+                  <Typography variant="subtitle1" gutterBottom>
+                    Accolades
+                  </Typography>
+                  <AccoladesCarousel accolades={project.accolades} />
+                </Box>
+              )}
             </Grid>
           ))}
         </Grid>
-        {(() => {
-          const accolades = resumeData.projects.flatMap(
-            (p) => p.accolades ?? []
-          );
-          return accolades.length > 0 ? (
-            <>
-              <Typography variant="h6" gutterBottom sx={{ mt: 4 }}>
-                Accolades
-              </Typography>
-              <AccoladesCarousel accolades={accolades} />
-            </>
-          ) : null;
-        })()}
       </TronPaper>
     </FadeInSection>
   );


### PR DESCRIPTION
## Summary
- Show each project's accolades directly beneath its card in the Projects grid
- Drop the standalone Accolades section from the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bba300c5d883308f943e06e199c657