### PR TITLE
feat: add job board connectors

### DIFF
--- a/src/utils/indeedConnector.ts
+++ b/src/utils/indeedConnector.ts
@@ -1,0 +1,95 @@
+/**
+ * Utilities for interacting with the Indeed API.
+ *
+ * The functions below are mocked to return sample data so that the application
+ * can be developed without access to the real Indeed services.
+ */
+
+export interface IndeedProfile {
+  id: string;
+  name: string;
+  resumeTitle: string;
+}
+
+export interface IndeedJob {
+  id: string;
+  title: string;
+  company: string;
+  location: string;
+}
+
+export interface IndeedMessage {
+  id: string;
+  from: string;
+  body: string;
+}
+
+/**
+ * Retrieve the user's profile from Indeed.
+ *
+ * A production implementation would call an endpoint such as
+ * `https://api.indeed.com/v1/profile` with an API key:
+ *
+ * ```ts
+ * const response = await fetch("https://api.indeed.com/v1/profile", {
+ *   headers: { Authorization: `Bearer ${apiKey}` },
+ * });
+ * const data = (await response.json()) as IndeedProfile;
+ * return data;
+ * ```
+ */
+export async function fetchProfile(): Promise<IndeedProfile> {
+  return {
+    id: "abc",
+    name: "Grace Hopper",
+    resumeTitle: "Computer Scientist",
+  };
+}
+
+/**
+ * Search for jobs on Indeed.
+ *
+ * In reality this would send a request like
+ * `https://api.indeed.com/v2/jobs?q=${encodeURIComponent(query)}` and parse the
+ * JSON response.
+ */
+export async function searchJobs(query: string): Promise<IndeedJob[]> {
+  void query;
+  return [
+    {
+      id: "j1",
+      title: "Frontend Developer",
+      company: "Indeed",
+      location: "Austin, TX",
+    },
+    {
+      id: "j2",
+      title: "Data Analyst",
+      company: "Indeed",
+      location: "New York, NY",
+    },
+  ];
+}
+
+/**
+ * Fetch recent messages from the Indeed messaging platform.
+ *
+ * A real implementation would call an endpoint like
+ * `https://api.indeed.com/v1/messages` with the appropriate credentials and
+ * return the parsed JSON.
+ */
+export async function fetchMessages(): Promise<IndeedMessage[]> {
+  return [
+    {
+      id: "m1",
+      from: "Recruiter",
+      body: "Your application looks promising. Let's talk!",
+    },
+    {
+      id: "m2",
+      from: "Indeed Support",
+      body: "Your job alert has been created.",
+    },
+  ];
+}
+

--- a/src/utils/linkedinConnector.ts
+++ b/src/utils/linkedinConnector.ts
@@ -1,0 +1,109 @@
+/**
+ * Utilities for interacting with the LinkedIn API.
+ *
+ * These functions are currently mocked for development purposes. They simulate
+ * the shape of data returned by LinkedIn so that the rest of the application
+ * can be developed without live API access.
+ */
+
+export interface LinkedInProfile {
+  id: string;
+  firstName: string;
+  lastName: string;
+  headline: string;
+}
+
+export interface LinkedInJob {
+  id: string;
+  title: string;
+  company: string;
+  location: string;
+}
+
+export interface LinkedInMessage {
+  id: string;
+  from: string;
+  body: string;
+}
+
+/**
+ * Retrieve the authenticated user's profile from LinkedIn.
+ *
+ * In a real implementation this would make an authenticated HTTP request to
+ * `https://api.linkedin.com/v2/me` using an OAuth access token:
+ *
+ * ```ts
+ * const response = await fetch("https://api.linkedin.com/v2/me", {
+ *   headers: { Authorization: `Bearer ${token}` },
+ * });
+ * const data = (await response.json()) as LinkedInProfile;
+ * return data;
+ * ```
+ *
+ * Here we return sample data for development.
+ */
+export async function fetchProfile(): Promise<LinkedInProfile> {
+  return {
+    id: "123",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    headline: "Pioneer of Computing",
+  };
+}
+
+/**
+ * Search LinkedIn jobs.
+ *
+ * A production version would query LinkedIn's job search endpoint, for example:
+ *
+ * ```ts
+ * const response = await fetch(
+ *   `https://api.linkedin.com/v2/jobSearch?q=${encodeURIComponent(query)}`,
+ *   { headers: { Authorization: `Bearer ${token}` } }
+ * );
+ * const jobs = (await response.json()) as LinkedInJob[];
+ * return jobs;
+ * ```
+ *
+ * This mock returns a static list of jobs.
+ */
+export async function searchJobs(query: string): Promise<LinkedInJob[]> {
+  void query; // silence unused parameter in mock implementation
+  return [
+    {
+      id: "1",
+      title: "Software Engineer",
+      company: "LinkedIn",
+      location: "Remote",
+    },
+    {
+      id: "2",
+      title: "Product Manager",
+      company: "LinkedIn",
+      location: "San Francisco, CA",
+    },
+  ];
+}
+
+/**
+ * Fetch recent LinkedIn messages.
+ *
+ * In production this would call something like
+ * `https://api.linkedin.com/v2/messages` with the appropriate authorization
+ * header and return the parsed JSON response.
+ */
+export async function fetchMessages(): Promise<LinkedInMessage[]> {
+  return [
+    {
+      id: "m1",
+      from: "Recruiter",
+      body: "We came across your profile and would love to chat.",
+    },
+    {
+      id: "m2",
+      from: "Colleague",
+      body: "Great work on the recent project!",
+    },
+  ];
+}
+


### PR DESCRIPTION
## Summary
- add mocked LinkedIn connector with profile, job search, and messaging utilities
- add mocked Indeed connector with matching API stubs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c63d4540188330bf36bdab3d814e78