### PR TITLE
feat: add prompt templates mapping

### DIFF
--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -1,0 +1,17 @@
+export interface PromptTemplate {
+  displayText: string;
+  fullText: string;
+}
+
+export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
+  resumeSummary: {
+    displayText: "Resume Summary",
+    fullText:
+      "Summarize your professional experience and key strengths in 2-3 sentences.",
+  },
+  coverLetter: {
+    displayText: "Cover Letter",
+    fullText:
+      "Draft a concise cover letter highlighting why you are a great fit for the role.",
+  },
+};

--- a/src/utils/promptMapper.ts
+++ b/src/utils/promptMapper.ts
@@ -1,0 +1,5 @@
+import { PROMPT_TEMPLATES } from "../consts/prompts";
+
+export function getPromptFullText(label: string): string | undefined {
+  return PROMPT_TEMPLATES[label]?.fullText;
+}


### PR DESCRIPTION
## Summary
- add reusable prompt templates constants
- helper to map prompt labels to full text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6401e2b8c833098aa9a63d0ac4b33