### PR TITLE
feat: add resume parser hook

### DIFF
--- a/src/hooks/useResumeParser.ts
+++ b/src/hooks/useResumeParser.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from "react";
+
+import { pdfToMarkdown } from "@/utils/talentforge/pdfParser";
+
+export default function useResumeParser() {
+  const [resume, setResume] = useState("");
+
+  const parseResume = useCallback(async (input: File | string) => {
+    if (typeof input === "string") {
+      setResume(input);
+      return input;
+    }
+    const text = await pdfToMarkdown(input);
+    setResume(text);
+    return text;
+  }, []);
+
+  return { resume, parseResume };
+}
+

--- a/src/utils/talentforge/pdfParser.ts
+++ b/src/utils/talentforge/pdfParser.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import * as pdfjs from "pdfjs-dist";
+
+import { Buffer } from "buffer";
+
+declare global {
+  interface Window {
+    Buffer: typeof Buffer;
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.Buffer = window.Buffer || Buffer;
+}
+
+export async function pdfToMarkdown(file: File): Promise<string> {
+  const reader = new FileReader();
+  const workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`;
+
+  pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
+
+  const fileReadPromise = new Promise<ArrayBuffer>((resolve, reject) => {
+    reader.onload = () => {
+      resolve(reader.result as ArrayBuffer);
+    };
+    reader.onerror = reject;
+  });
+
+  reader.readAsArrayBuffer(file);
+
+  const buffer = await fileReadPromise;
+  const pdfData = new Uint8Array(buffer);
+
+  const doc = await pdfjs.getDocument({ data: pdfData }).promise;
+  const numPages = doc.numPages;
+
+  let markdown = "";
+
+  for (let i = 1; i <= numPages; i++) {
+    const page = await doc.getPage(i);
+    const content = await page.getTextContent();
+
+    for (const item of content.items as unknown as { str: string }[]) {
+      markdown += item.str + "\n";
+    }
+
+    markdown += "\n\n";
+  }
+
+  return markdown;
+}
+


### PR DESCRIPTION
## Summary
- add pdf parsing utility for TalentForge
- introduce useResumeParser hook supporting file and text input

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c63e3d06fc83308b570a4a339de219