### PR TITLE
fix: avoid prefixing absolute URLs with base path

### DIFF
--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -9,8 +9,18 @@ export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 /**
  * Prefix a path with `BASE_PATH` so asset URLs resolve correctly both locally
  * and when deployed under a GitHub Pages style subpath.
+ *
+ * Absolute URLs (including protocol‑relative ones) are returned unchanged so
+ * that external resources aren't accidentally prefixed with the local
+ * deployment path.
  */
 export function withBasePath(path: string): string {
+  // Skip prefixing if the path is already an absolute URL like "http://"
+  // or "mailto:" or a protocol-relative URL starting with "//".
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(path) || path.startsWith("//")) {
+    return path;
+  }
+
   const base = BASE_PATH.endsWith("/") ? BASE_PATH.slice(0, -1) : BASE_PATH;
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   return `${base}${normalizedPath}`;


### PR DESCRIPTION
## Summary
- skip base path prefixing for absolute or protocol-relative URLs
- document behavior in withBasePath helper

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bfac0d1de88330b4384dafc4dba63c