### PR TITLE
Add TalentForge theme and sidebar layout

### DIFF
--- a/src/app/talentforge/layout.tsx
+++ b/src/app/talentforge/layout.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import { ThemeProvider } from '@mui/material/styles';
+import talentforgeTheme from '@/themes/talentforgeTheme';
+
+export default function TalentForgeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const navItems = [
+    { label: 'Dashboard', href: '/talentforge' },
+    { label: 'Resumes', href: '/talentforge/resumes' },
+    { label: 'Offers', href: '/talentforge/offers' },
+    { label: 'Inbox', href: '/talentforge/inbox' },
+    { label: 'Settings', href: '/talentforge/settings' },
+  ];
+
+  return (
+    <ThemeProvider theme={talentforgeTheme}>
+      <CssBaseline />
+      <Box sx={{ display: 'flex' }}>
+        <Box component="nav" sx={{ width: 240, flexShrink: 0 }}>
+          <List>
+            {navItems.map(({ label, href }) => (
+              <ListItem key={label} disablePadding>
+                <ListItemButton component={Link} href={href}>
+                  <ListItemText primary={label} />
+                </ListItemButton>
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+        <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+          {children}
+        </Box>
+      </Box>
+    </ThemeProvider>
+  );
+}

--- a/src/themes/talentforgeTheme.ts
+++ b/src/themes/talentforgeTheme.ts
@@ -1,0 +1,6 @@
+import { createTheme } from '@mui/material/styles';
+import getLPTheme from './talentforge/theme';
+
+const talentforgeTheme = createTheme(getLPTheme('light'));
+
+export default talentforgeTheme;


### PR DESCRIPTION
## Summary
- add reusable TalentForge MUI theme
- create TalentForge layout wrapped in ThemeProvider with sidebar navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c646f58d0c833093bf7ef96aa7aee5