### PR TITLE
feat(talentforge): add OpenAI key modal

### DIFF
--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -6,10 +6,6 @@ import CssBaseline from "@mui/material/CssBaseline";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import Container from "@mui/material/Container";
-import TextField from "@mui/material/TextField";
-import Button from "@mui/material/Button";
-import Typography from "@mui/material/Typography";
 import AppAppBar from "@/components/talentforge/AppAppBar";
 import Hero from "@/components/talentforge/Hero";
 import Highlights from "@/components/talentforge/Highlights";
@@ -26,14 +22,11 @@ import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
 
 import "./page.css"; // Ensure global styles are applied
-import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
-import Image from "next/image";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function TalentForgePage() {
   const [mode, setMode] = React.useState<PaletteMode>("light");
   const defaultTheme = createTheme({ palette: { mode } });
-  const [apiKeyReady, setApiKeyReady] = React.useState(hasOpenAIKey());
   const { setDocumentTitle } = useDocumentTitle();
 
   React.useEffect(() => {
@@ -43,55 +36,6 @@ export default function TalentForgePage() {
   const toggleColorMode = () => {
     setMode((prev) => (prev === "dark" ? "light" : "dark"));
   };
-
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const key = String(formData.get("apiKey"))?.trim();
-    if (key) {
-      setOpenAIKey(key);
-      setApiKeyReady(true);
-    }
-  };
-
-  if (!apiKeyReady) {
-    return (
-      <ThemeProvider theme={defaultTheme}>
-        <CssBaseline />
-        <Container component="main" maxWidth="sm" sx={{ mt: 8, mb: 4 }}>
-          <Image
-            src="/logo192.png"
-            style={{ width: "192px", height: "auto" }}
-            alt="talentforge logo"
-            width={192}
-            height={194}
-          />
-          <Typography variant="h4" component="h1" gutterBottom>
-            Welcome to TalentForge
-          </Typography>
-          <Typography variant="body1" paragraph>
-            TalentForge needs an OpenAI API key to talk with OpenAI. The key you
-            type here goes straight from your browser to OpenAI and stays
-            between you and OpenAI. TalentForge does not store your key anywhere
-            and does not send it anywhere else. If you do not fully trust
-            TalentForge, do not enter your key.
-          </Typography>
-          <Box component="form" onSubmit={handleSubmit}>
-            <TextField
-              label="OpenAI API Key"
-              name="apiKey"
-              type="password"
-              fullWidth
-              required
-            />
-            <Button type="submit" variant="contained" sx={{ mt: 2 }}>
-              Continue
-            </Button>
-          </Box>
-        </Container>
-      </ThemeProvider>
-    );
-  }
 
   return (
     <ThemeProvider theme={defaultTheme}>

--- a/src/components/talentforge/ChatAssistant.tsx
+++ b/src/components/talentforge/ChatAssistant.tsx
@@ -12,12 +12,14 @@ import {
 } from "@mui/material";
 
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
-import { askOpenAI } from "@/utils/talentforge/utils";
+import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import OpenAiKeyModal from "./OpenAiKeyModal";
 import { ChatMessage } from "@/types/talentforge/types";
 
 export default function ChatAssistant() {
   const [selectedPrompt, setSelectedPrompt] = useState<string>("");
   const [chatHistory, setChatHistory] = useState<(ChatMessage | null)[]>([]);
+  const [openKeyModal, setOpenKeyModal] = useState(false);
 
   const handleChange = (event: SelectChangeEvent) => {
     setSelectedPrompt(event.target.value as string);
@@ -27,6 +29,10 @@ export default function ChatAssistant() {
     if (!selectedPrompt) return;
     const fullText = PROMPT_TEMPLATES[selectedPrompt]?.fullText;
     if (!fullText) return;
+    if (!hasOpenAIKey()) {
+      setOpenKeyModal(true);
+      return;
+    }
 
     askOpenAI({
       context: "",
@@ -40,6 +46,10 @@ export default function ChatAssistant() {
 
   return (
     <Box>
+      <OpenAiKeyModal
+        open={openKeyModal}
+        onClose={() => setOpenKeyModal(false)}
+      />
       <Stack spacing={2}>
         <Select
           value={selectedPrompt}

--- a/src/components/talentforge/Hero.tsx
+++ b/src/components/talentforge/Hero.tsx
@@ -23,7 +23,12 @@ import {
   userQuestionPrompt,
 } from "@/consts/talentforge/consts";
 import { ChatMessage } from "@/types/talentforge/types";
-import { askOpenAI, pdfToMarkdown } from "@/utils/talentforge/utils";
+import {
+  askOpenAI,
+  pdfToMarkdown,
+  hasOpenAIKey,
+} from "@/utils/talentforge/utils";
+import OpenAiKeyModal from "./OpenAiKeyModal";
 
 import CircularProgressWithLabel from "./CircularProgressWithLabel";
 import FileUploader from "./FileUploader";
@@ -41,6 +46,7 @@ export default function Hero() {
   >(0);
   const [pdfProgress, setPdfProgress] = React.useState<number | null>(null);
   const [openTerms, setOpenTerms] = React.useState<boolean>(false);
+  const [openKeyModal, setOpenKeyModal] = React.useState(false);
   const setChatHistory = (newChatHistory: typeof chatHistory) => {
     setChatHistoryState(newChatHistory);
     setActiveQuestionIndex(null);
@@ -50,6 +56,10 @@ export default function Hero() {
   const userQuestionInputRef = React.useRef<HTMLInputElement>(null);
 
   const askUserQuestion = async () => {
+    if (!hasOpenAIKey()) {
+      setOpenKeyModal(true);
+      return;
+    }
     const context =
       pdfAsMarkdown?.length > aiBufferSize ? pdfSummary : pdfAsMarkdown;
 
@@ -125,6 +135,10 @@ export default function Hero() {
       })}
     >
       <TermsDialog open={openTerms} onClose={() => setOpenTerms(false)} />
+      <OpenAiKeyModal
+        open={openKeyModal}
+        onClose={() => setOpenKeyModal(false)}
+      />
       <Container
         sx={{
           display: "flex",
@@ -181,6 +195,10 @@ export default function Hero() {
               outputType="files"
               sx={{ width: { xs: "100%" } }}
               onChange={async (filesFromParam) => {
+                if (!hasOpenAIKey()) {
+                  setOpenKeyModal(true);
+                  return;
+                }
                 const files = filesFromParam as File[];
                 if (files && files.length > 0) {
                   const markdown = await pdfToMarkdown(files[0]);

--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -13,7 +13,8 @@ import {
 } from "@mui/material";
 
 import FileUploader from "./FileUploader";
-import { askOpenAI, pdfToMarkdown } from "@/utils/talentforge/utils";
+import { askOpenAI, pdfToMarkdown, hasOpenAIKey } from "@/utils/talentforge/utils";
+import OpenAiKeyModal from "./OpenAiKeyModal";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 
 export default function OfferCompare() {
@@ -21,6 +22,7 @@ export default function OfferCompare() {
   const [compensation, setCompensation] = useState("");
   const [result, setResult] = useState("");
   const [loading, setLoading] = useState(false);
+  const [openKeyModal, setOpenKeyModal] = useState(false);
 
   const handleFileChange = async (filesFromParam: File[] | string | undefined) => {
     const files = filesFromParam as File[];
@@ -33,6 +35,10 @@ export default function OfferCompare() {
   };
 
   const analyzeOffer = async () => {
+    if (!hasOpenAIKey()) {
+      setOpenKeyModal(true);
+      return;
+    }
     const context = `Offer Letter:\n${offerText}\n\nCurrent Compensation:\n${compensation}`;
     const prompt = PROMPT_TEMPLATES["Negotiate Offer"]?.fullText || "";
     setLoading(true);
@@ -50,6 +56,10 @@ export default function OfferCompare() {
 
   return (
     <Box>
+      <OpenAiKeyModal
+        open={openKeyModal}
+        onClose={() => setOpenKeyModal(false)}
+      />
       <Stack spacing={2}>
         <FileUploader
           accept=".pdf,.txt"

--- a/src/components/talentforge/OpenAiKeyModal.tsx
+++ b/src/components/talentforge/OpenAiKeyModal.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  DialogProps,
+} from "@mui/material";
+
+import { setOpenAIKey } from "@/utils/talentforge/utils";
+
+export interface OpenAiKeyModalProps
+  extends Omit<DialogProps, "open" | "onClose"> {
+  open?: boolean;
+  onClose?: () => void;
+}
+
+export default function OpenAiKeyModal({
+  open = false,
+  onClose,
+}: OpenAiKeyModalProps) {
+  const [key, setKey] = React.useState("");
+
+  const handleClose = () => {
+    onClose?.();
+  };
+
+  const handleSave = () => {
+    const trimmed = key.trim();
+    if (!trimmed) return;
+    setOpenAIKey(trimmed);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("talentforge-openai-key", trimmed);
+    }
+    handleClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Enter OpenAI API Key</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          margin="dense"
+          label="OpenAI API Key"
+          type="password"
+          fullWidth
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleSave} disabled={!key.trim()}>
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -11,7 +11,8 @@ import {
   Typography,
 } from "@mui/material";
 
-import { askOpenAI } from "@/utils/talentforge/utils";
+import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import OpenAiKeyModal from "./OpenAiKeyModal";
 
 interface StoredResume {
   id: string;
@@ -45,6 +46,7 @@ const suggestTags = async (content: string): Promise<string[]> => {
 export default function ResumeManager() {
   const [resumes, setResumes] = useState<StoredResume[]>([]);
   const [text, setText] = useState("");
+  const [openKeyModal, setOpenKeyModal] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -58,6 +60,10 @@ export default function ResumeManager() {
   }, []);
 
   const handleSave = async () => {
+    if (!hasOpenAIKey()) {
+      setOpenKeyModal(true);
+      return;
+    }
     if (!text.trim()) return;
     const tags = await suggestTags(text);
     const newResume: StoredResume = { id: uuid(), content: text, tags };
@@ -69,6 +75,10 @@ export default function ResumeManager() {
 
   return (
     <Box>
+      <OpenAiKeyModal
+        open={openKeyModal}
+        onClose={() => setOpenKeyModal(false)}
+      />
       <TextField
         label="Paste your resume"
         multiline

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -7,13 +7,30 @@ import { aiBufferSize } from "@/consts/talentforge/consts";
 
 import { Buffer } from "buffer";
 
+const OPENAI_STORAGE_KEY = "talentforge-openai-key";
 let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || "";
+if (typeof window !== "undefined" && !apiKey) {
+  apiKey = window.localStorage.getItem(OPENAI_STORAGE_KEY) || "";
+}
 
 export const setOpenAIKey = (key: string) => {
   apiKey = key;
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(OPENAI_STORAGE_KEY, key);
+  }
 };
 
-export const hasOpenAIKey = () => apiKey.trim().length > 0;
+export const hasOpenAIKey = () => {
+  if (apiKey.trim().length > 0) return true;
+  if (typeof window !== "undefined") {
+    const stored = window.localStorage.getItem(OPENAI_STORAGE_KEY);
+    if (stored) {
+      apiKey = stored;
+      return true;
+    }
+  }
+  return false;
+};
 
 const requestCompletion = async (systemMessage: string) => {
   const response = await fetch("https://api.openai.com/v1/chat/completions", {


### PR DESCRIPTION
## Summary
- add OpenAI key modal for TalentForge
- persist API key in localStorage under `talentforge-openai-key`
- show modal when LLM features are used without a stored key

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c646ee56a083309f2b426e2d86e571