### PR TITLE
feat: add OAuth providers and message inbox endpoints

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -14,9 +14,10 @@ import {
 import { ArchiveOutlined, ReplyOutlined } from "@mui/icons-material";
 
 import { askOpenAI } from "@/utils/talentforge/utils";
+import { getStoredTokens } from "@/utils/talentforge/oauth";
 
 interface InboxMessage {
-  id: number;
+  id: string;
   source: string;
   sender: string;
   subject: string;
@@ -26,33 +27,56 @@ interface InboxMessage {
   quickReply?: string;
 }
 
-const initialMessages: InboxMessage[] = [
-  {
-    id: 1,
-    source: "Email",
-    sender: "hr@example.com",
-    subject: "Interview Invitation",
-    content: "We would love to schedule an interview with you next week.",
-    tags: [],
-    archived: false,
-  },
-  {
-    id: 2,
-    source: "LinkedIn",
-    sender: "Jane Recruiter",
-    subject: "New Opportunity",
-    content: "I came across your profile and think you'd be a great fit...",
-    tags: ["networking"],
-    archived: false,
-  },
-];
-
 export default function Inbox() {
-  const [messages, setMessages] = React.useState<InboxMessage[]>(initialMessages);
-  const [tagInputs, setTagInputs] = React.useState<Record<number, string>>({});
-  const [loading, setLoading] = React.useState<Record<number, boolean>>({});
+  const [messages, setMessages] = React.useState<InboxMessage[]>([]);
+  const [tagInputs, setTagInputs] = React.useState<Record<string, string>>({});
+  const [loading, setLoading] = React.useState<Record<string, boolean>>({});
+  const [pageTokens, setPageTokens] = React.useState<Record<string, string | undefined>>({});
+  const [loadingMore, setLoadingMore] = React.useState(false);
 
-  const handleTagAdd = (id: number) => {
+  const fetchMessages = React.useCallback(
+    async (provider: string, pageToken?: string) => {
+      const tokens = getStoredTokens(provider);
+      if (!tokens?.accessToken) {
+        return { messages: [] as InboxMessage[], nextPageToken: undefined as string | undefined };
+      }
+      const params = pageToken ? `?pageToken=${encodeURIComponent(pageToken)}` : "";
+      const res = await fetch(`/api/messages/${provider}${params}`, {
+        headers: {
+          Authorization: `Bearer ${tokens.accessToken}`,
+        },
+      });
+      if (!res.ok) {
+        return { messages: [] as InboxMessage[], nextPageToken: undefined as string | undefined };
+      }
+      const data = (await res.json()) as {
+        messages: InboxMessage[];
+        nextPageToken?: string;
+      };
+      return data;
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    const load = async () => {
+      const providers = ["gmail", "linkedin"];
+      const all: InboxMessage[] = [];
+      const tokens: Record<string, string | undefined> = {};
+      for (const p of providers) {
+        const data = await fetchMessages(p);
+        all.push(
+          ...data.messages.map((m) => ({ ...m, tags: m.tags || [], archived: false }))
+        );
+        if (data.nextPageToken) tokens[p] = data.nextPageToken;
+      }
+      setMessages(all);
+      setPageTokens(tokens);
+    };
+    void load();
+  }, [fetchMessages]);
+
+  const handleTagAdd = (id: string) => {
     const tag = (tagInputs[id] || "").trim();
     if (!tag) return;
     setMessages((msgs) =>
@@ -61,7 +85,7 @@ export default function Inbox() {
     setTagInputs((t) => ({ ...t, [id]: "" }));
   };
 
-  const handleTagDelete = (id: number, tag: string) => {
+  const handleTagDelete = (id: string, tag: string) => {
     setMessages((msgs) =>
       msgs.map((m) =>
         m.id === id ? { ...m, tags: m.tags.filter((t) => t !== tag) } : m
@@ -69,13 +93,13 @@ export default function Inbox() {
     );
   };
 
-  const toggleArchive = (id: number) => {
+  const toggleArchive = (id: string) => {
     setMessages((msgs) =>
       msgs.map((m) => (m.id === id ? { ...m, archived: !m.archived } : m))
     );
   };
 
-  const handleQuickReply = async (id: number) => {
+  const handleQuickReply = async (id: string) => {
     const msg = messages.find((m) => m.id === id);
     if (!msg) return;
     setLoading((l) => ({ ...l, [id]: true }));
@@ -93,6 +117,23 @@ export default function Inbox() {
         m.id === id ? { ...m, quickReply: response?.message || "" } : m
       )
     );
+  };
+
+  const loadMore = async () => {
+    setLoadingMore(true);
+    const providers = Object.keys(pageTokens).filter((p) => pageTokens[p]);
+    const fetched: InboxMessage[] = [];
+    const newTokens: Record<string, string | undefined> = {};
+    for (const p of providers) {
+      const data = await fetchMessages(p, pageTokens[p]);
+      fetched.push(
+        ...data.messages.map((m) => ({ ...m, tags: m.tags || [], archived: false }))
+      );
+      newTokens[p] = data.nextPageToken;
+    }
+    setMessages((prev) => [...prev, ...fetched]);
+    setPageTokens((prev) => ({ ...prev, ...newTokens }));
+    setLoadingMore(false);
   };
 
   return (
@@ -181,6 +222,11 @@ export default function Inbox() {
           )}
         </Box>
       ))}
+      {Object.values(pageTokens).some(Boolean) && (
+        <Button variant="outlined" onClick={loadMore} disabled={loadingMore}>
+          Load more
+        </Button>
+      )}
     </Stack>
   );
 }

--- a/src/pages/api/messages/gmail.ts
+++ b/src/pages/api/messages/gmail.ts
@@ -1,0 +1,88 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  const accessToken = req.headers.authorization?.replace("Bearer ", "");
+  if (!accessToken) {
+    res.status(401).json({ error: "Missing access token" });
+    return;
+  }
+
+  const pageToken = Array.isArray(req.query.pageToken)
+    ? req.query.pageToken[0]
+    : (req.query.pageToken as string | undefined);
+
+  const url =
+    "https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=10" +
+    (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : "");
+
+  try {
+    const listRes = await fetch(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const listData = (await listRes.json()) as Record<string, unknown>;
+    if (!listRes.ok) {
+      res
+        .status(listRes.status)
+        .json({ error: (listData.error as string) || "Gmail API error" });
+      return;
+    }
+
+    const messagesArray: unknown[] = Array.isArray(listData.messages)
+      ? (listData.messages as unknown[])
+      : [];
+
+    const messages = await Promise.all(
+      messagesArray
+        .filter(
+          (m): m is { id: string } =>
+            typeof m === "object" &&
+            m !== null &&
+            typeof (m as Record<string, unknown>).id === "string"
+        )
+        .map(async (m) => {
+          const detailRes = await fetch(
+            `https://gmail.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=metadata`,
+            { headers: { Authorization: `Bearer ${accessToken}` } }
+          );
+          const detail = (await detailRes.json()) as Record<string, unknown>;
+          const payload = detail.payload as
+            | { headers?: unknown[] }
+            | undefined;
+          const headers = Array.isArray(payload?.headers)
+            ? (payload?.headers as unknown[])
+            : [];
+          const subjectHeader = headers.find(
+            (h): h is { name: string; value: string } =>
+              typeof h === "object" &&
+              h !== null &&
+              (h as Record<string, unknown>).name === "Subject" &&
+              typeof (h as Record<string, unknown>).value === "string"
+          );
+          const fromHeader = headers.find(
+            (h): h is { name: string; value: string } =>
+              typeof h === "object" &&
+              h !== null &&
+              (h as Record<string, unknown>).name === "From" &&
+              typeof (h as Record<string, unknown>).value === "string"
+          );
+          return {
+            id: m.id,
+            source: "gmail",
+            sender: fromHeader ? fromHeader.value : "",
+            subject: subjectHeader ? subjectHeader.value : "",
+            content: typeof detail.snippet === "string" ? detail.snippet : "",
+          };
+        })
+    );
+
+    res.status(200).json({
+      messages,
+      nextPageToken: typeof listData.nextPageToken === "string" ? listData.nextPageToken : undefined,
+    });
+  } catch {
+    res.status(500).json({ error: "Failed to fetch Gmail messages" });
+  }
+}

--- a/src/pages/api/messages/linkedin.ts
+++ b/src/pages/api/messages/linkedin.ts
@@ -1,0 +1,66 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  const accessToken = req.headers.authorization?.replace("Bearer ", "");
+  if (!accessToken) {
+    res.status(401).json({ error: "Missing access token" });
+    return;
+  }
+
+  const startParam = Array.isArray(req.query.start)
+    ? req.query.start[0]
+    : (req.query.start as string | undefined);
+  const start = startParam ? parseInt(startParam, 10) : 0;
+  const count = 10;
+  const url = `https://api.linkedin.com/v2/messages?q=List&start=${start}&count=${count}`;
+
+  try {
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    const data = (await response.json()) as Record<string, unknown>;
+    if (!response.ok) {
+      res
+        .status(response.status)
+        .json({ error: (data.message as string) || "LinkedIn API error" });
+      return;
+    }
+
+    const elements: unknown[] = Array.isArray(data.elements)
+      ? (data.elements as unknown[])
+      : [];
+
+    const messages = elements
+      .filter(
+        (m): m is Record<string, unknown> =>
+          typeof m === "object" && m !== null
+      )
+      .map((m) => ({
+        id:
+          typeof m["id"] === "string"
+            ? (m["id"] as string)
+            : typeof m["eventId"] === "string"
+            ? (m["eventId"] as string)
+            : Math.random().toString(36).slice(2),
+        source: "linkedin",
+        sender: typeof m["from"] === "string" ? (m["from"] as string) : "",
+        subject: typeof m["subject"] === "string" ? (m["subject"] as string) : "",
+        content:
+          typeof m["body"] === "string"
+            ? (m["body"] as string)
+            : typeof m["text"] === "string"
+            ? (m["text"] as string)
+            : "",
+      }));
+
+    const nextStart = start + messages.length;
+    const nextPageToken = messages.length === count ? String(nextStart) : undefined;
+
+    res.status(200).json({ messages, nextPageToken });
+  } catch {
+    res.status(500).json({ error: "Failed to fetch LinkedIn messages" });
+  }
+}

--- a/src/utils/talentforge/oauth.ts
+++ b/src/utils/talentforge/oauth.ts
@@ -11,6 +11,44 @@ export interface OAuthTokens {
   expiresIn: number;
 }
 
+interface OAuthProviderConfig {
+  authUrl: string;
+  clientId: string;
+  scope: string;
+  extraParams?: Record<string, string>;
+}
+
+export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
+  gmail: {
+    authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    clientId: process.env.NEXT_PUBLIC_GMAIL_CLIENT_ID || "",
+    scope: "https://www.googleapis.com/auth/gmail.readonly",
+    extraParams: { access_type: "offline", prompt: "consent" },
+  },
+  linkedin: {
+    authUrl: "https://www.linkedin.com/oauth/v2/authorization",
+    clientId: process.env.NEXT_PUBLIC_LINKEDIN_CLIENT_ID || "",
+    scope: "r_liteprofile r_emailaddress w_member_social",
+  },
+};
+
+export function getAuthUrl(
+  provider: keyof typeof OAUTH_PROVIDERS,
+  redirectUri: string,
+  state = ""
+): string {
+  const config = OAUTH_PROVIDERS[provider];
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: config.clientId,
+    redirect_uri: redirectUri,
+    scope: config.scope,
+    ...(state ? { state } : {}),
+    ...config.extraParams,
+  });
+  return `${config.authUrl}?${params.toString()}`;
+}
+
 const STORAGE_KEY_PREFIX = "talentforge_oauth_";
 
 export function saveTokens(provider: string, tokens: OAuthTokens): void {


### PR DESCRIPTION
## Summary
- add Gmail and LinkedIn OAuth provider configs
- implement Gmail and LinkedIn message API routes with pagination support
- update Inbox component to fetch and paginate messages from new endpoints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c36e889c948330ac7540baf54815b1