### PR TITLE
feat: add oauth helpers and settings ui

### DIFF
--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
+import { clearTokens, getStoredTokens } from "@/utils/talentforge/oauth";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+interface Provider {
+  id: string;
+  name: string;
+  authUrl: string;
+}
+
+const providers: Provider[] = [
+  {
+    id: "linkedin",
+    name: "LinkedIn",
+    authUrl: "/api/oauth/authorize?provider=linkedin",
+  },
+  {
+    id: "indeed",
+    name: "Indeed",
+    authUrl: "/api/oauth/authorize?provider=indeed",
+  },
+];
+
+export default function SettingsClient() {
+  const [connections, setConnections] = useState<Record<string, boolean>>({});
+  const { setDocumentTitle } = useDocumentTitle();
+
+  useEffect(() => {
+    setDocumentTitle("Settings");
+    const conn: Record<string, boolean> = {};
+    providers.forEach((p) => {
+      conn[p.id] = !!getStoredTokens(p.id);
+    });
+    setConnections(conn);
+  }, [setDocumentTitle]);
+
+  const handleConnect = (provider: Provider) => {
+    window.location.href = provider.authUrl;
+  };
+
+  const handleDisconnect = (provider: Provider) => {
+    clearTokens(provider.id);
+    setConnections({ ...connections, [provider.id]: false });
+  };
+
+  return (
+    <Box sx={{ py: 8 }}>
+      <Container maxWidth="sm">
+        <Typography variant="h4" gutterBottom>
+          External Accounts
+        </Typography>
+        {providers.map((provider) => (
+          <Box
+            key={provider.id}
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              mb: 2,
+            }}
+          >
+            <Typography>{provider.name}</Typography>
+            {connections[provider.id] ? (
+              <Button
+                variant="outlined"
+                onClick={() => handleDisconnect(provider)}
+              >
+                Disconnect
+              </Button>
+            ) : (
+              <Button
+                variant="contained"
+                onClick={() => handleConnect(provider)}
+              >
+                Connect
+              </Button>
+            )}
+          </Box>
+        ))}
+      </Container>
+    </Box>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import SettingsClient from "./SettingsClient";
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description: "Manage external accounts",
+};
+
+export default function Page() {
+  return <SettingsClient />;
+}

--- a/src/utils/talentforge/oauth.ts
+++ b/src/utils/talentforge/oauth.ts
@@ -1,0 +1,77 @@
+// Utility helpers for managing OAuth token exchange and refresh
+
+const TOKEN_ENDPOINT =
+  process.env.NEXT_PUBLIC_OAUTH_TOKEN_ENDPOINT || "/api/oauth/token";
+const REFRESH_ENDPOINT =
+  process.env.NEXT_PUBLIC_OAUTH_REFRESH_ENDPOINT || "/api/oauth/refresh";
+
+export interface OAuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+const STORAGE_KEY_PREFIX = "talentforge_oauth_";
+
+export function saveTokens(provider: string, tokens: OAuthTokens): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(
+    `${STORAGE_KEY_PREFIX}${provider}`,
+    JSON.stringify(tokens)
+  );
+}
+
+export function getStoredTokens(provider: string): OAuthTokens | null {
+  if (typeof window === "undefined") return null;
+  const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}${provider}`);
+  return raw ? (JSON.parse(raw) as OAuthTokens) : null;
+}
+
+export function clearTokens(provider: string): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(`${STORAGE_KEY_PREFIX}${provider}`);
+}
+
+export async function exchangeCode(
+  provider: string,
+  code: string
+): Promise<OAuthTokens | null> {
+  try {
+    const response = await fetch(
+      `${TOKEN_ENDPOINT}?provider=${encodeURIComponent(provider)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      }
+    );
+    if (!response.ok) return null;
+    const data = (await response.json()) as OAuthTokens;
+    saveTokens(provider, data);
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export async function refreshAccessToken(
+  provider: string,
+  refreshToken: string
+): Promise<OAuthTokens | null> {
+  try {
+    const response = await fetch(
+      `${REFRESH_ENDPOINT}?provider=${encodeURIComponent(provider)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken }),
+      }
+    );
+    if (!response.ok) return null;
+    const data = (await response.json()) as OAuthTokens;
+    saveTokens(provider, data);
+    return data;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add OAuth helper for token exchange and refresh
- add settings page for connecting external accounts

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdaae374483308e1e921b9eb47764