### PR TITLE
fix: return empty string from useOrigin

### DIFF
--- a/src/hooks/useOrigin.ts
+++ b/src/hooks/useOrigin.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-export default function useOrigin() {
+export default function useOrigin(): string {
   const [mounted, setMounted] = useState(false);
   const origin =
     typeof window !== "undefined" && window.location.origin
@@ -14,7 +14,7 @@ export default function useOrigin() {
   }, []);
 
   if (!mounted) {
-    return null;
+    return "";
   }
 
   return origin;


### PR DESCRIPTION
## Summary
- return empty string from `useOrigin` before mount
- type hook to always return a string

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c63be871448330bc33b0b8deca05e3