### PR TITLE
fix: guard intersection observer

### DIFF
--- a/src/hooks/useIsVisible.ts
+++ b/src/hooks/useIsVisible.ts
@@ -4,12 +4,16 @@ export function useIsVisible(ref: React.RefObject<HTMLElement | null>) {
   const [isIntersecting, setIntersecting] = useState(false);
 
   useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
     const observer = new IntersectionObserver(([entry]) =>
       setIntersecting(entry.isIntersecting)
     );
 
-    observer.observe(ref.current!);
+    observer.observe(element);
     return () => {
+      observer.unobserve(element);
       observer.disconnect();
     };
   }, [ref]);


### PR DESCRIPTION
## Summary
- handle empty refs in `useIsVisible` hook to prevent runtime errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfaa2722448330a2bf8b79c868b2f7