### PR TITLE
feat: add client-side filtering utilities

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -14,6 +14,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { filterByText } from "@/utils/search";
 
 import { autoReply } from "@/utils/autoReply";
 
@@ -49,14 +50,16 @@ export default function Inbox() {
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [search, setSearch] = useState("");
 
   const handleFilterChange = (event: SelectChangeEvent) => {
     setFilter(event.target.value as "all" | "unread" | "read");
   };
 
-  const filteredMessages = MOCK_MESSAGES.filter(
-    (message) => filter === "all" || message.status === filter,
-  );
+  const filteredMessages = filterByText(MOCK_MESSAGES, search, [
+    "content",
+    "connector",
+  ]).filter((message) => filter === "all" || message.status === filter);
 
   const handleAutoReply = async (message: ConnectorMessage) => {
     const reply = await autoReply([
@@ -79,6 +82,12 @@ export default function Inbox() {
           <MenuItem value="unread">Unread</MenuItem>
           <MenuItem value="read">Read</MenuItem>
         </Select>
+        <TextField
+          label="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ maxWidth: 300 }}
+        />
         <List>
           {filteredMessages.map((message) => (
             <ListItem key={message.id} alignItems="flex-start">

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -10,6 +10,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { filterByTag, filterByText } from "@/utils/search";
 
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import OpenAiKeyModal from "./OpenAiKeyModal";
@@ -47,6 +48,8 @@ export default function ResumeManager() {
   const [resumes, setResumes] = useState<StoredResume[]>([]);
   const [text, setText] = useState("");
   const [openKeyModal, setOpenKeyModal] = useState(false);
+  const [searchText, setSearchText] = useState("");
+  const [searchTag, setSearchTag] = useState("");
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -73,6 +76,11 @@ export default function ResumeManager() {
     setText("");
   };
 
+  const filteredResumes = filterByTag(
+    filterByText(resumes, searchText, ["content"]),
+    searchTag,
+  );
+
   return (
     <Box>
       <OpenAiKeyModal
@@ -91,7 +99,17 @@ export default function ResumeManager() {
         Save
       </Button>
       <Stack spacing={2} sx={{ mt: 4 }}>
-        {resumes.map((resume) => (
+        <TextField
+          label="Filter by text"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+        />
+        <TextField
+          label="Filter by tag"
+          value={searchTag}
+          onChange={(e) => setSearchTag(e.target.value)}
+        />
+        {filteredResumes.map((resume) => (
           <Box key={resume.id}>
             <Typography variant="subtitle1" gutterBottom>
               {resume.id}

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,20 @@
+export function filterByText<T>(items: T[], text: string, fields: (keyof T)[]): T[] {
+  if (!text) return items;
+  const query = text.toLowerCase();
+  return items.filter((item) =>
+    fields.some((field) => {
+      const value = item[field];
+      if (value === undefined || value === null) return false;
+      return String(value).toLowerCase().includes(query);
+    }),
+  );
+}
+
+export function filterByTag<T extends { tags: string[] }>(items: T[], tag: string): T[] {
+  if (!tag) return items;
+  const query = tag.toLowerCase();
+  return items.filter((item) =>
+    item.tags?.some((t) => t.toLowerCase().includes(query)),
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable search helpers for text and tag matching
- hook up resume manager to filter resumes by free text and tags
- enable inbox search for messages by content or connector

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c6495cb1c48330a5b6ce05d56d2689