### PR TITLE
test: ensure timer cleared after unmount

### DIFF
--- a/src/components/showcase/CircularTimer/CircularTimer.test.tsx
+++ b/src/components/showcase/CircularTimer/CircularTimer.test.tsx
@@ -50,9 +50,23 @@ describe("<CircularTimer />", () => {
     const clearSpy = jest.spyOn(global, "clearInterval");
     const { unmount } = render(<CircularTimer />);
 
+    // advance once to update the label before unmounting
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    const label = screen.getByText("1 s");
+
     // we expect one timer was created; now unmount should clear it
     unmount();
     expect(clearSpy).toHaveBeenCalledTimes(1);
+
+    // advancing timers after unmount should not trigger clearInterval again
+    // or cause the label to update
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(label.textContent).toBe("1 s");
 
     clearSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- enhance unmount test for CircularTimer to verify intervals and labels stop updating after unmount

## Testing
- `npm test src/components/showcase/CircularTimer/CircularTimer.test.tsx` (fails: Missing script: "test")
- `npx jest src/components/showcase/CircularTimer/CircularTimer.test.tsx` (fails: 403 Forbidden - GET https://registry.npmjs.org/jest)
- `npm run lint src/components/showcase/CircularTimer/CircularTimer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c63e7820d08330aea280a5ce14ae58