### PR TITLE
feat: add TalentForge domain types

### DIFF
--- a/src/types/talentforge.ts
+++ b/src/types/talentforge.ts
@@ -1,0 +1,61 @@
+export interface UserProfile {
+  /** Unique identifier for the user. */
+  id: string;
+  /** Display name of the user. */
+  name: string;
+  /** Email address of the user. */
+  email: string;
+  /** Resumes associated with the user. */
+  resumes: Resume[];
+}
+
+export interface Resume {
+  /** Unique identifier for the resume. */
+  id: string;
+  /** Original filename of the resume. */
+  filename: string;
+  /** URL where the resume file can be accessed. */
+  url: string;
+}
+
+export interface JobApplication {
+  /** Unique identifier for the job application. */
+  id: string;
+  /** Identifier of the job listing being applied to. */
+  jobId: string;
+  /** Identifier of the resume used for the application. */
+  resumeId: string;
+  /** Current status of the application. */
+  status: ApplicationStatus;
+}
+
+export interface Message {
+  /** Unique identifier for the message. */
+  id: string;
+  /** Identifier of the user sending the message. */
+  from: string;
+  /** Identifier of the user receiving the message. */
+  to: string;
+  /** Timestamp in ISO format when the message was sent. */
+  sentAt: string;
+  /** Body of the message. */
+  body: string;
+}
+
+export interface Offer {
+  /** Unique identifier for the offer. */
+  id: string;
+  /** Identifier of the related job application. */
+  applicationId: string;
+  /** Proposed salary or compensation. */
+  compensation: string;
+  /** Whether the offer has been accepted. */
+  accepted: boolean;
+}
+
+export type ApplicationStatus =
+  | "applied"
+  | "interview"
+  | "offer"
+  | "rejected";
+


### PR DESCRIPTION
## Summary
- add TalentForge types for user profiles, resumes, applications, messages and offers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c63bc00c7c83309e5debe7a6ac9d0e