### PR TITLE
feat: add chat response templates

### DIFF
--- a/src/components/talentforge/ChatAssistant.tsx
+++ b/src/components/talentforge/ChatAssistant.tsx
@@ -6,6 +6,7 @@ import Markdown from "react-markdown";
 import {
   Box,
   IconButton,
+  MenuItem,
   OutlinedInput,
   Stack,
   TextField,
@@ -13,6 +14,7 @@ import {
 import { SendOutlined } from "@mui/icons-material";
 
 import { jobSearchPrompt } from "@/consts/talentforge/consts";
+import { responseTemplates } from "@/consts/talentforge/responseTemplates";
 import { ChatMessage } from "@/types/talentforge/types";
 import { askOpenAI } from "@/utils/talentforge/utils";
 
@@ -27,6 +29,7 @@ export default function ChatAssistant() {
     []
   );
   const [message, setMessage] = React.useState("");
+  const [selectedTemplate, setSelectedTemplate] = React.useState("");
   const [resumeStrengths, setResumeStrengths] = React.useState("");
   const [jobMatches, setJobMatches] = React.useState("");
   const [recruiterNotes, setRecruiterNotes] = React.useState("");
@@ -52,6 +55,7 @@ export default function ChatAssistant() {
     });
 
     setMessage("");
+    setSelectedTemplate("");
   };
 
   React.useEffect(() => {
@@ -120,6 +124,27 @@ export default function ChatAssistant() {
           </Box>
         ))}
       </Stack>
+
+      <TextField
+        select
+        label="Quick responses"
+        value={selectedTemplate}
+        onChange={(e) => {
+          const template = responseTemplates.find(
+            (t) => t.id === e.target.value
+          );
+          setSelectedTemplate(e.target.value);
+          if (template) {
+            setMessage(template.template);
+          }
+        }}
+      >
+        {responseTemplates.map((t) => (
+          <MenuItem key={t.id} value={t.id}>
+            {t.label}
+          </MenuItem>
+        ))}
+      </TextField>
 
       <OutlinedInput
         fullWidth

--- a/src/consts/talentforge/responseTemplates.ts
+++ b/src/consts/talentforge/responseTemplates.ts
@@ -1,0 +1,26 @@
+export interface ResponseTemplate {
+  id: string;
+  label: string;
+  template: string;
+}
+
+export const responseTemplates: ResponseTemplate[] = [
+  {
+    id: "politeDecline",
+    label: "Polite decline",
+    template:
+      "Thank you for reaching out. I'm not pursuing new opportunities at the moment, but I appreciate your consideration.",
+  },
+  {
+    id: "requestDetails",
+    label: "Request for details",
+    template:
+      "Thanks for getting in touch. Could you share more details about the role and expectations?",
+  },
+  {
+    id: "interested",
+    label: "Interested",
+    template:
+      "The opportunity sounds interesting. I'd love to learn more and discuss how I might contribute.",
+  },
+];


### PR DESCRIPTION
## Summary
- add reusable chat response templates for quick recruiter replies
- allow selecting templates within chat assistant

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd801d160833084357f39766cebe6