### PR TITLE
docs: clarify useFrameRate hook returns callback

### DIFF
--- a/src/hooks/lightgun-web/useFrameRate.ts
+++ b/src/hooks/lightgun-web/useFrameRate.ts
@@ -2,8 +2,12 @@ import { useEffect, useRef, type MutableRefObject } from "react";
 
 /**
  * Provides a callback to compute frame timing information.
- * Returns { fps, scale } where `scale` is the ratio of the
- * actual frame duration to the target 60 FPS frame duration.
+ *
+ * The hook returns a timing callback. When invoked every animation frame
+ * with the current timestamp, it updates the exported `fpsRef` and
+ * `scaleRef`. `fpsRef` holds the calculated frames per second and
+ * `scaleRef` stores the ratio of the actual frame duration to the target
+ * 60 FPS frame duration.
  */
 export let fpsRef: MutableRefObject<number>;
 export let scaleRef: MutableRefObject<number>;


### PR DESCRIPTION
## Summary
- clarify `useFrameRate` hook returns a timing callback
- mention `fpsRef` and `scaleRef` updates instead of returning an object

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c63e712cb483308925a185a37035b0