### PR TITLE
Fix project card layout to fill grid rows

### DIFF
--- a/src/components/app/ProjectsGrid.tsx
+++ b/src/components/app/ProjectsGrid.tsx
@@ -20,9 +20,17 @@ export default function ProjectsGrid() {
         <Typography variant="h6" gutterBottom>
           Projects
         </Typography>
-        <Grid container spacing={2}>
+        <Grid container spacing={2} alignItems="stretch">
           {resumeData.projects.map((project, index) => (
-            <Grid item xs={12} sm={6} md={4} lg={3} key={project.href}>
+            <Grid
+              item
+              xs={12}
+              sm={6}
+              md={4}
+              lg={3}
+              key={project.href}
+              sx={{ display: "flex" }}
+            >
               <Card
                 variant="outlined"
                 sx={{
@@ -31,6 +39,7 @@ export default function ProjectsGrid() {
                   borderColor: "divider",
                   display: "flex",
                   flexDirection: "column",
+                  flexGrow: 1,
                 }}
               >
                 <CardHeader


### PR DESCRIPTION
## Summary
- Stretch project cards to fill available height in their grid rows
- Ensure grid items flex so card bottoms align

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bba798a3348330a2cde73a68468729