### PR TITLE
docs: add TalentForge setup instructions

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,12 @@
+# Environment variables for TalentForge
+NEXT_PUBLIC_OPENAI_API_KEY=your_openai_api_key
+NEXT_PUBLIC_INDEED_API_KEY=your_indeed_api_key
+NEXT_PUBLIC_INDEED_API_URL=https://api.indeed.com/v2
+NEXT_PUBLIC_LINKEDIN_API_KEY=your_linkedin_api_key
+NEXT_PUBLIC_LINKEDIN_CLIENT_ID=your_linkedin_client_id
+NEXT_PUBLIC_LINKEDIN_API_URL=https://api.linkedin.com/v2
+NEXT_PUBLIC_GMAIL_CLIENT_ID=your_gmail_client_id
+NEXT_PUBLIC_TALENTFORGE_STORAGE_API_URL=https://storage.example.com
+NEXT_PUBLIC_OAUTH_TOKEN_ENDPOINT=/api/oauth/token
+NEXT_PUBLIC_OAUTH_REFRESH_ENDPOINT=/api/oauth/refresh
+NEXT_PUBLIC_BASE_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ web_modules/
 .env
 .env.*
 !.env.example
+!.env.local.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ npm start
 
 During development, run `npm run dev` to start the local server.
 
+## TalentForge Setup
+
+TalentForge integrates with several external services. Copy `.env.local.example` to `.env.local` and provide the following values:
+
+- `NEXT_PUBLIC_OPENAI_API_KEY` – OpenAI API key.
+- `NEXT_PUBLIC_INDEED_API_KEY` – Indeed API key.
+- `NEXT_PUBLIC_INDEED_API_URL` – Indeed API base URL.
+- `NEXT_PUBLIC_LINKEDIN_API_KEY` – LinkedIn API key.
+- `NEXT_PUBLIC_LINKEDIN_CLIENT_ID` – LinkedIn OAuth client ID.
+- `NEXT_PUBLIC_LINKEDIN_API_URL` – LinkedIn API base URL.
+- `NEXT_PUBLIC_GMAIL_CLIENT_ID` – Gmail OAuth client ID.
+- `NEXT_PUBLIC_TALENTFORGE_STORAGE_API_URL` – TalentForge storage service endpoint.
+- `NEXT_PUBLIC_OAUTH_TOKEN_ENDPOINT` – OAuth token endpoint.
+- `NEXT_PUBLIC_OAUTH_REFRESH_ENDPOINT` – OAuth refresh endpoint.
+- `NEXT_PUBLIC_BASE_PATH` – optional base path for deployment.
+
+Launch the TalentForge page and follow the onboarding wizard for initial configuration steps.
+
 ## Getting Started
 
 First, run the development server:


### PR DESCRIPTION
## Summary
- document TalentForge environment variables and onboarding wizard in README
- provide `.env.local.example` template and allow it through `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint -- .`


------
https://chatgpt.com/codex/tasks/task_e_68c37b48f03c83308c231523cb639802