### PR TITLE
Add job tracker and document generator links

### DIFF
--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -15,6 +15,7 @@ import Hero from "@/components/talentforge/Hero";
 import Highlights from "@/components/talentforge/Highlights";
 import DocumentGenerator from "@/components/talentforge/DocumentGenerator";
 import JobSearch from "@/components/talentforge/JobSearch";
+import JobTracker from "@/components/talentforge/JobTracker";
 // import LogoCollection from "./components/LogoCollection";
 // import Pricing from "./components/Pricing";
 // import Features from "./components/Features";
@@ -103,6 +104,7 @@ export default function TalentForgePage() {
       <Box sx={{ bgcolor: "background.default" }}>
         <DocumentGenerator />
         <JobSearch />
+        <JobTracker />
         {/* <LogoCollection /> */}
         {/* <Features />
         <Divider />

--- a/src/components/talentforge/DocumentGenerator.tsx
+++ b/src/components/talentforge/DocumentGenerator.tsx
@@ -67,7 +67,7 @@ export default function DocumentGenerator() {
   const ready = jobDescription.trim() && resume.trim();
 
   return (
-    <Box sx={{ py: 6 }}>
+    <Box id="document-generator" sx={{ py: 6 }}>
       <Container maxWidth="md">
         <Stack spacing={2}>
           <Typography variant="h4" component="h2" align="center">

--- a/src/components/talentforge/JobSearch.tsx
+++ b/src/components/talentforge/JobSearch.tsx
@@ -108,9 +108,12 @@ export default function JobSearch() {
               <Typography variant="body2" sx={{ mb: 1 }}>
                 {job.location}
               </Typography>
-              <Link href={job.url} target="_blank" rel="noopener">
-                View Job
-              </Link>
+              <Stack direction="row" spacing={1}>
+                <Link href={job.url} target="_blank" rel="noopener">
+                  View Job
+                </Link>
+                <Link href="#document-generator">Generate Docs</Link>
+              </Stack>
             </Box>
           ))}
         </Stack>

--- a/src/components/talentforge/JobTracker.tsx
+++ b/src/components/talentforge/JobTracker.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Container,
+  FormControl,
+  Grid,
+  InputLabel,
+  Link,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  ApplicationStatus,
+  JobApplication,
+} from "@/types/talentforge/job";
+import {
+  loadJobApplications,
+  saveJobApplications,
+} from "@/utils/talentforge/storage";
+
+const STATUSES: ApplicationStatus[] = [
+  "applied",
+  "interview",
+  "offer",
+  "rejected",
+];
+
+const emptyApplication: JobApplication = {
+  title: "",
+  company: "",
+  location: "",
+  url: "",
+  source: "",
+  status: "applied",
+};
+
+export default function JobTracker() {
+  const [applications, setApplications] = useState<JobApplication[]>([]);
+  const [form, setForm] = useState<JobApplication>(emptyApplication);
+
+  useEffect(() => {
+    loadJobApplications().then((data) => {
+      if (data) setApplications(data);
+    });
+  }, []);
+
+  useEffect(() => {
+    saveJobApplications(applications);
+  }, [applications]);
+
+  const handleChangeForm = (
+    field: keyof JobApplication,
+    value: string
+  ) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleAdd = () => {
+    if (!form.title.trim()) return;
+    setApplications((prev) => [...prev, form]);
+    setForm(emptyApplication);
+  };
+
+  const handleStatusChange = (
+    index: number,
+    status: ApplicationStatus
+  ) => {
+    setApplications((prev) =>
+      prev.map((app, i) => (i === index ? { ...app, status } : app))
+    );
+  };
+
+  return (
+    <Box sx={{ py: 6 }}>
+      <Container maxWidth="lg">
+        <Stack spacing={2}>
+          <Typography variant="h4" component="h2" align="center">
+            Job Tracker
+          </Typography>
+          <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+            <TextField
+              label="Title"
+              value={form.title}
+              onChange={(e) => handleChangeForm("title", e.target.value)}
+            />
+            <TextField
+              label="Company"
+              value={form.company}
+              onChange={(e) => handleChangeForm("company", e.target.value)}
+            />
+            <TextField
+              label="Location"
+              value={form.location}
+              onChange={(e) => handleChangeForm("location", e.target.value)}
+            />
+            <TextField
+              label="URL"
+              value={form.url}
+              onChange={(e) => handleChangeForm("url", e.target.value)}
+            />
+            <TextField
+              label="Source"
+              value={form.source}
+              onChange={(e) => handleChangeForm("source", e.target.value)}
+            />
+            <Button variant="contained" onClick={handleAdd}>
+              Add
+            </Button>
+          </Stack>
+          <Grid container spacing={2}>
+            {STATUSES.map((status) => (
+              <Grid item xs={12} md={3} key={status}>
+                <Typography
+                  variant="h6"
+                  sx={{ textTransform: "capitalize", mb: 1 }}
+                >
+                  {status}
+                </Typography>
+                <Stack spacing={1}>
+                  {applications.map((app, idx) => (
+                    app.status === status && (
+                      <Box
+                        key={idx}
+                        sx={{
+                          p: 2,
+                          border: 1,
+                          borderColor: "divider",
+                          borderRadius: 1,
+                        }}
+                      >
+                        <Typography variant="subtitle2" fontWeight={600}>
+                          {app.title}
+                        </Typography>
+                        <Typography variant="body2">{app.company}</Typography>
+                        <FormControl fullWidth size="small" sx={{ mt: 1 }}>
+                          <InputLabel id={`status-label-${idx}`}>Status</InputLabel>
+                          <Select
+                            labelId={`status-label-${idx}`}
+                            value={app.status}
+                            label="Status"
+                            onChange={(e) =>
+                              handleStatusChange(
+                                idx,
+                                e.target.value as ApplicationStatus
+                              )
+                            }
+                          >
+                            {STATUSES.map((s) => (
+                              <MenuItem
+                                key={s}
+                                value={s}
+                                sx={{ textTransform: "capitalize" }}
+                              >
+                                {s}
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                        <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                          <Link href={app.url} target="_blank" rel="noopener">
+                            View
+                          </Link>
+                          <Link href="#document-generator">Docs</Link>
+                        </Stack>
+                      </Box>
+                    )
+                  ))}
+                </Stack>
+              </Grid>
+            ))}
+          </Grid>
+        </Stack>
+      </Container>
+    </Box>
+  );
+}
+

--- a/src/types/talentforge/job.ts
+++ b/src/types/talentforge/job.ts
@@ -10,3 +10,14 @@ export interface JobListing {
   /** Source of the job listing, e.g. "indeed" or "linkedin" */
   source: string;
 }
+
+export type ApplicationStatus =
+  | "applied"
+  | "interview"
+  | "offer"
+  | "rejected";
+
+export interface JobApplication extends JobListing {
+  /** Current status of the job application */
+  status: ApplicationStatus;
+}

--- a/src/utils/talentforge/storage.ts
+++ b/src/utils/talentforge/storage.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChatMessage } from "@/types/talentforge/types";
-import { JobListing } from "@/types/talentforge/job";
+import { JobApplication } from "@/types/talentforge/job";
 import { ParsedResume } from "@/types/talentforge/resume";
 
 const STORAGE_API_URL = process.env.NEXT_PUBLIC_TALENTFORGE_STORAGE_API_URL;
@@ -69,13 +69,13 @@ export async function loadChatHistory(): Promise<ChatMessage[] | null> {
 }
 
 export async function saveJobApplications(
-  applications: JobListing[]
+  applications: JobApplication[]
 ): Promise<void> {
   await storeItem(STORAGE_KEYS.jobApplications, applications);
 }
 
-export async function loadJobApplications(): Promise<JobListing[] | null> {
-  return await getItem<JobListing[]>(STORAGE_KEYS.jobApplications);
+export async function loadJobApplications(): Promise<JobApplication[] | null> {
+  return await getItem<JobApplication[]>(STORAGE_KEYS.jobApplications);
 }
 
 export async function clearStorage(): Promise<void> {


### PR DESCRIPTION
## Summary
- add job tracker component with columns for applied, interview, offer, and rejected
- persist job applications via saveJobApplications in storage
- link job listings and tracker entries to the Document Generator for quick resume/cover letter creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2a9bd3c4883308204a7a48f6f13ed