### PR TITLE
Add Petly project page and resume entry

### DIFF
--- a/src/app/petly/page.tsx
+++ b/src/app/petly/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { Container, Typography } from "@mui/material";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function PetlyPage() {
+  const { setDocumentTitle } = useDocumentTitle();
+  useEffect(() => {
+    setDocumentTitle("Petly");
+  }, [setDocumentTitle]);
+
+  return (
+    <Container sx={{ py: 8 }}>
+      <Typography variant="h4" gutterBottom>
+        Petly
+      </Typography>
+      <video
+        src="/demovideos/petly.mov"
+        controls
+        style={{ width: "100%", maxWidth: 800 }}
+      />
+      <Typography variant="body1" sx={{ mt: 2 }}>
+        Petly blended a Facebook-style experience for pet owners with
+        full veterinary health records—vaccinations, x-rays, visits, and
+        invoices. Built at IDEXX, the portal transformed boxy Liferay
+        widgets into a playful notebook of sticky notes, lists, and
+        photos.
+      </Typography>
+    </Container>
+  );
+}

--- a/src/consts/resumeData.ts
+++ b/src/consts/resumeData.ts
@@ -315,6 +315,15 @@ export const projects: {
     interestsMeWhy:
       "Turning clinical events into podcasts explores a novel medium for physician updates. It combines summarization, text-to-speech, and healthcare data.",
   },
+  {
+    name: "Petly",
+    description:
+      "Pet owner portal mixing a social feed with full veterinary EHR access including vaccinations, x-rays, visits, and invoices.",
+    href: "/petly",
+    type: "work",
+    interestsMeWhy:
+      "At IDEXX we reshaped boxy Liferay portals into a playful notebook of sticky notes, lists, and photos—no square portlets in sight.",
+  },
 ];
 
 export const recognition: {


### PR DESCRIPTION
## Summary
- add Petly project entry highlighting veterinary social portal and EHR features
- create Petly page with embedded demo video and description

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c64ad4e05c83308c5ecf1353a48514