### PR TITLE
Fix mermaid test typo in Timeline tests

### DIFF
--- a/src/components/showcase/Timeline/Timeline.test.tsx
+++ b/src/components/showcase/Timeline/Timeline.test.tsx
@@ -104,7 +104,7 @@ describe("Timeline component", () => {
     const mermaid = `
       timeline
       05/16 12∶30 : Event A: Detail A : notes : 123
-      05/16 13∶00:Event B:Detail B : testResuls : 123
+      05/16 13∶00:Event B:Detail B : testResults : 123
       05/16 14∶00 : Event C : labs : 123
     `;
 


### PR DESCRIPTION
## Summary
- correct spelling of `testResults` in Timeline mermaid parsing test

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c63e560e4083308dcc96d03e1c9efd