### PR TITLE
feat: add TalentForge AI personal project

### DIFF
--- a/src/consts/resumeData.ts
+++ b/src/consts/resumeData.ts
@@ -315,6 +315,12 @@ export const projects: {
     interestsMeWhy:
       "Turning clinical events into podcasts explores a novel medium for physician updates. It combines summarization, text-to-speech, and healthcare data.",
   },
+  {
+    name: "TalentForge AI",
+    description: "AI headhunter and resume assistant",
+    href: "/talentforge",
+    type: "personal",
+  },
 ];
 
 export const recognition: {


### PR DESCRIPTION
## Summary
- add TalentForge AI to resume data projects list as a personal project

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfc60a95b0833083630f97e1ea5728