### PR TITLE
docs: note T and U mapping in 2-bit comment

### DIFF
--- a/src/utils/dna/sequenceUtils.tsx
+++ b/src/utils/dna/sequenceUtils.tsx
@@ -27,7 +27,7 @@ export function baseToColor(base: string): string {
 
 export function baseTo2bit(basePair: string): string {
   // .2Bit format is
-  // T to 00, C to 01, A to 10, and G to 11
+  // T/U to 00, C to 01, A to 10, and G to 11
   // see https://genome.ucsc.edu/FAQ/FAQformat.html#format7
   /** @todo support other formats listed */
   switch (basePair.toUpperCase()) {


### PR DESCRIPTION
## Summary
- clarify `.2Bit` comment that both T and U map to `00`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c649b1e43c83309f845ccbaf154269