### PR TITLE
feat: manage resumes with tags

### DIFF
--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { v4 as uuid } from "uuid";
+import {
+  Box,
+  Button,
+  Chip,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+import { askOpenAI } from "@/utils/talentforge/utils";
+
+interface StoredResume {
+  id: string;
+  content: string;
+  tags: string[];
+}
+
+const STORAGE_KEY = "resumes";
+
+const suggestTags = async (content: string): Promise<string[]> => {
+  try {
+    const res = await askOpenAI({
+      context: content,
+      user: "Suggest tags for this resume",
+      system:
+        "You are an assistant that extracts up to 5 concise tags from resume text. Return tags separated by commas.",
+      logMessagesToChatHistory: false,
+      returnFirstResponse: true,
+      chatHistory: [],
+    });
+    const message = res?.message?.trim() ?? "";
+    return message
+      .split(/,|\n/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+};
+
+export default function ResumeManager() {
+  const [resumes, setResumes] = useState<StoredResume[]>([]);
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setResumes(JSON.parse(stored));
+      } catch {
+        setResumes([]);
+      }
+    }
+  }, []);
+
+  const handleSave = async () => {
+    if (!text.trim()) return;
+    const tags = await suggestTags(text);
+    const newResume: StoredResume = { id: uuid(), content: text, tags };
+    const updated = [...resumes, newResume];
+    setResumes(updated);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    setText("");
+  };
+
+  return (
+    <Box>
+      <TextField
+        label="Paste your resume"
+        multiline
+        minRows={6}
+        fullWidth
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <Button variant="contained" sx={{ mt: 2 }} onClick={handleSave}>
+        Save
+      </Button>
+      <Stack spacing={2} sx={{ mt: 4 }}>
+        {resumes.map((resume) => (
+          <Box key={resume.id}>
+            <Typography variant="subtitle1" gutterBottom>
+              {resume.id}
+            </Typography>
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              {resume.tags.map((tag) => (
+                <Chip key={tag} label={tag} sx={{ mb: 1 }} />
+              ))}
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+

--- a/src/types/talentforge.ts
+++ b/src/types/talentforge.ts
@@ -16,6 +16,8 @@ export interface Resume {
   filename: string;
   /** URL where the resume file can be accessed. */
   url: string;
+  /** Tags describing the resume's contents. */
+  tags?: string[];
 }
 
 export interface JobApplication {


### PR DESCRIPTION
## Summary
- extend Resume type with optional tags property
- add ResumeManager component to save resumes and suggest tags with LLM

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c64013c820833092e42e82a6c78ab5