### PR TITLE
Add PDF export utilities and buttons

### DIFF
--- a/src/components/talentforge/ChatAssistant.tsx
+++ b/src/components/talentforge/ChatAssistant.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Box,
   Button,
@@ -13,6 +13,7 @@ import {
 
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
 import { ChatMessage } from "@/types/talentforge/types";
 
@@ -20,6 +21,7 @@ export default function ChatAssistant() {
   const [selectedPrompt, setSelectedPrompt] = useState<string>("");
   const [chatHistory, setChatHistory] = useState<(ChatMessage | null)[]>([]);
   const [openKeyModal, setOpenKeyModal] = useState(false);
+  const chatRef = useRef<HTMLDivElement>(null);
 
   const handleChange = (event: SelectChangeEvent) => {
     setSelectedPrompt(event.target.value as string);
@@ -73,7 +75,17 @@ export default function ChatAssistant() {
         >
           Send
         </Button>
-        <Stack spacing={1}>
+        <Button
+          variant="outlined"
+          onClick={() =>
+            chatRef.current &&
+            exportElementToPdf(chatRef.current, "chat-history.pdf")
+          }
+          disabled={chatHistory.length === 0}
+        >
+          Export
+        </Button>
+        <Stack spacing={1} ref={chatRef}>
           {chatHistory.map(
             (chat, index) =>
               chat && (

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
 
 interface StoredResume {
@@ -101,6 +102,17 @@ export default function ResumeManager() {
                 <Chip key={tag} label={tag} sx={{ mb: 1 }} />
               ))}
             </Stack>
+            <Button
+              size="small"
+              sx={{ mt: 1 }}
+              onClick={() => {
+                const temp = document.createElement("div");
+                temp.textContent = resume.content;
+                exportElementToPdf(temp, `${resume.id}.pdf`);
+              }}
+            >
+              Export
+            </Button>
           </Box>
         ))}
       </Stack>

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -1,0 +1,20 @@
+export async function exportElementToPdf(element: HTMLElement, fileName = "export.pdf") {
+  if (typeof window === "undefined") return;
+  try {
+    const { jsPDF } = await import("jspdf");
+    const doc = new jsPDF();
+    doc.text(element.innerText, 10, 10);
+    doc.save(fileName);
+  } catch {
+    const printWindow = window.open("", "_blank");
+    if (!printWindow) {
+      window.print();
+      return;
+    }
+    printWindow.document.write(element.outerHTML);
+    printWindow.document.close();
+    printWindow.focus();
+    printWindow.print();
+    printWindow.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add PDF export helper using jsPDF with window.print fallback
- add export button to ChatAssistant for saving chat history
- add per-resume export button in ResumeManager

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c6495e65e0833092aa70f80c854143