### PR TITLE
Add Jest setup and tests for talentforge utilities

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  testMatch: ['**/src/tests/**/*.test.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: {
+        module: 'commonjs',
+      },
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -42,6 +43,9 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/src/tests/talentforge/autoReply.test.ts
+++ b/src/tests/talentforge/autoReply.test.ts
@@ -1,0 +1,37 @@
+import { setOpenAIKey, hasOpenAIKey, autoReply, AutoReplyMessage } from "../../utils/autoReply";
+
+describe("autoReply utilities", () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+    setOpenAIKey("");
+  });
+
+  test("setOpenAIKey and hasOpenAIKey", () => {
+    expect(hasOpenAIKey()).toBe(false);
+    setOpenAIKey("abc");
+    expect(hasOpenAIKey()).toBe(true);
+    setOpenAIKey(" ");
+    expect(hasOpenAIKey()).toBe(false);
+  });
+
+  test("autoReply returns trimmed string content", async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      json: async () => ({ choices: [{ message: { content: " hello " } }] }),
+    });
+    setOpenAIKey("key");
+    const result = await autoReply([]);
+    expect(result).toBe("hello");
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  test("autoReply joins array content", async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      json: async () => ({
+        choices: [{ message: { content: ["foo ", { text: "bar" }, { other: "" }] } }],
+      }),
+    });
+    setOpenAIKey("key");
+    const result = await autoReply([] as AutoReplyMessage[]);
+    expect(result).toBe("foo bar ");
+  });
+});

--- a/src/tests/talentforge/promptMapper.test.ts
+++ b/src/tests/talentforge/promptMapper.test.ts
@@ -1,0 +1,13 @@
+import { getPromptFullText } from "../../utils/promptMapper";
+import { PROMPT_TEMPLATES } from "../../consts/prompts";
+
+describe("promptMapper", () => {
+  test("returns full text for known label", () => {
+    const label = Object.keys(PROMPT_TEMPLATES)[0];
+    expect(getPromptFullText(label)).toBe(PROMPT_TEMPLATES[label].fullText);
+  });
+
+  test("returns undefined for unknown label", () => {
+    expect(getPromptFullText("unknown")).toBeUndefined();
+  });
+});

--- a/src/tests/talentforge/storage.test.ts
+++ b/src/tests/talentforge/storage.test.ts
@@ -1,0 +1,43 @@
+import { saveItem, loadItem, deleteItem, listItems } from "../../utils/storage";
+
+describe("storage utilities", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("saveItem and loadItem roundtrip", () => {
+    const key = "test";
+    const value = { a: 1 };
+    saveItem(key, value, 1);
+    expect(loadItem<typeof value>(key, 1)).toEqual(value);
+  });
+
+  test("loadItem migrates older versions", () => {
+    const key = "old";
+    saveItem(key, { name: "old" }, 1);
+
+    const migrated = loadItem<{ name: string }>(
+      key,
+      2,
+      (data) => ({ name: String((data as any).name) + "2" })
+    );
+    expect(migrated).toEqual({ name: "old2" });
+    // migrated value should be stored with new version
+    expect(loadItem(key, 2)).toEqual({ name: "old2" });
+  });
+
+  test("deleteItem removes value", () => {
+    saveItem("tmp", 123, 1);
+    deleteItem("tmp");
+    expect(loadItem("tmp", 1)).toBeUndefined();
+  });
+
+  test("listItems respects prefix and version", () => {
+    saveItem("p:one", 1, 1);
+    saveItem("p:two", 2, 2); // different version
+    saveItem("other", 3, 1);
+
+    const items = listItems<number>("p:", 1);
+    expect(items).toEqual({ "p:one": 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest and jsdom
- add tests for storage, promptMapper, and autoReply utilities
- wire npm test to run Jest suites

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c64c4cb0f48330a89ebde19f00dcb9