### PR TITLE
Fix RandomCard uniform probability

### DIFF
--- a/go/blackjack/random/random.go
+++ b/go/blackjack/random/random.go
@@ -8,10 +8,8 @@ import (
 )
 
 func RandomCard() cards.Card {
-	value := cards.CardValues[rand.Intn(len(cards.CardValues))]
-	if value == cards.One {
-		value = cards.Ace
-	}
+	// Skip cards.One so each rank has equal probability
+	value := cards.CardValues[rand.Intn(len(cards.CardValues)-1)+1]
 	return cards.CreateCard(cards.Suites[rand.Intn(len(cards.Suites))], value)
 }
 

--- a/go/blackjack/random/random_test.go
+++ b/go/blackjack/random/random_test.go
@@ -1,0 +1,41 @@
+package random
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"blackjack/cards"
+)
+
+// TestRandomCardUniform ensures each rank is equally likely.
+func TestRandomCardUniform(t *testing.T) {
+	defer rand.Seed(time.Now().UnixNano())
+	rand.Seed(1)
+	const draws = 130000
+	counts := map[cards.CardValue]int{}
+	for i := 0; i < draws; i++ {
+		c := RandomCard()
+		if c.Value == cards.One {
+			t.Fatalf("RandomCard returned cards.One")
+		}
+		counts[c.Value]++
+	}
+
+	expectedRanks := len(cards.CardValues) - 1 // exclude cards.One
+	if len(counts) != expectedRanks {
+		t.Fatalf("got %d ranks, want %d", len(counts), expectedRanks)
+	}
+
+	mean := draws / expectedRanks
+	tolerance := int(float64(mean) * 0.05) // 5% tolerance
+	for v, c := range counts {
+		diff := c - mean
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > tolerance {
+			t.Fatalf("card %v count %d differs from mean %d by more than %d", v, c, mean, tolerance)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- avoid drawing cards.One so all ranks are equally likely
- add unit test checking uniform rank distribution

## Testing
- `cd go/blackjack && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c649a8567483308c14e02ce85d8c88