### PR TITLE
Add TalentForge demo data bootstrap

### DIFF
--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -29,6 +29,7 @@ import "./page.css"; // Ensure global styles are applied
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
 import Image from "next/image";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import insertMockData from "@/utils/mockData";
 
 export default function TalentForgePage() {
   const [mode, setMode] = React.useState<PaletteMode>("light");
@@ -37,6 +38,7 @@ export default function TalentForgePage() {
   const { setDocumentTitle } = useDocumentTitle();
 
   React.useEffect(() => {
+    insertMockData();
     setDocumentTitle("TalentForge");
   }, [setDocumentTitle]);
 

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -1,0 +1,65 @@
+import { UserProfile, Resume, Offer } from "@/types/talentforge";
+
+// Sample resumes for demonstration purposes
+export const mockResumes: Resume[] = [
+  {
+    id: "resume-1",
+    filename: "jane-doe-software.pdf",
+    url: "https://example.com/jane-doe-software.pdf",
+    tags: ["software", "typescript"],
+  },
+  {
+    id: "resume-2",
+    filename: "jane-doe-product.pdf",
+    url: "https://example.com/jane-doe-product.pdf",
+    tags: ["product", "management"],
+  },
+];
+
+// Sample job offers for demonstration purposes
+export const mockOffers: Offer[] = [
+  {
+    id: "offer-1",
+    applicationId: "app-1",
+    compensation: "$120,000",
+    accepted: false,
+  },
+  {
+    id: "offer-2",
+    applicationId: "app-2",
+    compensation: "$135,000 + stock",
+    accepted: true,
+  },
+];
+
+// Sample user profile that references the above resumes
+export const mockUserProfile: UserProfile = {
+  id: "user-1",
+  name: "Jane Doe",
+  email: "jane.doe@example.com",
+  resumes: mockResumes,
+};
+
+const DEMO_DATA_KEY = "tf_demo_data_inserted";
+
+/**
+ * Insert mock data into localStorage on first run for demonstration purposes.
+ */
+export function insertMockData(): void {
+  if (typeof window === "undefined") return;
+
+  if (localStorage.getItem(DEMO_DATA_KEY)) {
+    return;
+  }
+
+  try {
+    localStorage.setItem("userProfile", JSON.stringify(mockUserProfile));
+    localStorage.setItem("resumes", JSON.stringify(mockResumes));
+    localStorage.setItem("offers", JSON.stringify(mockOffers));
+    localStorage.setItem(DEMO_DATA_KEY, "true");
+  } catch {
+    // Ignore write errors (e.g., storage is unavailable)
+  }
+}
+
+export default insertMockData;


### PR DESCRIPTION
## Summary
- add mock resumes, offers, and user profile data
- bootstrap localStorage with demo data on first visit

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c64706bf9483308bc83ad32793b1f4