### PR TITLE
Isolate TalentForge from Bookworm without modifying bookworm

### DIFF
--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -30,7 +30,7 @@ import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
 import Image from "next/image";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
-export default function BookwormPage() {
+export default function TalentForgePage() {
   const [mode, setMode] = React.useState<PaletteMode>("light");
   const defaultTheme = createTheme({ palette: { mode } });
   const [apiKeyReady, setApiKeyReady] = React.useState(hasOpenAIKey());


### PR DESCRIPTION
## Summary
- keep Bookworm modules untouched by reverting earlier changes
- confirm TalentForge page uses its own components and utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfc1e35dac8330ae1601d72e82edf5