### PR TITLE
docs: add TalentForge overview

### DIFF
--- a/docs/talentforge.md
+++ b/docs/talentforge.md
@@ -1,0 +1,43 @@
+# TalentForge
+
+## Setup
+
+1. Install dependencies and start the development server.
+   ```bash
+   npm install
+   npm run dev
+   ```
+2. Copy `.env.local.example` to `.env.local` and provide the required API keys and endpoints for services such as OpenAI, Indeed, LinkedIn, Gmail, and the TalentForge storage API.
+3. Visit `http://localhost:3000/talentforge` and follow the onboarding wizard.
+
+## Data Model Overview
+
+TalentForge uses TypeScript interfaces to describe core entities:
+
+- **UserProfile** – user identifier, display name, email, and associated resumes.
+- **Resume** – file metadata and optional tags for the uploaded resume.
+- **JobListing** – title, company, location, URL, and source of a job post.
+- **JobApplication** – extends `JobListing` with an `id` and an application status (`applied`, `interview`, `offer`, or `rejected`).
+- **Message** – sender, recipient, timestamp, and message body.
+- **Offer** – compensation details tied to a specific application.
+- **ChatMessage** – conversational messages exchanged with the AI assistant.
+
+## Connector Architecture
+
+Connectors abstract external services behind a common interface defined in `src/types/connector.ts`. Each connector implements:
+
+- `authenticate()` – prepare access to the service.
+- `fetchData()` – retrieve data such as profiles or job listings.
+- `sendMessage(message)` – deliver outbound messages.
+
+The repository includes mocked connectors for LinkedIn and Indeed in `src/utils/` that return sample data so the application can run without live API access. Additional connectors can follow the same pattern.
+
+## Mock Data Instructions
+
+During development the connectors provide static responses. To adjust mock data:
+
+1. Edit the connector files in `src/utils/` (for example `linkedinConnector.ts` or `indeedConnector.ts`).
+2. Update the returned objects or arrays to reflect the scenarios you want to test.
+3. Restart the dev server to load the new mock data.
+
+These mocks allow front‑end development and integration testing without relying on external APIs.


### PR DESCRIPTION
## Summary
- document TalentForge setup steps and local onboarding
- outline TalentForge data models and connector interface
- describe mock connector usage for local development

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c64c43e2d8833087874f3ac6579512