### PR TITLE
feat(talentforge): add job application status management

### DIFF
--- a/src/app/talentforge/applications/page.tsx
+++ b/src/app/talentforge/applications/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import JobApplications from "@/components/talentforge/JobApplications";
+
+export default function ApplicationsPage() {
+  return <JobApplications />;
+}
+

--- a/src/app/talentforge/layout.tsx
+++ b/src/app/talentforge/layout.tsx
@@ -18,6 +18,7 @@ export default function TalentForgeLayout({
 }) {
   const navItems = [
     { label: 'Dashboard', href: '/talentforge' },
+    { label: 'Applications', href: '/talentforge/applications' },
     { label: 'Resumes', href: '/talentforge/resumes' },
     { label: 'Offers', href: '/talentforge/offers' },
     { label: 'Inbox', href: '/talentforge/inbox' },

--- a/src/components/talentforge/JobApplications.tsx
+++ b/src/components/talentforge/JobApplications.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  Typography,
+} from "@mui/material";
+import type {
+  ApplicationStatus,
+  JobApplication,
+} from "@/types/talentforge";
+import {
+  getJobApplications,
+  updateJobApplicationStatus,
+} from "@/utils/talentforge/applicationStore";
+
+const STATUS_OPTIONS: ApplicationStatus[] = [
+  "applied",
+  "interview",
+  "offer",
+  "rejected",
+];
+
+export default function JobApplications() {
+  const [applications, setApplications] = useState<JobApplication[]>([]);
+
+  useEffect(() => {
+    setApplications(getJobApplications());
+  }, []);
+
+  const handleStatusChange = (
+    id: string,
+    event: SelectChangeEvent<ApplicationStatus>,
+  ) => {
+    const updated = updateJobApplicationStatus(
+      id,
+      event.target.value as ApplicationStatus,
+    );
+    setApplications(updated);
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Job Applications
+      </Typography>
+      <Stack spacing={2}>
+        {applications.map((app) => (
+          <Box
+            key={app.id}
+            sx={{ display: "flex", alignItems: "center", gap: 2 }}
+          >
+            <Box sx={{ flexGrow: 1 }}>
+              <Typography fontWeight="bold">{app.title}</Typography>
+              <Typography variant="body2" color="text.secondary">
+                {app.company} – {app.location}
+              </Typography>
+            </Box>
+            <Select
+              size="small"
+              value={app.status}
+              onChange={(e) => handleStatusChange(app.id, e)}
+            >
+              {STATUS_OPTIONS.map((status) => (
+                <MenuItem key={status} value={status}>
+                  {status.charAt(0).toUpperCase() + status.slice(1)}
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+

--- a/src/types/talentforge.ts
+++ b/src/types/talentforge.ts
@@ -1,3 +1,9 @@
+import type {
+  ApplicationStatus,
+  JobApplication,
+  JobListing,
+} from "./talentforge/job";
+
 export interface UserProfile {
   /** Unique identifier for the user. */
   id: string;
@@ -18,17 +24,6 @@ export interface Resume {
   url: string;
   /** Tags describing the resume's contents. */
   tags?: string[];
-}
-
-export interface JobApplication {
-  /** Unique identifier for the job application. */
-  id: string;
-  /** Identifier of the job listing being applied to. */
-  jobId: string;
-  /** Identifier of the resume used for the application. */
-  resumeId: string;
-  /** Current status of the application. */
-  status: ApplicationStatus;
 }
 
 export interface Message {
@@ -55,9 +50,5 @@ export interface Offer {
   accepted: boolean;
 }
 
-export type ApplicationStatus =
-  | "applied"
-  | "interview"
-  | "offer"
-  | "rejected";
+export type { JobApplication, ApplicationStatus, JobListing };
 

--- a/src/types/talentforge/job.ts
+++ b/src/types/talentforge/job.ts
@@ -18,6 +18,8 @@ export type ApplicationStatus =
   | "rejected";
 
 export interface JobApplication extends JobListing {
+  /** Unique identifier for the job application */
+  id: string;
   /** Current status of the job application */
   status: ApplicationStatus;
 }

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -1,4 +1,9 @@
-import { UserProfile, Resume, Offer } from "@/types/talentforge";
+import {
+  UserProfile,
+  Resume,
+  Offer,
+  JobApplication,
+} from "@/types/talentforge";
 
 // Sample resumes for demonstration purposes
 export const mockResumes: Resume[] = [
@@ -32,6 +37,28 @@ export const mockOffers: Offer[] = [
   },
 ];
 
+// Sample job applications for demonstration purposes
+export const mockApplications: JobApplication[] = [
+  {
+    id: "app-1",
+    title: "Frontend Developer",
+    company: "Acme Corp",
+    location: "Remote",
+    url: "https://example.com/jobs/frontend",
+    source: "linkedin",
+    status: "applied",
+  },
+  {
+    id: "app-2",
+    title: "Backend Engineer",
+    company: "Beta LLC",
+    location: "New York, NY",
+    url: "https://example.com/jobs/backend",
+    source: "indeed",
+    status: "interview",
+  },
+];
+
 // Sample user profile that references the above resumes
 export const mockUserProfile: UserProfile = {
   id: "user-1",
@@ -56,6 +83,7 @@ export function insertMockData(): void {
     localStorage.setItem("userProfile", JSON.stringify(mockUserProfile));
     localStorage.setItem("resumes", JSON.stringify(mockResumes));
     localStorage.setItem("offers", JSON.stringify(mockOffers));
+    localStorage.setItem("jobApplications", JSON.stringify(mockApplications));
     localStorage.setItem(DEMO_DATA_KEY, "true");
   } catch {
     // Ignore write errors (e.g., storage is unavailable)

--- a/src/utils/talentforge/applicationStore.ts
+++ b/src/utils/talentforge/applicationStore.ts
@@ -1,0 +1,40 @@
+import type {
+  ApplicationStatus,
+  JobApplication,
+} from "@/types/talentforge";
+
+const STORAGE_KEY = "jobApplications";
+
+export function getJobApplications(): JobApplication[] {
+  if (typeof window === "undefined") return [];
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (!stored) return [];
+  try {
+    return JSON.parse(stored) as JobApplication[];
+  } catch {
+    return [];
+  }
+}
+
+function setJobApplications(apps: JobApplication[]): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(apps));
+}
+
+export function updateJobApplicationStatus(
+  id: string,
+  status: ApplicationStatus,
+): JobApplication[] {
+  const apps = getJobApplications().map((app) =>
+    app.id === id ? { ...app, status } : app,
+  );
+  setJobApplications(apps);
+  return apps;
+}
+
+export function addJobApplication(app: JobApplication): JobApplication[] {
+  const apps = [...getJobApplications(), app];
+  setJobApplications(apps);
+  return apps;
+}
+


### PR DESCRIPTION
## Summary
- extend JobApplication model with an id and status field and re-export types
- add JobApplications component with status dropdown and data persistence
- wire up Applications page, nav item, mock data, and local storage helpers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c64958468083309101fc713cb186c7