### PR TITLE
feat: add toast notifications and error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-markdown": "^10.1.0",
     "react-refresh": "^0.11.0",
     "recharts": "^2.10.3",
+    "notistack": "^3.0.0",
     "uuid": "^11.1.0",
     "web-vitals": "^2.1.4"
   },

--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -99,25 +99,26 @@ export default function TalentForgePage() {
   return (
     <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
-      <AppAppBar mode={mode} toggleColorMode={toggleColorMode} />
-      <Hero />
-      <Box sx={{ bgcolor: "background.default" }}>
-        <DocumentGenerator />
-        <JobSearch />
-        <JobTracker />
-        {/* <LogoCollection /> */}
-        {/* <Features />
-        <Divider />
-        <Testimonials />
-        <Divider /> */}
-        <Highlights />
-        <Divider />
-        {/* <Pricing />
-        <Divider /> */}
-        <FAQ />
-        <Divider />
-        <Footer />
-      </Box>
+      <AppAppBar mode={mode} toggleColorMode={toggleColorMode}>
+        <Hero />
+        <Box sx={{ bgcolor: "background.default" }}>
+          <DocumentGenerator />
+          <JobSearch />
+          <JobTracker />
+          {/* <LogoCollection /> */}
+          {/* <Features />
+          <Divider />
+          <Testimonials />
+          <Divider /> */}
+          <Highlights />
+          <Divider />
+          {/* <Pricing />
+          <Divider /> */}
+          <FAQ />
+          <Divider />
+          <Footer />
+        </Box>
+      </AppAppBar>
     </ThemeProvider>
   );
 }

--- a/src/app/talentforge/settings/page.tsx
+++ b/src/app/talentforge/settings/page.tsx
@@ -110,96 +110,97 @@ export default function TalentForgeSettingsPage() {
   return (
     <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
-      <AppAppBar mode={mode} toggleColorMode={toggleColorMode} />
-      <Container component="main" maxWidth="sm" sx={{ mt: 10 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Settings
-        </Typography>
-        <Box component="form" onSubmit={handleSubmit}>
-          <Stack spacing={2}>
-            <TextField
-              label="Desired Roles"
-              value={settings.roles}
-              onChange={handleChange("roles")}
-              fullWidth
-            />
-            <TextField
-              label="Industries"
-              value={settings.industries}
-              onChange={handleChange("industries")}
-              fullWidth
-            />
-            <TextField
-              label="Locations"
-              value={settings.locations}
-              onChange={handleChange("locations")}
-              fullWidth
-            />
-            <Stack direction="row" spacing={2}>
+      <AppAppBar mode={mode} toggleColorMode={toggleColorMode}>
+        <Container component="main" maxWidth="sm" sx={{ mt: 10 }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Settings
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit}>
+            <Stack spacing={2}>
               <TextField
-                label="Salary Min"
-                type="number"
-                value={settings.salaryMin}
-                onChange={handleChange("salaryMin")}
+                label="Desired Roles"
+                value={settings.roles}
+                onChange={handleChange("roles")}
                 fullWidth
               />
               <TextField
-                label="Salary Max"
-                type="number"
-                value={settings.salaryMax}
-                onChange={handleChange("salaryMax")}
+                label="Industries"
+                value={settings.industries}
+                onChange={handleChange("industries")}
                 fullWidth
               />
-            </Stack>
-            <Box>
-              <Typography variant="h6" sx={{ mb: 1 }}>
-                Quick Replies
-              </Typography>
-              <Stack spacing={1}>
-                {quickReplies.map((qr) => (
-                  <Stack
-                    key={qr.id}
-                    direction="row"
-                    spacing={1}
-                    alignItems="flex-start"
-                  >
-                    <TextField
-                      label="Label"
-                      value={qr.label}
-                      onChange={handleQuickReplyChange(qr.id, "label")}
-                      sx={{ width: 200 }}
-                    />
-                    <TextField
-                      label="Template"
-                      value={qr.template}
-                      onChange={handleQuickReplyChange(qr.id, "template")}
-                      multiline
-                      minRows={2}
-                      fullWidth
-                    />
-                    <IconButton
-                      aria-label="delete"
-                      onClick={() => handleDeleteQuickReply(qr.id)}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </Stack>
-                ))}
-                <Button
-                  variant="outlined"
-                  onClick={handleAddQuickReply}
-                  sx={{ alignSelf: "flex-start" }}
-                >
-                  Add Quick Reply
-                </Button>
+              <TextField
+                label="Locations"
+                value={settings.locations}
+                onChange={handleChange("locations")}
+                fullWidth
+              />
+              <Stack direction="row" spacing={2}>
+                <TextField
+                  label="Salary Min"
+                  type="number"
+                  value={settings.salaryMin}
+                  onChange={handleChange("salaryMin")}
+                  fullWidth
+                />
+                <TextField
+                  label="Salary Max"
+                  type="number"
+                  value={settings.salaryMax}
+                  onChange={handleChange("salaryMax")}
+                  fullWidth
+                />
               </Stack>
-            </Box>
-            <Button type="submit" variant="contained" sx={{ alignSelf: "flex-start" }}>
-              Save
-            </Button>
-          </Stack>
-        </Box>
-      </Container>
+              <Box>
+                <Typography variant="h6" sx={{ mb: 1 }}>
+                  Quick Replies
+                </Typography>
+                <Stack spacing={1}>
+                  {quickReplies.map((qr) => (
+                    <Stack
+                      key={qr.id}
+                      direction="row"
+                      spacing={1}
+                      alignItems="flex-start"
+                    >
+                      <TextField
+                        label="Label"
+                        value={qr.label}
+                        onChange={handleQuickReplyChange(qr.id, "label")}
+                        sx={{ width: 200 }}
+                      />
+                      <TextField
+                        label="Template"
+                        value={qr.template}
+                        onChange={handleQuickReplyChange(qr.id, "template")}
+                        multiline
+                        minRows={2}
+                        fullWidth
+                      />
+                      <IconButton
+                        aria-label="delete"
+                        onClick={() => handleDeleteQuickReply(qr.id)}
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    </Stack>
+                  ))}
+                  <Button
+                    variant="outlined"
+                    onClick={handleAddQuickReply}
+                    sx={{ alignSelf: "flex-start" }}
+                  >
+                    Add Quick Reply
+                  </Button>
+                </Stack>
+              </Box>
+              <Button type="submit" variant="contained" sx={{ alignSelf: "flex-start" }}>
+                Save
+              </Button>
+            </Stack>
+          </Box>
+        </Container>
+      </AppAppBar>
     </ThemeProvider>
   );
 }

--- a/src/components/dna/AddSequenceCard.tsx
+++ b/src/components/dna/AddSequenceCard.tsx
@@ -12,6 +12,7 @@ import { blue, grey } from "./colors";
 import Title from "../app/Title";
 import { Science } from "@mui/icons-material";
 import { withBasePath } from "@/utils/basePath";
+import { useSnackbar } from "notistack";
 
 const Textarea = styled(TextareaAutosize)(
   ({ theme }) => `
@@ -62,17 +63,25 @@ export default function AddSequenceCard({
     null
   );
   const loadSampleMenuOpen = Boolean(loadSampleMenuEl);
+  const { enqueueSnackbar } = useSnackbar();
 
   const loadSample = async (sample: string) => {
-    const rawSequenceContent = await (
-      await fetch(withBasePath(`/dna/examples/${sample}`))
-    ).text();
+    try {
+      const rawSequenceContent = await (
+        await fetch(withBasePath(`/dna/examples/${sample}`))
+      ).text();
 
-    parseSequence(rawSequenceContent, sample, (parsedSequence) => {
-      parsedSequence.sequence = parsedSequence.sequence.trim();
+      parseSequence(rawSequenceContent, sample, (parsedSequence) => {
+        parsedSequence.sequence = parsedSequence.sequence.trim();
 
-      onAddSequence?.(parsedSequence);
-    });
+        onAddSequence?.(parsedSequence);
+      });
+    } catch (err) {
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to load sample", err);
+      }
+      enqueueSnackbar("Failed to load sample sequence.", { variant: "error" });
+    }
   };
 
   return (

--- a/src/components/talentforge/AppAppBar.tsx
+++ b/src/components/talentforge/AppAppBar.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { PaletteMode } from "@mui/material";
+import { SnackbarProvider } from "notistack";
 import Box from "@mui/material/Box";
 import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
@@ -24,9 +25,10 @@ const logoStyle = {
 interface AppAppBarProps {
   mode: PaletteMode;
   toggleColorMode: () => void;
+  children?: React.ReactNode;
 }
 
-function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
+function AppAppBar({ mode, toggleColorMode, children }: AppAppBarProps) {
   const [open, setOpen] = React.useState(false);
 
   const toggleDrawer = (newOpen: boolean) => () => {
@@ -48,16 +50,17 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
   };
 
   return (
-    <div>
-      <AppBar
-        position="fixed"
-        sx={{
-          boxShadow: 0,
-          bgcolor: "transparent",
-          backgroundImage: "none",
-          mt: 2,
-        }}
-      >
+    <SnackbarProvider maxSnack={3} autoHideDuration={3000}>
+      <div>
+        <AppBar
+          position="fixed"
+          sx={{
+            boxShadow: 0,
+            bgcolor: "transparent",
+            backgroundImage: "none",
+            mt: 2,
+          }}
+        >
         <Container maxWidth="lg">
           <Toolbar
             variant="regular"
@@ -243,8 +246,10 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
             </Box>
           </Toolbar>
         </Container>
-      </AppBar>
-    </div>
+        </AppBar>
+        {children}
+      </div>
+    </SnackbarProvider>
   );
 }
 

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -1,23 +1,22 @@
 "use client";
 
 import * as React from "react";
-
-import { Box, Chip, IconButton, MenuItem, Stack, TextField, Typography } from "@mui/material";
-import { ArchiveOutlined } from "@mui/icons-material";
-import {
-  responseTemplates as defaultTemplates,
-  ResponseTemplate,
-} from "@/consts/talentforge/responseTemplates";
 import {
   Box,
   Button,
   Chip,
   IconButton,
+  MenuItem,
   Stack,
   TextField,
   Typography,
 } from "@mui/material";
-import { ArchiveOutlined, ReplyOutlined } from "@mui/icons-material";
+import { ArchiveOutlined } from "@mui/icons-material";
+import { useSnackbar } from "notistack";
+import {
+  responseTemplates as defaultTemplates,
+  ResponseTemplate,
+} from "@/consts/talentforge/responseTemplates";
 
 import { askOpenAI } from "@/utils/talentforge/utils";
 import { scheduleFollowUp } from "@/utils/talentforge/followUp";
@@ -38,60 +37,75 @@ interface InboxMessage {
 export default function Inbox() {
   const [messages, setMessages] = React.useState<InboxMessage[]>([]);
   const [tagInputs, setTagInputs] = React.useState<Record<string, string>>({});
-  const [loading, setLoading] = React.useState<Record<string, boolean>>({});
   const [pageTokens, setPageTokens] = React.useState<Record<string, string | undefined>>({});
   const [loadingMore, setLoadingMore] = React.useState(false);
-  const [tagInputs, setTagInputs] = React.useState<Record<number, string>>({});
   const [quickReplies, setQuickReplies] = React.useState<ResponseTemplate[]>(
     defaultTemplates
   );
-  const [selectedTemplates, setSelectedTemplates] = React.useState<
-    Record<number, string>
-  >({});
-  const [tagSuggestionsLoading, setTagSuggestionsLoading] =
-    React.useState<Record<number, boolean>>({});
+  const [selectedTemplates, setSelectedTemplates] = React.useState<Record<number, string>>({});
+  const [tagSuggestionsLoading, setTagSuggestionsLoading] = React.useState<Record<number, boolean>>({});
+  const { enqueueSnackbar } = useSnackbar();
 
   const fetchMessages = React.useCallback(
     async (provider: string, pageToken?: string) => {
-      const tokens = getStoredTokens(provider);
-      if (!tokens?.accessToken) {
+      try {
+        const tokens = getStoredTokens(provider);
+        if (!tokens?.accessToken) {
+          return { messages: [] as InboxMessage[], nextPageToken: undefined as string | undefined };
+        }
+        const params = pageToken ? `?pageToken=${encodeURIComponent(pageToken)}` : "";
+        const res = await fetch(`/api/messages/${provider}${params}`, {
+          headers: {
+            Authorization: `Bearer ${tokens.accessToken}`,
+          },
+        });
+        if (!res.ok) {
+          enqueueSnackbar(`Failed to fetch ${provider} messages.`, { variant: "error" });
+          if (process.env.NODE_ENV === "development") {
+            console.error(`Failed to fetch ${provider} messages`, res.statusText);
+          }
+          return { messages: [] as InboxMessage[], nextPageToken: undefined as string | undefined };
+        }
+        const data = (await res.json()) as {
+          messages: InboxMessage[];
+          nextPageToken?: string;
+        };
+        return data;
+      } catch (err) {
+        if (process.env.NODE_ENV === "development") {
+          console.error(`Error fetching ${provider} messages`, err);
+        }
+        enqueueSnackbar(`Error fetching ${provider} messages.`, { variant: "error" });
         return { messages: [] as InboxMessage[], nextPageToken: undefined as string | undefined };
       }
-      const params = pageToken ? `?pageToken=${encodeURIComponent(pageToken)}` : "";
-      const res = await fetch(`/api/messages/${provider}${params}`, {
-        headers: {
-          Authorization: `Bearer ${tokens.accessToken}`,
-        },
-      });
-      if (!res.ok) {
-        return { messages: [] as InboxMessage[], nextPageToken: undefined as string | undefined };
-      }
-      const data = (await res.json()) as {
-        messages: InboxMessage[];
-        nextPageToken?: string;
-      };
-      return data;
     },
-    []
+    [enqueueSnackbar]
   );
 
   React.useEffect(() => {
     const load = async () => {
-      const providers = ["gmail", "linkedin"];
-      const all: InboxMessage[] = [];
-      const tokens: Record<string, string | undefined> = {};
-      for (const p of providers) {
-        const data = await fetchMessages(p);
-        all.push(
-          ...data.messages.map((m) => ({ ...m, tags: m.tags || [], archived: false }))
-        );
-        if (data.nextPageToken) tokens[p] = data.nextPageToken;
+      try {
+        const providers = ["gmail", "linkedin"];
+        const all: InboxMessage[] = [];
+        const tokens: Record<string, string | undefined> = {};
+        for (const p of providers) {
+          const data = await fetchMessages(p);
+          all.push(
+            ...data.messages.map((m) => ({ ...m, tags: m.tags || [], archived: false }))
+          );
+          if (data.nextPageToken) tokens[p] = data.nextPageToken;
+        }
+        setMessages(all);
+        setPageTokens(tokens);
+      } catch (err) {
+        if (process.env.NODE_ENV === "development") {
+          console.error("Failed to load messages", err);
+        }
+        enqueueSnackbar("Failed to load messages.", { variant: "error" });
       }
-      setMessages(all);
-      setPageTokens(tokens);
     };
     void load();
-  }, [fetchMessages]);
+  }, [fetchMessages, enqueueSnackbar]);
 
   const handleTagAdd = (id: string) => {
     const tag = (tagInputs[id] || "").trim();
@@ -189,26 +203,6 @@ export default function Inbox() {
     );
   };
 
-  const handleQuickReply = async (id: string) => {
-    const msg = messages.find((m) => m.id === id);
-    if (!msg) return;
-    setLoading((l) => ({ ...l, [id]: true }));
-    const response = await askOpenAI({
-      context: msg.content,
-      user: "Draft a brief professional reply to the above message.",
-      system:
-        "You are an assistant that crafts concise, professional replies to messages based on the provided context. Reply directly without preamble.",
-      chatHistory: [],
-      returnFirstResponse: true,
-    });
-    setLoading((l) => ({ ...l, [id]: false }));
-    setMessages((msgs) =>
-      msgs.map((m) =>
-        m.id === id ? { ...m, quickReply: response?.message || "" } : m
-      )
-    );
-  };
-
   const handleScheduleFollowUp = (id: number, days: number) => {
     const msg = messages.find((m) => m.id === id);
     if (!msg) return;
@@ -225,19 +219,27 @@ export default function Inbox() {
 
   const loadMore = async () => {
     setLoadingMore(true);
-    const providers = Object.keys(pageTokens).filter((p) => pageTokens[p]);
-    const fetched: InboxMessage[] = [];
-    const newTokens: Record<string, string | undefined> = {};
-    for (const p of providers) {
-      const data = await fetchMessages(p, pageTokens[p]);
-      fetched.push(
-        ...data.messages.map((m) => ({ ...m, tags: m.tags || [], archived: false }))
-      );
-      newTokens[p] = data.nextPageToken;
+    try {
+      const providers = Object.keys(pageTokens).filter((p) => pageTokens[p]);
+      const fetched: InboxMessage[] = [];
+      const newTokens: Record<string, string | undefined> = {};
+      for (const p of providers) {
+        const data = await fetchMessages(p, pageTokens[p]);
+        fetched.push(
+          ...data.messages.map((m) => ({ ...m, tags: m.tags || [], archived: false }))
+        );
+        newTokens[p] = data.nextPageToken;
+      }
+      setMessages((prev) => [...prev, ...fetched]);
+      setPageTokens((prev) => ({ ...prev, ...newTokens }));
+    } catch (err) {
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to load more messages", err);
+      }
+      enqueueSnackbar("Failed to load more messages.", { variant: "error" });
+    } finally {
+      setLoadingMore(false);
     }
-    setMessages((prev) => [...prev, ...fetched]);
-    setPageTokens((prev) => ({ ...prev, ...newTokens }));
-    setLoadingMore(false);
   };
 
   return (

--- a/src/components/talentforge/JobSearch.tsx
+++ b/src/components/talentforge/JobSearch.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useSnackbar } from "notistack";
 import {
   Box,
   Button,
@@ -44,16 +45,27 @@ export default function JobSearch() {
   const [jobs, setJobs] = useState<JobListing[]>([]);
   const [errors, setErrors] = useState<string[]>([]);
   const [filters, setFilters] = useState<Filters>({ roles: [], locations: [] });
+  const { enqueueSnackbar } = useSnackbar();
 
   useEffect(() => {
     setFilters(loadFilters());
   }, []);
 
   const handleSearch = async () => {
-    const { jobs: results, errors: errs }: AggregatedJobSearchResult =
-      await aggregateJobSearch(query, filters);
-    setJobs(results);
-    setErrors(errs);
+    try {
+      const { jobs: results, errors: errs }: AggregatedJobSearchResult =
+        await aggregateJobSearch(query, filters);
+      setJobs(results);
+      setErrors(errs);
+      errs.forEach((e) => enqueueSnackbar(e, { variant: "error" }));
+    } catch (err) {
+      if (process.env.NODE_ENV === "development") {
+        console.error("Job search failed", err);
+      }
+      enqueueSnackbar("Failed to search jobs. Please try again.", {
+        variant: "error",
+      });
+    }
   };
 
   const hasFilters =

--- a/src/utils/talentforge/indeedApi.ts
+++ b/src/utils/talentforge/indeedApi.ts
@@ -47,11 +47,16 @@ const normalizeIndeedJob = (job: Record<string, unknown>): JobListing => {
   };
 };
 
+export interface IndeedJobSearchResult {
+  jobs: JobListing[];
+  error?: string;
+}
+
 export async function searchIndeedJobs(
   query: string,
   filters: IndeedSearchFilters = {}
-): Promise<JobListing[]> {
-  if (!query.trim()) return [];
+): Promise<IndeedJobSearchResult> {
+  if (!query.trim()) return { jobs: [] };
 
   const params = new URLSearchParams();
   params.set("q", query);
@@ -77,7 +82,10 @@ export async function searchIndeedJobs(
   try {
     const response = await fetch(url, { headers });
     if (!response.ok) {
-      return [];
+      if (process.env.NODE_ENV === "development") {
+        console.error("Indeed API error", response.status, response.statusText);
+      }
+      return { jobs: [], error: "Indeed API request failed." };
     }
     const data: unknown = await response.json();
     const dataObj = data as {
@@ -90,12 +98,17 @@ export async function searchIndeedJobs(
       ? dataObj.jobs
       : [];
 
-    return jobsArray
-      .filter((job): job is Record<string, unknown> =>
-        typeof job === "object" && job !== null
-      )
-      .map((job) => normalizeIndeedJob(job));
-  } catch {
-    return [];
+    return {
+      jobs: jobsArray
+        .filter((job): job is Record<string, unknown> =>
+          typeof job === "object" && job !== null
+        )
+        .map((job) => normalizeIndeedJob(job)),
+    };
+  } catch (err) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Failed to fetch Indeed jobs", err);
+    }
+    return { jobs: [], error: "Failed to fetch Indeed jobs." };
   }
 }

--- a/src/utils/talentforge/jobAggregator.ts
+++ b/src/utils/talentforge/jobAggregator.ts
@@ -34,17 +34,20 @@ export async function aggregateJobSearch(
 ): Promise<AggregatedJobSearchResult> {
   if (!query.trim()) return { jobs: [], errors: [] };
 
-  const [indeedJobs, linkedinResult] = await Promise.all([
+  const [indeedResult, linkedinResult] = await Promise.all([
     searchIndeedJobs(query, filters),
     searchLinkedInJobs(query),
   ]);
 
   const errors: string[] = [];
+  if (indeedResult.error) {
+    errors.push(indeedResult.error);
+  }
   if (linkedinResult.error) {
     errors.push(linkedinResult.error);
   }
 
-  const combined = [...indeedJobs, ...linkedinResult.jobs];
+  const combined = [...indeedResult.jobs, ...linkedinResult.jobs];
   const deduped = dedupeJobs(combined);
   const sorted = deduped.sort(
     (a, b) => relevanceScore(b, query) - relevanceScore(a, query),

--- a/src/utils/talentforge/linkedinApi.ts
+++ b/src/utils/talentforge/linkedinApi.ts
@@ -91,6 +91,13 @@ export async function searchLinkedInJobs(
   try {
     const response = await fetch(url, { headers });
     if (!response.ok) {
+      if (process.env.NODE_ENV === "development") {
+        console.error(
+          "LinkedIn API error",
+          response.status,
+          response.statusText
+        );
+      }
       return {
         jobs: [],
         error: `LinkedIn API error: ${response.status} ${response.statusText}`,
@@ -115,6 +122,9 @@ export async function searchLinkedInJobs(
         .map((job) => normalizeLinkedInJob(job)),
     };
   } catch (err) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Failed to fetch LinkedIn jobs", err);
+    }
     const message = err instanceof Error ? err.message : "Unknown error";
     return {
       jobs: [],

--- a/src/utils/talentforge/oauth.ts
+++ b/src/utils/talentforge/oauth.ts
@@ -87,7 +87,10 @@ export async function exchangeCode(
     const data = (await response.json()) as OAuthTokens;
     saveTokens(provider, data);
     return data;
-  } catch {
+  } catch (err) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Error exchanging code", err);
+    }
     return null;
   }
 }
@@ -109,7 +112,10 @@ export async function refreshAccessToken(
     const data = (await response.json()) as OAuthTokens;
     saveTokens(provider, data);
     return data;
-  } catch {
+  } catch (err) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Error refreshing access token", err);
+    }
     return null;
   }
 }

--- a/src/utils/talentforge/storage.ts
+++ b/src/utils/talentforge/storage.ts
@@ -14,11 +14,17 @@ const STORAGE_KEYS = {
 
 async function storeItem<T>(key: string, value: T): Promise<void> {
   if (STORAGE_API_URL) {
-    await fetch(`${STORAGE_API_URL}/${key}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(value),
-    });
+    try {
+      await fetch(`${STORAGE_API_URL}/${key}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(value),
+      });
+    } catch (err) {
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to store item", err);
+      }
+    }
     return;
   }
 
@@ -34,7 +40,10 @@ async function getItem<T>(key: string): Promise<T | null> {
       if (response.ok) {
         return (await response.json()) as T;
       }
-    } catch {
+    } catch (err) {
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to get item", err);
+      }
       return null;
     }
     return null;
@@ -80,7 +89,13 @@ export async function loadJobApplications(): Promise<JobApplication[] | null> {
 
 export async function clearStorage(): Promise<void> {
   if (STORAGE_API_URL) {
-    await fetch(`${STORAGE_API_URL}/clear`, { method: "POST" });
+    try {
+      await fetch(`${STORAGE_API_URL}/clear`, { method: "POST" });
+    } catch (err) {
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to clear storage", err);
+      }
+    }
     return;
   }
 

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -19,27 +19,28 @@ export const setOpenAIKey = (key: string) => {
 export const hasOpenAIKey = () => apiKey.trim().length > 0;
 
 const requestCompletion = async (systemMessage: string) => {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: "gpt-3.5-turbo",
-      temperature: 0.5,
-      top_p: 0.8,
-      messages: [
-        {
-          role: "system",
-          content: systemMessage,
-        },
-      ],
-    }),
-  });
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        temperature: 0.5,
+        top_p: 0.8,
+        messages: [
+          {
+            role: "system",
+            content: systemMessage,
+          },
+        ],
+      }),
+    });
 
-  const data = await response.json();
-  const content = data?.choices?.[0]?.message?.content;
+    const data = await response.json();
+    const content = data?.choices?.[0]?.message?.content;
 
   // `content` can be a string (old API) or an array of text segments (new API)
   if (Array.isArray(content)) {
@@ -56,7 +57,13 @@ const requestCompletion = async (systemMessage: string) => {
     );
   }
 
-  return content || "";
+    return content || "";
+  } catch (err) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("OpenAI request failed", err);
+    }
+    throw new Error("Failed to fetch completion");
+  }
 };
 
 export const askOpenAI = async ({


### PR DESCRIPTION
## Summary
- integrate notistack toast provider in AppAppBar and wrap TalentForge pages
- display user-friendly error snackbars for job search, inbox, and DNA sequence loading
- add try/catch with debug logging for external API requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3729101a08330a5bc0f1d5e2108cc