### PR TITLE
Add VSCode task to build blackjack WebAssembly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,13 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "Build Blackjack Wasm",
+            "type": "node-terminal",
+            "request": "launch",
+            "command": "GOOS=js GOARCH=wasm go build -o ../../public/main.wasm",
+            "cwd": "${workspaceFolder}/go/blackjack"
+        },
+        {
             "name": "Launch Test (short)",
             "type": "go",
             "request": "launch",


### PR DESCRIPTION
## Summary
- add a VS Code launch entry to compile blackjack to `public/main.wasm`

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bfb187c1008330921055091a220adc