### PR TITLE
Add TalentForge route to navigation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ drawer menu links to several demos and games:
 
 - [GeneBoard](http://localhost:3000/dna)
 - [Bookworm](http://localhost:3000/bookworm)
+- [TalentForge](http://localhost:3000/talentforge)
 - [Blackjack](http://localhost:3000/blackjack)
 - [Warbirds](http://localhost:3000/warbirds)
 - [ZombieFish](http://localhost:3000/zombiefish)

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -23,6 +23,7 @@ import {
   Casino,
   Flight,
   BugReport,
+  Build,
 } from "@mui/icons-material";
 import AppBar from "@/components/app/AppBar";
 import Drawer from "@/components/app/Drawer";
@@ -141,6 +142,12 @@ export default function HomePageClient() {
                 <MenuBook />
               </ListItemIcon>
               <ListItemText primary="Bookworm" />
+            </ListItemButton>
+            <ListItemButton component="a" href={withBasePath("/talentforge")}>
+              <ListItemIcon>
+                <Build />
+              </ListItemIcon>
+              <ListItemText primary="TalentForge" />
             </ListItemButton>
             <ListItemButton component="a" href={withBasePath("/blackjack")}>
               <ListItemIcon>


### PR DESCRIPTION
## Summary
- add TalentForge entry in navigation drawer
- document TalentForge route in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfc1ff57e48330aa373c80ec2630ff