### PR TITLE
Add TalentForge env example and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ TalentForge integrates with several external services. Copy `.env.local.example`
 
 Launch the TalentForge page and follow the onboarding wizard for initial configuration steps.
 
+For a minimal setup you can copy `talentforge.env.example` to `talentforge.env` and provide:
+
+- `NEXT_PUBLIC_OPENAI_KEY` – OpenAI API key.
+- `NEXT_PUBLIC_APP_NAME` – application name displayed in the UI.
+
 ## Getting Started
 
 First, run the development server:

--- a/talentforge.env.example
+++ b/talentforge.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for TalentForge
+NEXT_PUBLIC_OPENAI_KEY=your_openai_key
+NEXT_PUBLIC_APP_NAME=TalentForge


### PR DESCRIPTION
## Summary
- add `talentforge.env.example` with basic variables
- document how to use the new env file in the TalentForge setup instructions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c64c43509c8330a49d74a03346d74e