### PR TITLE
feat: brand TalentForge AI

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "bookworm",
-  "name": "bookworm",
+  "short_name": "TalentForge AI",
+  "name": "TalentForge AI",
   "icons": [
     {
       "src": "favicon.ico",
@@ -8,7 +8,7 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
+      "src": "talentforge-logo.png",
       "type": "image/png",
       "sizes": "192x192"
     },

--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -37,7 +37,7 @@ export default function TalentForgePage() {
   const { setDocumentTitle } = useDocumentTitle();
 
   React.useEffect(() => {
-    setDocumentTitle("Bookworm");
+    setDocumentTitle("TalentForge AI");
   }, [setDocumentTitle]);
 
   const toggleColorMode = () => {
@@ -60,21 +60,21 @@ export default function TalentForgePage() {
         <CssBaseline />
         <Container component="main" maxWidth="sm" sx={{ mt: 8, mb: 4 }}>
           <Image
-            src="/logo192.png"
+            src="/talentforge-logo.png"
             style={{ width: "192px", height: "auto" }}
-            alt="bookworm logo"
+            alt="TalentForge AI logo"
             width={192}
             height={194}
           />
           <Typography variant="h4" component="h1" gutterBottom>
-            Welcome to Bookworm
+            Welcome to TalentForge AI
           </Typography>
           <Typography variant="body1" paragraph>
-            Bookworm needs an OpenAI API key to talk with OpenAI. The key you
-            type here goes straight from your browser to OpenAI and stays
-            between you and OpenAI. Bookworm does not store your key anywhere
-            and does not send it anywhere else. If you do not fully trust
-            Bookworm, do not enter your key.
+            TalentForge AI needs an OpenAI API key to talk with OpenAI. The key
+            you type here goes straight from your browser to OpenAI and stays
+            between you and OpenAI. TalentForge AI does not store your key
+            anywhere and does not send it anywhere else. If you do not fully
+            trust TalentForge AI, do not enter your key.
           </Typography>
           <Box component="form" onSubmit={handleSubmit}>
             <TextField

--- a/src/components/talentforge/AppAppBar.tsx
+++ b/src/components/talentforge/AppAppBar.tsx
@@ -91,9 +91,9 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
               }}
             >
               <Image
-                src="/logo192.png"
+                src="/talentforge-logo.png"
                 style={logoStyle}
-                alt="bookworm logo"
+                alt="TalentForge AI logo"
                 width={192}
                 height={194}
               />
@@ -108,7 +108,7 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>
               <Box sx={{ display: { xs: "none", md: "flex" } }}>
                 <MenuItem

--- a/src/components/talentforge/FAQ.tsx
+++ b/src/components/talentforge/FAQ.tsx
@@ -63,7 +63,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>
               {"?"}
             </Typography>
@@ -74,7 +74,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Bookworm is an advanced AI-powered tool designed to summarize PDF
+              TalentForge AI is an advanced AI-powered tool designed to summarize PDF
               documents and answer content-specific questions. It offers a
               user-friendly interface and continuously improves over time to
               provide efficient document handling and deeper comprehension.
@@ -101,7 +101,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>{" "}
               save time?
             </Typography>
@@ -112,7 +112,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Bookworm dramatically reduces the time spent reading and
+              TalentForge AI dramatically reduces the time spent reading and
               comprehending long PDF documents by providing concise summaries.
               This allows users to quickly grasp key points, freeing up time for
               other tasks or deeper study on specific areas of interest.
@@ -139,7 +139,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>{" "}
               enhance understanding?
             </Typography>
@@ -150,7 +150,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Bookworm enhances understanding by allowing users to ask specific
+              TalentForge AI enhances understanding by allowing users to ask specific
               questions about the PDF content. It clarifies complex information
               and provides detailed insights, which is particularly valuable for
               dense academic papers, technical manuals, and detailed reports
@@ -178,7 +178,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>{" "}
               accessible anywhere?
             </Typography>
@@ -189,7 +189,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Yes, Bookworm is designed to be accessible anywhere and anytime.
+              Yes, TalentForge AI is designed to be accessible anywhere and anytime.
                 Whether you&apos;re on the go or at your desk, you can easily upload
               documents and interact with your material without the need for
               extensive reading or manual searching through pages.
@@ -216,7 +216,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>
               ?
             </Typography>
@@ -227,7 +227,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Bookworm is beneficial for students, professionals, and anyone who
+              TalentForge AI is beneficial for students, professionals, and anyone who
               deals with large volumes of PDF documents. It helps streamline
               document handling, improve comprehension, and save time, making it
               an invaluable tool for various tasks and industries.
@@ -254,7 +254,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>{" "}
               handle different types of PDF documents?
             </Typography>
@@ -265,7 +265,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Yes, Bookworm is versatile and can handle various types of PDF
+              Yes, TalentForge AI is versatile and can handle various types of PDF
               documents, including academic papers, technical manuals, reports,
               and more. Its advanced AI capabilities adapt to different content
               structures and complexities to provide accurate summaries and
@@ -293,7 +293,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>{" "}
               easy to use?
             </Typography>
@@ -304,7 +304,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Yes, Bookworm offers an intuitive, user-friendly interface that is
+              Yes, TalentForge AI offers an intuitive, user-friendly interface that is
               easy to navigate. Its features are designed to be accessible and
               straightforward, allowing users to upload documents, ask
               questions, and interact with the content seamlessly.
@@ -331,7 +331,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>{" "}
               require any installation?
             </Typography>
@@ -342,7 +342,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              No, Bookworm is a web-based application that does not require any
+              No, TalentForge AI is a web-based application that does not require any
               installation. Users can access it directly through their web
               browsers, making it convenient to use on any device with an
               internet connection.
@@ -369,7 +369,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>{" "}
               secure?
             </Typography>
@@ -380,10 +380,10 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Yes, Bookworm takes user privacy and data security seriously. It
+              Yes, TalentForge AI takes user privacy and data security seriously. It
               uses encryption and other security measures to protect user data
               and ensure confidentiality while handling PDF documents.
-              Additionally, Bookworm does not store uploaded documents after
+              Additionally, TalentForge AI does not store uploaded documents after
               processing.
             </Typography>
           </AccordionDetails>
@@ -408,7 +408,7 @@ export default function FAQ() {
                   fontStyle: "normal",
                 }}
               >
-                bookworm
+                TalentForge AI
               </Typography>{" "}
               be used for collaborative work?
             </Typography>
@@ -419,7 +419,7 @@ export default function FAQ() {
               gutterBottom
               sx={{ maxWidth: { sm: "100%", md: "70%" } }}
             >
-              Currently, Bookworm is primarily designed for individual use.
+              Currently, TalentForge AI is primarily designed for individual use.
               However, future updates may include collaborative features to
               facilitate teamwork and document sharing among users.
             </Typography>

--- a/src/components/talentforge/Footer.tsx
+++ b/src/components/talentforge/Footer.tsx
@@ -31,37 +31,37 @@ const logoStyle = {
 };
 
 const aboutUs = `
-Bookworm is an innovative AI-powered tool designed to revolutionize the way we interact with PDF documents. Our mission is to empower users to efficiently handle and comprehend large volumes of textual content with ease.
+TalentForge AI is an innovative AI-powered tool designed to revolutionize the way we interact with PDF documents. Our mission is to empower users to efficiently handle and comprehend large volumes of textual content with ease.
 
 ## Our Vision
 
-At Bookworm, we envision a future where accessing and understanding complex documents is effortless. By leveraging advanced artificial intelligence technologies, we aim to provide users with intelligent summaries, insightful analysis, and instant answers to content-specific questions.
+At TalentForge AI, we envision a future where accessing and understanding complex documents is effortless. By leveraging advanced artificial intelligence technologies, we aim to provide users with intelligent summaries, insightful analysis, and instant answers to content-specific questions.
 
 ## Our Mission
 
-Our mission is to simplify the process of document handling and comprehension. We strive to save users time and effort by offering a user-friendly interface that allows for seamless interaction with PDF documents. Whether you're a student, professional, or researcher, Bookworm is your essential companion for unlocking the wealth of knowledge hidden within your documents.
+Our mission is to simplify the process of document handling and comprehension. We strive to save users time and effort by offering a user-friendly interface that allows for seamless interaction with PDF documents. Whether you're a student, professional, or researcher, TalentForge AI is your essential companion for unlocking the wealth of knowledge hidden within your documents.
 
 ## Key Features
 
-- **Summarization**: Bookworm generates concise summaries of PDF documents, enabling users to grasp key points quickly.
-- **Question-Answering**: With Bookworm's question-answering capability, users can ask specific questions about the content and receive instant answers.
-- **Continuous Improvement**: Bookworm's AI algorithms continuously learn and improve over time, ensuring that users receive the most accurate and relevant information.
-- **Accessibility**: Bookworm is accessible anywhere, anytime, allowing users to upload and interact with documents on the go.
+- **Summarization**: TalentForge AI generates concise summaries of PDF documents, enabling users to grasp key points quickly.
+- **Question-Answering**: With TalentForge AI's question-answering capability, users can ask specific questions about the content and receive instant answers.
+- **Continuous Improvement**: TalentForge AI's AI algorithms continuously learn and improve over time, ensuring that users receive the most accurate and relevant information.
+- **Accessibility**: TalentForge AI is accessible anywhere, anytime, allowing users to upload and interact with documents on the go.
 
 ## Meet the Team
 
-Our team consists of passionate individuals dedicated to making document handling and comprehension more efficient and accessible. With expertise in artificial intelligence, natural language processing, and user experience design, we're committed to delivering an exceptional user experience with Bookworm.
+Our team consists of passionate individuals dedicated to making document handling and comprehension more efficient and accessible. With expertise in artificial intelligence, natural language processing, and user experience design, we're committed to delivering an exceptional user experience with TalentForge AI.
 
 ## Contact Us
 
-Have questions or feedback? We'd love to hear from you! Feel free to reach out to us at [richardfrankskr@hotmail.com](mailto:richardfranksjr@hotmail.com) and join us on our mission to revolutionize document handling and comprehension with Bookworm.
+Have questions or feedback? We'd love to hear from you! Feel free to reach out to us at [richardfranksjr@hotmail.com](mailto:richardfranksjr@hotmail.com) and join us on our mission to revolutionize document handling and comprehension with TalentForge AI.
 `;
 
 function Copyright() {
   return (
     <Typography variant="body2" color="text.secondary" mt={1}>
       {"Copyright © "}
-      <Link href="https://github.com/rfranks/bookworm">
+      <Link href="https://github.com/rfranks/talentforge">
         <Typography
           variant="body2"
           component={"span"}
@@ -71,7 +71,7 @@ function Copyright() {
             fontStyle: "normal",
           }}
         >
-          bookworm
+          TalentForge AI
         </Typography>
       </Link>{" "}
       {new Date().getFullYear()}
@@ -148,9 +148,9 @@ export default function Footer() {
           <Box sx={{ width: { xs: "100%", sm: "60%" } }}>
             <Box sx={{ ml: "-15px" }}>
               <Image
-                src="/logo192.png"
+                src="/talentforge-logo.png"
                 style={logoStyle}
-                alt="bookworm logo"
+                alt="TalentForge AI logo"
                 width={192}
                 height={194}
               />
@@ -300,7 +300,7 @@ export default function Footer() {
         >
           <IconButton
             color="inherit"
-            href="https://github.com/rfranks/bookworm"
+            href="https://github.com/rfranks/talentforge"
             aria-label="GitHub"
             sx={{ alignSelf: "center" }}
           >

--- a/src/components/talentforge/Hero.tsx
+++ b/src/components/talentforge/Hero.tsx
@@ -157,7 +157,7 @@ export default function Hero() {
                 fontStyle: "normal",
               }}
             >
-              bookworm
+              TalentForge AI
             </Typography>
           </Typography>
           <Typography
@@ -283,7 +283,7 @@ export default function Hero() {
                         fontStyle: "normal",
                       }}
                     >
-                      bookworm
+                      TalentForge AI
                     </Typography>
                     &nbsp;says...
                   </Typography>
@@ -331,7 +331,7 @@ export default function Hero() {
 
         <OutlinedInput
           ref={userQuestionInputRef}
-          placeholder="Ask bookworm anything about your PDF..."
+          placeholder="Ask TalentForge AI anything about your PDF..."
           fullWidth
           value={userQuestion}
           onChange={(event) => setUserQuestion(event.target.value)}

--- a/src/components/talentforge/Highlights.tsx
+++ b/src/components/talentforge/Highlights.tsx
@@ -13,19 +13,19 @@ const items = [
     icon: <AccessTime />,
     title: "Efficiency and Time-Saving",
     description:
-      "Bookworm dramatically reduces the time you spend reading and comprehending long PDF documents. By providing concise summaries, it allows you to grasp the key points quickly, freeing up time for other tasks or deeper study on specific areas of interest.",
+      "TalentForge AI dramatically reduces the time you spend reading and comprehending long PDF documents. By providing concise summaries, it allows you to grasp the key points quickly, freeing up time for other tasks or deeper study on specific areas of interest.",
   },
   {
     icon: <Psychology />,
     title: "Enhanced Understanding",
     description:
-      "With the ability to ask specific questions about the PDF content, Bookworm enhances your understanding by clarifying complex information and providing detailed insights. This feature is particularly valuable for dense academic papers, technical manuals, and detailed reports where nuances matter.",
+      "With the ability to ask specific questions about the PDF content, TalentForge AI enhances your understanding by clarifying complex information and providing detailed insights. This feature is particularly valuable for dense academic papers, technical manuals, and detailed reports where nuances matter.",
   },
   {
     icon: <AutoFixHighRoundedIcon />,
     title: "Accessibility and Convenience",
     description:
-      "Bookworm is designed to be accessible anywhere and anytime. Whether you’re on the go or at your desk, you can easily upload documents and interact with your material without the need for extensive reading or manual searching through pages. This makes it an invaluable tool for students, professionals, and anyone who needs to process written content efficiently.",
+      "TalentForge AI is designed to be accessible anywhere and anytime. Whether you’re on the go or at your desk, you can easily upload documents and interact with your material without the need for extensive reading or manual searching through pages. This makes it an invaluable tool for students, professionals, and anyone who needs to process written content efficiently.",
   },
 ];
 
@@ -70,7 +70,7 @@ export default function Highlights() {
                 fontStyle: "normal",
               }}
             >
-              bookworm
+              TalentForge AI
             </Typography>{" "}
             stands out with its advanced AI that not only summarizes PDFs but
             also answers content-specific questions, offering an intuitive,

--- a/src/components/talentforge/TermsDialog.tsx
+++ b/src/components/talentforge/TermsDialog.tsx
@@ -14,59 +14,59 @@ import { Close } from "@mui/icons-material";
 
 const terms = `
 
-Welcome to Bookworm! These Terms of Use govern your use of Bookworm, an advanced AI-powered tool designed to summarize PDF documents and answer content-specific questions.
+Welcome to TalentForge AI! These Terms of Use govern your use of TalentForge AI, an advanced AI-powered tool designed to summarize PDF documents and answer content-specific questions.
 
-By accessing or using Bookworm, you agree to be bound by these Terms of Use. If you do not agree with any part of these terms, you may not use Bookworm.
+By accessing or using TalentForge AI, you agree to be bound by these Terms of Use. If you do not agree with any part of these terms, you may not use TalentForge AI.
 
-### 1. Use of Bookworm
+### 1. Use of TalentForge AI
 
 ** 1.1 Use License **
 
-- You may use Bookworm solely for your personal or internal business purposes in accordance with these Terms of Use.
+- You may use TalentForge AI solely for your personal or internal business purposes in accordance with these Terms of Use.
 
-- You may not use Bookworm for any unlawful or unauthorized purpose, including but not limited to violating any applicable laws or regulations.
+- You may not use TalentForge AI for any unlawful or unauthorized purpose, including but not limited to violating any applicable laws or regulations.
 
-- You agree not to reproduce, duplicate, copy, sell, resell, or exploit any portion of Bookworm without express written permission from the owner.
+- You agree not to reproduce, duplicate, copy, sell, resell, or exploit any portion of TalentForge AI without express written permission from the owner.
 
 ### 2. User Content
 
 ** 2.1 Ownership of User Content **
 
-- You retain ownership of any content you upload or submit to Bookworm ("User Content").
+- You retain ownership of any content you upload or submit to TalentForge AI ("User Content").
 
-- By uploading or submitting User Content, you grant Bookworm a worldwide, non-exclusive, royalty-free, transferable license to use, reproduce, distribute, modify, adapt, display, and perform the User Content in connection with Bookworm's operation and promotion.
+- By uploading or submitting User Content, you grant TalentForge AI a worldwide, non-exclusive, royalty-free, transferable license to use, reproduce, distribute, modify, adapt, display, and perform the User Content in connection with TalentForge AI's operation and promotion.
 
 ### 3. Privacy
 
 ** 3.1 Privacy Policy **
 
-- Bookworm respects your privacy and handles your personal data in accordance with its Privacy Policy.
+- TalentForge AI respects your privacy and handles your personal data in accordance with its Privacy Policy.
 
-- By using Bookworm, you consent to the collection, use, and sharing of your information as described in the Privacy Policy.
+- By using TalentForge AI, you consent to the collection, use, and sharing of your information as described in the Privacy Policy.
 
 ### 4. Intellectual Property
 
 ** 4.1 Ownership of Intellectual Property **
 
-- All content, trademarks, service marks, logos, and other intellectual property rights on Bookworm are the property of their respective owners.
+- All content, trademarks, service marks, logos, and other intellectual property rights on TalentForge AI are the property of their respective owners.
 
-- You may not use any trademarks, service marks, or logos displayed on Bookworm without the prior written consent of the owner.
+- You may not use any trademarks, service marks, or logos displayed on TalentForge AI without the prior written consent of the owner.
 
 ### 5. Limitation of Liability
 
 ** 5.1 Disclaimer of Warranties **
 
-- Bookworm is provided on an "as is" and "as available" basis. We make no warranties or representations about the accuracy or completeness of the content provided by Bookworm.
+- TalentForge AI is provided on an "as is" and "as available" basis. We make no warranties or representations about the accuracy or completeness of the content provided by TalentForge AI.
 
-- In no event shall Bookworm or its affiliates be liable for any indirect, incidental, special, consequential, or punitive damages arising out of or in connection with your use of Bookworm.
+- In no event shall TalentForge AI or its affiliates be liable for any indirect, incidental, special, consequential, or punitive damages arising out of or in connection with your use of TalentForge AI.
 
 ### 6. Changes to Terms of Use
 
 ** 6.1 Modifications **
 
-- Bookworm reserves the right to modify or replace these Terms of Use at any time. Any changes will be effective immediately upon posting the revised Terms of Use on Bookworm.
+- TalentForge AI reserves the right to modify or replace these Terms of Use at any time. Any changes will be effective immediately upon posting the revised Terms of Use on TalentForge AI.
 
-- Your continued use of Bookworm after any changes to these Terms of Use constitutes your acceptance of the revised terms.
+- Your continued use of TalentForge AI after any changes to these Terms of Use constitutes your acceptance of the revised terms.
 
 ### 7. Governing Law
 
@@ -76,7 +76,7 @@ By accessing or using Bookworm, you agree to be bound by these Terms of Use. If 
 
 ### 8. Contact Us
 
-- If you have any questions about these Terms of Use, please contact us at [richardfrankskr@hotmail.com](mailto:richardfranksjr@hotmail.com).
+- If you have any questions about these Terms of Use, please contact us at [richardfranksjr@hotmail.com](mailto:richardfranksjr@hotmail.com).
 `;
 
 export interface TermsDialogProps


### PR DESCRIPTION
## Summary
- rename Bookworm references in TalentForge page and components to TalentForge AI
- update manifest to use TalentForge AI name and logo path
- revert earlier contact updates in Bookworm components so Bookworm remains unchanged

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfc5120cc08330bfcd9707b572f531