### PR TITLE
feat: add auto reply utility and inbox integration

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 
-import ChatAssistant from "./ChatAssistant";
+import { autoReply } from "@/utils/autoReply";
 
 interface ConnectorMessage {
   id: string;
@@ -48,6 +48,7 @@ const MOCK_MESSAGES: ConnectorMessage[] = [
 export default function Inbox() {
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
 
   const handleFilterChange = (event: SelectChangeEvent) => {
     setFilter(event.target.value as "all" | "unread" | "read");
@@ -56,6 +57,18 @@ export default function Inbox() {
   const filteredMessages = MOCK_MESSAGES.filter(
     (message) => filter === "all" || message.status === filter,
   );
+
+  const handleAutoReply = async (message: ConnectorMessage) => {
+    const reply = await autoReply([
+      {
+        role: "system",
+        content:
+          "You are a helpful assistant crafting concise professional replies to incoming messages.",
+      },
+      { role: "user", content: message.content },
+    ]);
+    setDrafts((d) => ({ ...d, [message.id]: reply }));
+  };
 
   return (
     <Box>
@@ -95,11 +108,17 @@ export default function Inbox() {
                       multiline
                       rows={4}
                       fullWidth
+                      value={drafts[message.id] || ""}
+                      onChange={(e) =>
+                        setDrafts((d) => ({ ...d, [message.id]: e.target.value }))
+                      }
                     />
-                    <Typography variant="subtitle2">
-                      Draft with ChatAssistant
-                    </Typography>
-                    <ChatAssistant />
+                    <Button
+                      size="small"
+                      onClick={() => handleAutoReply(message)}
+                    >
+                      Generate Reply
+                    </Button>
                     <Button variant="contained">Send</Button>
                   </Stack>
                 )}

--- a/src/utils/autoReply.ts
+++ b/src/utils/autoReply.ts
@@ -1,0 +1,49 @@
+"use client";
+
+export interface AutoReplyMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || "";
+
+export const setOpenAIKey = (key: string) => {
+  apiKey = key;
+};
+
+export const hasOpenAIKey = () => apiKey.trim().length > 0;
+
+export async function autoReply(
+  messages: AutoReplyMessage[],
+): Promise<string> {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-3.5-turbo",
+      temperature: 0.7,
+      top_p: 0.9,
+      messages,
+    }),
+  });
+
+  const data = await response.json();
+  const content = data?.choices?.[0]?.message?.content;
+  if (Array.isArray(content)) {
+    return (
+      content
+        .map((c: unknown) => {
+          if (typeof c === "string") return c;
+          if (typeof c === "object" && c !== null && "text" in c) {
+            return (c as { text?: string }).text || "";
+          }
+          return "";
+        })
+        .join("") || ""
+    );
+  }
+  return (content || "").trim();
+}


### PR DESCRIPTION
## Summary
- implement an autoReply utility using OpenAI chat completions
- enable one-click AI reply generation in the inbox

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c646e413208330a599e335ef411ce7