### PR TITLE
feat: add connector interface and implement

### DIFF
--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -1,0 +1,10 @@
+export interface Connector {
+  /** Authenticate with the external service. */
+  authenticate(): Promise<void>;
+
+  /** Fetch data from the service. */
+  fetchData(): Promise<unknown>;
+
+  /** Send a message through the service. */
+  sendMessage(message: string): Promise<void>;
+}

--- a/src/utils/indeedConnector.ts
+++ b/src/utils/indeedConnector.ts
@@ -5,6 +5,8 @@
  * can be developed without access to the real Indeed services.
  */
 
+import { Connector } from "../types/connector";
+
 export interface IndeedProfile {
   id: string;
   name: string;
@@ -24,72 +26,72 @@ export interface IndeedMessage {
   body: string;
 }
 
-/**
- * Retrieve the user's profile from Indeed.
- *
- * A production implementation would call an endpoint such as
- * `https://api.indeed.com/v1/profile` with an API key:
- *
- * ```ts
- * const response = await fetch("https://api.indeed.com/v1/profile", {
- *   headers: { Authorization: `Bearer ${apiKey}` },
- * });
- * const data = (await response.json()) as IndeedProfile;
- * return data;
- * ```
- */
-export async function fetchProfile(): Promise<IndeedProfile> {
-  return {
-    id: "abc",
-    name: "Grace Hopper",
-    resumeTitle: "Computer Scientist",
-  };
-}
+export class IndeedConnector implements Connector {
+  /**
+   * Authenticate with Indeed.
+   *
+   * This mock implementation performs no action.
+   */
+  async authenticate(): Promise<void> {
+    // No authentication needed for mocked connector
+  }
 
-/**
- * Search for jobs on Indeed.
- *
- * In reality this would send a request like
- * `https://api.indeed.com/v2/jobs?q=${encodeURIComponent(query)}` and parse the
- * JSON response.
- */
-export async function searchJobs(query: string): Promise<IndeedJob[]> {
-  void query;
-  return [
-    {
-      id: "j1",
-      title: "Frontend Developer",
-      company: "Indeed",
-      location: "Austin, TX",
-    },
-    {
-      id: "j2",
-      title: "Data Analyst",
-      company: "Indeed",
-      location: "New York, NY",
-    },
-  ];
-}
+  /**
+   * Retrieve the user's profile from Indeed.
+   */
+  async fetchData(): Promise<IndeedProfile> {
+    return {
+      id: "abc",
+      name: "Grace Hopper",
+      resumeTitle: "Computer Scientist",
+    };
+  }
 
-/**
- * Fetch recent messages from the Indeed messaging platform.
- *
- * A real implementation would call an endpoint like
- * `https://api.indeed.com/v1/messages` with the appropriate credentials and
- * return the parsed JSON.
- */
-export async function fetchMessages(): Promise<IndeedMessage[]> {
-  return [
-    {
-      id: "m1",
-      from: "Recruiter",
-      body: "Your application looks promising. Let's talk!",
-    },
-    {
-      id: "m2",
-      from: "Indeed Support",
-      body: "Your job alert has been created.",
-    },
-  ];
-}
+  /**
+   * Send a message through Indeed.
+   *
+   * This mock simply resolves without performing any action.
+   */
+  async sendMessage(message: string): Promise<void> {
+    void message; // silence unused parameter in mock implementation
+  }
 
+  /**
+   * Search for jobs on Indeed.
+   */
+  async searchJobs(query: string): Promise<IndeedJob[]> {
+    void query;
+    return [
+      {
+        id: "j1",
+        title: "Frontend Developer",
+        company: "Indeed",
+        location: "Austin, TX",
+      },
+      {
+        id: "j2",
+        title: "Data Analyst",
+        company: "Indeed",
+        location: "New York, NY",
+      },
+    ];
+  }
+
+  /**
+   * Fetch recent messages from the Indeed messaging platform.
+   */
+  async fetchMessages(): Promise<IndeedMessage[]> {
+    return [
+      {
+        id: "m1",
+        from: "Recruiter",
+        body: "Your application looks promising. Let's talk!",
+      },
+      {
+        id: "m2",
+        from: "Indeed Support",
+        body: "Your job alert has been created.",
+      },
+    ];
+  }
+}

--- a/src/utils/linkedinConnector.ts
+++ b/src/utils/linkedinConnector.ts
@@ -6,6 +6,8 @@
  * can be developed without live API access.
  */
 
+import { Connector } from "../types/connector";
+
 export interface LinkedInProfile {
   id: string;
   firstName: string;
@@ -26,84 +28,77 @@ export interface LinkedInMessage {
   body: string;
 }
 
-/**
- * Retrieve the authenticated user's profile from LinkedIn.
- *
- * In a real implementation this would make an authenticated HTTP request to
- * `https://api.linkedin.com/v2/me` using an OAuth access token:
- *
- * ```ts
- * const response = await fetch("https://api.linkedin.com/v2/me", {
- *   headers: { Authorization: `Bearer ${token}` },
- * });
- * const data = (await response.json()) as LinkedInProfile;
- * return data;
- * ```
- *
- * Here we return sample data for development.
- */
-export async function fetchProfile(): Promise<LinkedInProfile> {
-  return {
-    id: "123",
-    firstName: "Ada",
-    lastName: "Lovelace",
-    headline: "Pioneer of Computing",
-  };
-}
+export class LinkedInConnector implements Connector {
+  /**
+   * Authenticate with LinkedIn.
+   *
+   * This mock implementation performs no action.
+   */
+  async authenticate(): Promise<void> {
+    // No authentication needed for mocked connector
+  }
 
-/**
- * Search LinkedIn jobs.
- *
- * A production version would query LinkedIn's job search endpoint, for example:
- *
- * ```ts
- * const response = await fetch(
- *   `https://api.linkedin.com/v2/jobSearch?q=${encodeURIComponent(query)}`,
- *   { headers: { Authorization: `Bearer ${token}` } }
- * );
- * const jobs = (await response.json()) as LinkedInJob[];
- * return jobs;
- * ```
- *
- * This mock returns a static list of jobs.
- */
-export async function searchJobs(query: string): Promise<LinkedInJob[]> {
-  void query; // silence unused parameter in mock implementation
-  return [
-    {
-      id: "1",
-      title: "Software Engineer",
-      company: "LinkedIn",
-      location: "Remote",
-    },
-    {
-      id: "2",
-      title: "Product Manager",
-      company: "LinkedIn",
-      location: "San Francisco, CA",
-    },
-  ];
-}
+  /**
+   * Retrieve the authenticated user's profile from LinkedIn.
+   *
+   * Here we return sample data for development.
+   */
+  async fetchData(): Promise<LinkedInProfile> {
+    return {
+      id: "123",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      headline: "Pioneer of Computing",
+    };
+  }
 
-/**
- * Fetch recent LinkedIn messages.
- *
- * In production this would call something like
- * `https://api.linkedin.com/v2/messages` with the appropriate authorization
- * header and return the parsed JSON response.
- */
-export async function fetchMessages(): Promise<LinkedInMessage[]> {
-  return [
-    {
-      id: "m1",
-      from: "Recruiter",
-      body: "We came across your profile and would love to chat.",
-    },
-    {
-      id: "m2",
-      from: "Colleague",
-      body: "Great work on the recent project!",
-    },
-  ];
-}
+  /**
+   * Send a message through LinkedIn.
+   *
+   * This mock simply resolves without performing any action.
+   */
+  async sendMessage(message: string): Promise<void> {
+    void message; // silence unused parameter in mock implementation
+  }
 
+  /**
+   * Search LinkedIn jobs.
+   *
+   * This mock returns a static list of jobs.
+   */
+  async searchJobs(query: string): Promise<LinkedInJob[]> {
+    void query; // silence unused parameter in mock implementation
+    return [
+      {
+        id: "1",
+        title: "Software Engineer",
+        company: "LinkedIn",
+        location: "Remote",
+      },
+      {
+        id: "2",
+        title: "Product Manager",
+        company: "LinkedIn",
+        location: "San Francisco, CA",
+      },
+    ];
+  }
+
+  /**
+   * Fetch recent LinkedIn messages.
+   */
+  async fetchMessages(): Promise<LinkedInMessage[]> {
+    return [
+      {
+        id: "m1",
+        from: "Recruiter",
+        body: "We came across your profile and would love to chat.",
+      },
+      {
+        id: "m2",
+        from: "Colleague",
+        body: "Great work on the recent project!",
+      },
+    ];
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable Connector interface with auth, data, and messaging methods
- refactor LinkedIn connector to class implementing Connector
- refactor Indeed connector to class implementing Connector

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c64963fd088330ab250c1b5df32a11