### PR TITLE
test: check timeline pending dot style without getComputedStyle

### DIFF
--- a/src/components/showcase/Timeline/Timeline.test.tsx
+++ b/src/components/showcase/Timeline/Timeline.test.tsx
@@ -79,10 +79,8 @@ describe("Timeline component", () => {
     ];
     const { container } = renderWithTheme(<Timeline events={pendingEvents} />);
     const dot = container.querySelector(".MuiTimelineDot-root") as HTMLElement;
-    // actual computed style
-    const bg = window.getComputedStyle(dot).backgroundColor;
     // MUI grey.400 is rgb(189, 189, 189)
-    expect(bg).toBe("rgb(189, 189, 189)");
+    expect(dot).toHaveStyle({ backgroundColor: "rgb(189, 189, 189)" });
   });
 
   it("renders exactly n–1 connectors", () => {


### PR DESCRIPTION
## Summary
- Assert pending timeline dot uses grey background with `toHaveStyle`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest src/components/showcase/Timeline/Timeline.test.tsx` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c649bbfe6c833097f128de2ec09103