### PR TITLE
docs: clarify Thinking indicator spacing

### DIFF
--- a/src/components/showcase/Thinking/index.tsx
+++ b/src/components/showcase/Thinking/index.tsx
@@ -15,8 +15,7 @@ export interface ThinkingProps {
   /** The color of the {@link CircularProgress} indicator.
    * Default color is "primary".
    * Default size is "16px".
-   * Default margin is "1" (1px).
-   * Default sx is { m: 1 }.
+   * Default sx is { m: 1 }, which sets the margin to one theme spacing unit (≈8px by default), not 1px.
    * Default variant is "indeterminate".
    * Default thickness is 3.6.
    * You can also pass other props to customize the {@link CircularProgress} component.


### PR DESCRIPTION
## Summary
- Clarify `Thinking` component JSDoc that `sx: { m: 1 }` applies one theme spacing unit (~8 px)

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c63bf2c5608330a967435c51759b28