### PR TITLE
Add job search utilities for Indeed and LinkedIn

### DIFF
--- a/src/types/talentforge/job.ts
+++ b/src/types/talentforge/job.ts
@@ -1,0 +1,12 @@
+export interface JobListing {
+  /** Title of the job listing */
+  title: string;
+  /** Name of the company offering the job */
+  company: string;
+  /** Location where the job is based */
+  location: string;
+  /** Direct link to the job posting */
+  url: string;
+  /** Source of the job listing, e.g. "indeed" or "linkedin" */
+  source: string;
+}

--- a/src/utils/talentforge/indeedApi.ts
+++ b/src/utils/talentforge/indeedApi.ts
@@ -1,0 +1,76 @@
+import { JobListing } from "@/types/talentforge/job";
+
+const INDEED_API_URL =
+  process.env.NEXT_PUBLIC_INDEED_API_URL ||
+  "https://api.indeed.com/v2/jobs";
+const INDEED_API_KEY = process.env.NEXT_PUBLIC_INDEED_API_KEY;
+
+const normalizeIndeedJob = (job: Record<string, unknown>): JobListing => {
+  const title =
+    typeof job.title === "string"
+      ? job.title
+      : typeof job.job_title === "string"
+      ? job.job_title
+      : "";
+  const company =
+    typeof job.company === "string"
+      ? job.company
+      : typeof job.company_name === "string"
+      ? job.company_name
+      : "";
+  const location =
+    typeof job.location === "string"
+      ? job.location
+      : [job.city, job.state, job.country]
+          .filter((v): v is string => typeof v === "string")
+          .join(", ");
+  const url =
+    typeof job.url === "string"
+      ? job.url
+      : typeof job.job_url === "string"
+      ? job.job_url
+      : "";
+
+  return {
+    title,
+    company,
+    location,
+    url,
+    source: "indeed",
+  };
+};
+
+export async function searchIndeedJobs(query: string): Promise<JobListing[]> {
+  if (!query.trim()) return [];
+
+  const url = `${INDEED_API_URL}?q=${encodeURIComponent(query)}`;
+  const headers: Record<string, string> = {};
+  if (INDEED_API_KEY) {
+    headers["X-API-KEY"] = INDEED_API_KEY;
+  }
+
+  try {
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      return [];
+    }
+    const data: unknown = await response.json();
+    const dataObj = data as {
+      results?: unknown[];
+      jobs?: unknown[];
+    };
+    const jobsArray: unknown[] = Array.isArray(dataObj.results)
+      ? dataObj.results
+      : Array.isArray(dataObj.jobs)
+      ? dataObj.jobs
+      : [];
+
+    return jobsArray
+      .filter((job): job is Record<string, unknown> =>
+        typeof job === "object" && job !== null
+      )
+      .map((job) => normalizeIndeedJob(job));
+  } catch {
+    return [];
+  }
+}

--- a/src/utils/talentforge/linkedinApi.ts
+++ b/src/utils/talentforge/linkedinApi.ts
@@ -1,0 +1,80 @@
+import { JobListing } from "@/types/talentforge/job";
+
+const LINKEDIN_API_URL =
+  process.env.NEXT_PUBLIC_LINKEDIN_API_URL ||
+  "https://api.linkedin.com/v2/jobSearch";
+const LINKEDIN_API_KEY = process.env.NEXT_PUBLIC_LINKEDIN_API_KEY;
+
+const normalizeLinkedInJob = (job: Record<string, unknown>): JobListing => {
+  const title =
+    typeof job.title === "string"
+      ? job.title
+      : typeof job["position"] === "string"
+      ? (job["position"] as string)
+      : "";
+  const company =
+    typeof job.company === "string"
+      ? job.company
+      : typeof job["companyName"] === "string"
+      ? (job["companyName"] as string)
+      : typeof job["company_name"] === "string"
+      ? (job["company_name"] as string)
+      : "";
+  const location =
+    typeof job.location === "string"
+      ? job.location
+      : [job["city"], job["state"], job["country"]]
+          .filter((v): v is string => typeof v === "string")
+          .join(", ");
+  const url =
+    typeof job.url === "string"
+      ? job.url
+      : typeof job["jobUrl"] === "string"
+      ? (job["jobUrl"] as string)
+      : "";
+
+  return {
+    title,
+    company,
+    location,
+    url,
+    source: "linkedin",
+  };
+};
+
+export async function searchLinkedInJobs(
+  query: string
+): Promise<JobListing[]> {
+  if (!query.trim()) return [];
+
+  const url = `${LINKEDIN_API_URL}?q=${encodeURIComponent(query)}`;
+  const headers: Record<string, string> = {};
+  if (LINKEDIN_API_KEY) {
+    headers["Authorization"] = `Bearer ${LINKEDIN_API_KEY}`;
+  }
+
+  try {
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      return [];
+    }
+    const data: unknown = await response.json();
+    const dataObj = data as {
+      elements?: unknown[];
+      results?: unknown[];
+    };
+    const jobsArray: unknown[] = Array.isArray(dataObj.elements)
+      ? dataObj.elements
+      : Array.isArray(dataObj.results)
+      ? dataObj.results
+      : [];
+
+    return jobsArray
+      .filter((job): job is Record<string, unknown> =>
+        typeof job === "object" && job !== null
+      )
+      .map((job) => normalizeLinkedInJob(job));
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add `JobListing` type to describe normalized job postings
- implement `searchIndeedJobs` to fetch and normalize results from the Indeed API
- implement `searchLinkedInJobs` to fetch and normalize results from the LinkedIn API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd905e8208330bc1b404471875fba