### PR TITLE
Fix slice pointer handling in Blackjack player iteration

### DIFF
--- a/go/blackjack/player/player.go
+++ b/go/blackjack/player/player.go
@@ -69,15 +69,15 @@ func CreatePlayer(playerStartStack int, minWager int) Player {
 
 func ForAllHands(player *Player, handFunc func(hand *Hand)) {
 	for i := 0; i < len(player.Hands); i++ {
-		hand := player.Hands[i]
-		handFunc(&hand)
+		hand := &player.Hands[i]
+		handFunc(hand)
 	}
 }
 
 func ForAllPlayers(players []Player, playerFunc func(player *Player)) {
 	for i := 0; i < len(players); i++ {
-		player := players[i]
-		playerFunc(&player)
+		p := &players[i]
+		playerFunc(p)
 	}
 }
 

--- a/go/blackjack/player/player_test.go
+++ b/go/blackjack/player/player_test.go
@@ -35,3 +35,27 @@ func TestCreatePlayer(t *testing.T) {
 		t.Fatalf("expected WillPlayTrifecta to be non-nil")
 	}
 }
+
+func TestForAllHandsModifiesOriginalSlice(t *testing.T) {
+	p := Player{Hands: []Hand{{}, {}}}
+	ForAllHands(&p, func(h *Hand) {
+		h.Busted = true
+	})
+	for i := range p.Hands {
+		if !p.Hands[i].Busted {
+			t.Fatalf("hand %d not modified", i)
+		}
+	}
+}
+
+func TestForAllPlayersModifiesOriginalSlice(t *testing.T) {
+	players := []Player{{Stack: 0}, {Stack: 0}}
+	ForAllPlayers(players, func(p *Player) {
+		p.Stack = 1
+	})
+	for i := range players {
+		if players[i].Stack != 1 {
+			t.Fatalf("player %d stack not modified", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Fix ForAllHands and ForAllPlayers to pass pointers to slice elements
- Add regression tests ensuring callbacks modify original hands and players

## Testing
- `cd go/blackjack && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c63e63535c8330859b41f701cd7be2