### PR TITLE
Parse and store structured resume data from PDFs

### DIFF
--- a/src/components/talentforge/Hero.tsx
+++ b/src/components/talentforge/Hero.tsx
@@ -187,7 +187,7 @@ export default function Hero() {
               onChange={async (filesFromParam) => {
                 const files = filesFromParam as File[];
                 if (files && files.length > 0) {
-                  const markdown = await pdfToMarkdown(files[0]);
+                  const { markdown } = await pdfToMarkdown(files[0]);
                   setPdfAsMarkdown(markdown);
 
                   const context = [markdown, resumeText]

--- a/src/types/talentforge/resume.ts
+++ b/src/types/talentforge/resume.ts
@@ -1,0 +1,10 @@
+export interface ParsedResume {
+  /** Contact information block. */
+  contact: string;
+  /** Experience entries in plain text. */
+  experience: string[];
+  /** Education entries in plain text. */
+  education: string[];
+  /** Skills list in plain text. */
+  skills: string[];
+}

--- a/src/utils/talentforge/resumeParser.ts
+++ b/src/utils/talentforge/resumeParser.ts
@@ -1,56 +1,52 @@
 "use client";
 
-import * as pdfjs from "pdfjs-dist";
-import { Buffer } from "buffer";
-
-// Ensure Buffer is available for pdf.js when running in the browser
-declare global {
-  interface Window {
-    Buffer: typeof Buffer;
-  }
-}
-
-if (typeof window !== "undefined") {
-  window.Buffer = window.Buffer || Buffer;
-}
+import { ParsedResume } from "@/types/talentforge/resume";
 
 /**
- * Convert a resume PDF file into plain text/Markdown.
+ * Parse Markdown resume text into structured sections.
  *
- * @param file - The uploaded PDF file.
- * @returns A promise that resolves to the extracted text.
+ * @param markdown - Resume converted to Markdown.
+ * @returns Parsed resume sections.
  */
-export async function pdfToResumeText(file: File): Promise<string> {
-  const reader = new FileReader();
-  const workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`;
+export function parseResume(markdown: string): ParsedResume {
+  const lines = markdown.split(/\r?\n/);
 
-  pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
+  const resume: ParsedResume = {
+    contact: "",
+    experience: [],
+    education: [],
+    skills: [],
+  };
 
-  const fileReadPromise = new Promise<ArrayBuffer>((resolve, reject) => {
-    reader.onload = () => resolve(reader.result as ArrayBuffer);
-    reader.onerror = reject;
-  });
+  let section: keyof ParsedResume = "contact";
 
-  reader.readAsArrayBuffer(file);
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
 
-  const buffer = await fileReadPromise;
-  const pdfData = new Uint8Array(buffer);
+    const lower = line.toLowerCase();
 
-  const doc = await pdfjs.getDocument({ data: pdfData }).promise;
-  let text = "";
-
-  for (let i = 1; i <= doc.numPages; i++) {
-    const page = await doc.getPage(i);
-    const content = await page.getTextContent();
-
-    for (const item of content.items as { str: string }[]) {
-      text += item.str + "\n";
+    if (lower.includes("experience")) {
+      section = "experience";
+      continue;
+    }
+    if (lower.includes("education")) {
+      section = "education";
+      continue;
+    }
+    if (lower.includes("skill")) {
+      section = "skills";
+      continue;
     }
 
-    text += "\n";
+    if (section === "contact") {
+      resume.contact += (resume.contact ? "\n" : "") + line;
+    } else {
+      (resume[section] as string[]).push(line);
+    }
   }
 
-  return text.trim();
+  return resume;
 }
 
-export default pdfToResumeText;
+export default parseResume;

--- a/src/utils/talentforge/storage.ts
+++ b/src/utils/talentforge/storage.ts
@@ -2,6 +2,7 @@
 
 import { ChatMessage } from "@/types/talentforge/types";
 import { JobListing } from "@/types/talentforge/job";
+import { ParsedResume } from "@/types/talentforge/resume";
 
 const STORAGE_API_URL = process.env.NEXT_PUBLIC_TALENTFORGE_STORAGE_API_URL;
 
@@ -49,12 +50,12 @@ async function getItem<T>(key: string): Promise<T | null> {
   return null;
 }
 
-export async function saveParsedResume(resume: string): Promise<void> {
+export async function saveParsedResume(resume: ParsedResume): Promise<void> {
   await storeItem(STORAGE_KEYS.resume, resume);
 }
 
-export async function loadParsedResume(): Promise<string | null> {
-  return await getItem<string>(STORAGE_KEYS.resume);
+export async function loadParsedResume(): Promise<ParsedResume | null> {
+  return await getItem<ParsedResume>(STORAGE_KEYS.resume);
 }
 
 export async function saveChatHistory(

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -4,6 +4,9 @@ import * as pdfjs from "pdfjs-dist";
 
 import { ChatMessage } from "@/types/talentforge/types";
 import { aiBufferSize } from "@/consts/talentforge/consts";
+import { ParsedResume } from "@/types/talentforge/resume";
+import parseResume from "./resumeParser";
+import { saveParsedResume } from "./storage";
 
 import { Buffer } from "buffer";
 
@@ -168,7 +171,9 @@ if (typeof window !== "undefined") {
   window.Buffer = window.Buffer || Buffer;
 }
 
-export async function pdfToMarkdown(file: File): Promise<string> {
+export async function pdfToMarkdown(
+  file: File
+): Promise<{ markdown: string; parsedResume: ParsedResume }> {
   const reader = new FileReader();
   const workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`;
 
@@ -202,5 +207,8 @@ export async function pdfToMarkdown(file: File): Promise<string> {
     markdown += "\n\n";
   }
 
-  return markdown;
+  const parsedResume = parseResume(markdown);
+  await saveParsedResume(parsedResume);
+
+  return { markdown, parsedResume };
 }


### PR DESCRIPTION
## Summary
- Add Markdown resume parser splitting contact, experience, education, and skills.
- Expose ParsedResume interface and persist parsed data to storage.
- Enhance pdfToMarkdown to return both raw Markdown and parsed resume.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bfdd565c14833094e29efc7b53280b