### PR TITLE
Fix off-by-one context chunking in OpenAI requests

### DIFF
--- a/src/utils/bookworm/utils.ts
+++ b/src/utils/bookworm/utils.ts
@@ -100,7 +100,7 @@ export const askOpenAI = async ({
   let responseText = "";
 
   do {
-    const rest = context.substring(Math.min(aiBufferSize + 1, context.length));
+    const rest = context.substring(Math.min(aiBufferSize, context.length));
     context = context.substring(0, Math.min(aiBufferSize, context.length));
 
     const systemMessage =


### PR DESCRIPTION
## Summary
- fix off-by-one error when chunking context for OpenAI API calls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfac0d1de88330b4384dafc4dba63c