### PR TITLE
Use toHaveStyle for spinner size assertion

### DIFF
--- a/src/components/showcase/Thinking/Thinking.test.tsx
+++ b/src/components/showcase/Thinking/Thinking.test.tsx
@@ -38,6 +38,6 @@ describe("<Thinking />", () => {
     renderComponent({ showIndicator: true, indicatorProps: custom });
     const spinner = screen.getByRole("progressbar");
     expect(spinner).toBeInTheDocument();
-    expect(spinner).toHaveAttribute("style", "width: 32px; height: 32px;");
+    expect(spinner).toHaveStyle({ width: "32px", height: "32px" });
   });
 });


### PR DESCRIPTION
## Summary
- update Thinking component tests to check spinner dimensions with `toHaveStyle`

## Testing
- `npm test src/components/showcase/Thinking/Thinking.test.tsx` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c63bf9a1e08330b1548800b7a029a9