### PR TITLE
Ensure isMaxBase consistently returns a boolean

### DIFF
--- a/src/utils/dna/sequenceUtils.tsx
+++ b/src/utils/dna/sequenceUtils.tsx
@@ -260,7 +260,7 @@ export function validBase(base: string): boolean {
   }
 }
 
-export function isMaxBase(sequence: string, base: Base) {
+export function isMaxBase(sequence: string, base: Base): boolean {
   const counts = getBasepairCounts(sequence)?.[0];
   const baseCounts: Array<number> = [
     counts.A,
@@ -279,7 +279,5 @@ export function isMaxBase(sequence: string, base: Base) {
     return false;
   }
 
-  if (counts[base] >= maxBasePairCount) {
-    return true;
-  }
+  return counts[base] >= maxBasePairCount;
 }


### PR DESCRIPTION
## Summary
- fix `isMaxBase` to always return a boolean and simplify logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfaa2722448330a2bf8b79c868b2f7