### PR TITLE
feat: add job search filters

### DIFF
--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -14,6 +14,7 @@ import AppAppBar from "@/components/talentforge/AppAppBar";
 import Hero from "@/components/talentforge/Hero";
 import Highlights from "@/components/talentforge/Highlights";
 import DocumentGenerator from "@/components/talentforge/DocumentGenerator";
+import JobSearch from "@/components/talentforge/JobSearch";
 // import LogoCollection from "./components/LogoCollection";
 // import Pricing from "./components/Pricing";
 // import Features from "./components/Features";
@@ -101,6 +102,7 @@ export default function TalentForgePage() {
       <Hero />
       <Box sx={{ bgcolor: "background.default" }}>
         <DocumentGenerator />
+        <JobSearch />
         {/* <LogoCollection /> */}
         {/* <Features />
         <Divider />

--- a/src/components/talentforge/JobSearch.tsx
+++ b/src/components/talentforge/JobSearch.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  Link,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { searchIndeedJobs, IndeedSearchFilters } from "@/utils/talentforge/indeedApi";
+import type { JobListing } from "@/types/talentforge/job";
+
+type Filters = IndeedSearchFilters;
+
+const loadFilters = (): Filters => {
+  if (typeof window === "undefined") return { roles: [], locations: [] };
+  try {
+    const saved = window.localStorage.getItem("talentforge-settings");
+    if (!saved) return { roles: [], locations: [] };
+    const parsed = JSON.parse(saved);
+    const roles = typeof parsed.roles === "string"
+      ? parsed.roles.split(",").map((r: string) => r.trim()).filter(Boolean)
+      : [];
+    const locations = typeof parsed.locations === "string"
+      ? parsed.locations.split(",").map((l: string) => l.trim()).filter(Boolean)
+      : [];
+    const salaryMin = parsed.salaryMin ? Number(parsed.salaryMin) : undefined;
+    const salaryMax = parsed.salaryMax ? Number(parsed.salaryMax) : undefined;
+    return { roles, locations, salaryMin, salaryMax };
+  } catch {
+    return { roles: [], locations: [] };
+  }
+};
+
+export default function JobSearch() {
+  const [query, setQuery] = useState("");
+  const [jobs, setJobs] = useState<JobListing[]>([]);
+  const [filters, setFilters] = useState<Filters>({ roles: [], locations: [] });
+
+  useEffect(() => {
+    setFilters(loadFilters());
+  }, []);
+
+  const handleSearch = async () => {
+    const results = await searchIndeedJobs(query, filters);
+    setJobs(results);
+  };
+
+  const hasFilters =
+    (filters.roles && filters.roles.length > 0) ||
+    (filters.locations && filters.locations.length > 0) ||
+    typeof filters.salaryMin === "number" ||
+    typeof filters.salaryMax === "number";
+
+  return (
+    <Box sx={{ py: 6 }}>
+      <Stack spacing={2}>
+        <Typography variant="h4" component="h2" align="center">
+          Job Search
+        </Typography>
+        <TextField
+          label="Search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <Button
+          variant="contained"
+          disabled={!query.trim()}
+          onClick={handleSearch}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Search
+        </Button>
+        {hasFilters && (
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            {filters.roles?.map((role) => (
+              <Chip key={`role-${role}`} label={`Role: ${role}`} />
+            ))}
+            {filters.locations?.map((loc) => (
+              <Chip key={`loc-${loc}`} label={`Location: ${loc}`} />
+            ))}
+            {typeof filters.salaryMin === "number" && (
+              <Chip label={`Min: $${filters.salaryMin}`} />
+            )}
+            {typeof filters.salaryMax === "number" && (
+              <Chip label={`Max: $${filters.salaryMax}`} />
+            )}
+          </Stack>
+        )}
+        <Stack spacing={1}>
+          {jobs.map((job, idx) => (
+            <Box
+              key={idx}
+              sx={{
+                p: 2,
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 1,
+              }}
+            >
+              <Typography variant="subtitle1" fontWeight={600}>
+                {job.title}
+              </Typography>
+              <Typography variant="body2">{job.company}</Typography>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                {job.location}
+              </Typography>
+              <Link href={job.url} target="_blank" rel="noopener">
+                View Job
+              </Link>
+            </Box>
+          ))}
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/src/utils/talentforge/indeedApi.ts
+++ b/src/utils/talentforge/indeedApi.ts
@@ -1,5 +1,12 @@
 import { JobListing } from "@/types/talentforge/job";
 
+export interface IndeedSearchFilters {
+  roles?: string[];
+  locations?: string[];
+  salaryMin?: number;
+  salaryMax?: number;
+}
+
 const INDEED_API_URL =
   process.env.NEXT_PUBLIC_INDEED_API_URL ||
   "https://api.indeed.com/v2/jobs";
@@ -40,10 +47,28 @@ const normalizeIndeedJob = (job: Record<string, unknown>): JobListing => {
   };
 };
 
-export async function searchIndeedJobs(query: string): Promise<JobListing[]> {
+export async function searchIndeedJobs(
+  query: string,
+  filters: IndeedSearchFilters = {}
+): Promise<JobListing[]> {
   if (!query.trim()) return [];
 
-  const url = `${INDEED_API_URL}?q=${encodeURIComponent(query)}`;
+  const params = new URLSearchParams();
+  params.set("q", query);
+  if (filters.roles && filters.roles.length > 0) {
+    params.set("roles", filters.roles.join(","));
+  }
+  if (filters.locations && filters.locations.length > 0) {
+    params.set("locations", filters.locations.join(","));
+  }
+  if (typeof filters.salaryMin === "number") {
+    params.set("salary_min", String(filters.salaryMin));
+  }
+  if (typeof filters.salaryMax === "number") {
+    params.set("salary_max", String(filters.salaryMax));
+  }
+
+  const url = `${INDEED_API_URL}?${params.toString()}`;
   const headers: Record<string, string> = {};
   if (INDEED_API_KEY) {
     headers["X-API-KEY"] = INDEED_API_KEY;


### PR DESCRIPTION
## Summary
- allow searchIndeedJobs to accept role, location and salary filters
- add JobSearch component that reads saved settings and displays active filters
- show JobSearch on TalentForge page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfdd8326ec8330b534180298593453