### PR TITLE
chore: improve talentforge accessibility

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,13 @@
+# Accessibility Audit
+
+## Overview
+An accessibility audit was attempted on the TalentForge pages using the Axe CLI. The CLI installation failed with an HTTP 403 error, indicating the package registry was inaccessible from the current environment.
+
+## Implemented Improvements
+- Labeled the main navigation toolbar and added ARIA labels to the Sign In and Sign Up buttons.
+- Added ARIA labels to the user question input and all file upload controls, including the Browse and Remove File buttons.
+- Marked the application status selector with an ARIA label.
+- Labeled the newsletter subscription button for screen readers.
+
+## Next Steps
+Once the CLI access issue is resolved, run Axe against `/talentforge` and `/talentforge/applications` to validate accessibility and address any remaining issues.

--- a/src/components/talentforge/AppAppBar.tsx
+++ b/src/components/talentforge/AppAppBar.tsx
@@ -60,6 +60,8 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
       >
         <Container maxWidth="lg">
           <Toolbar
+            component="nav"
+            aria-label="main navigation"
             variant="regular"
             sx={(theme) => ({
               display: "flex",
@@ -152,6 +154,7 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
                 component="a"
                 href="/material-ui/getting-started/templates/sign-in/"
                 target="_blank"
+                aria-label="sign in"
               >
                 Sign in
               </Button>
@@ -162,6 +165,7 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
                 component="a"
                 href="/material-ui/getting-started/templates/sign-up/"
                 target="_blank"
+                aria-label="sign up"
               >
                 Sign up
               </Button>
@@ -221,6 +225,7 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
                       component="a"
                       href="/material-ui/getting-started/templates/sign-up/"
                       target="_blank"
+                      aria-label="sign up"
                       sx={{ width: "100%" }}
                     >
                       Sign up
@@ -233,6 +238,7 @@ function AppAppBar({ mode, toggleColorMode }: AppAppBarProps) {
                       component="a"
                       href="/material-ui/getting-started/templates/sign-in/"
                       target="_blank"
+                      aria-label="sign in"
                       sx={{ width: "100%" }}
                     >
                       Sign in

--- a/src/components/talentforge/FileUploader.tsx
+++ b/src/components/talentforge/FileUploader.tsx
@@ -269,6 +269,7 @@ export default function FileUploader(props: FileUploaderProps) {
                   wrapperRef?.current?.click?.();
                 }}
                 sx={{ p: 1, zIndex: 1 }}
+                aria-label="browse files"
               >
                 <Box sx={{ p: 1 }}>Browse</Box>
               </Button>
@@ -283,6 +284,7 @@ export default function FileUploader(props: FileUploaderProps) {
                   onChange={handleFileInputChange}
                   multiple={limit > 1}
                   accept={accept}
+                  aria-label={label || "file uploader"}
                   style={{
                     display: "none",
                   }}
@@ -331,6 +333,7 @@ export default function FileUploader(props: FileUploaderProps) {
                         }}
                         startIcon={<CloseOutlined />}
                         color="info"
+                        aria-label="remove file"
                         sx={{
                           border: "none",
                           position: "absolute",

--- a/src/components/talentforge/Footer.tsx
+++ b/src/components/talentforge/Footer.tsx
@@ -179,6 +179,7 @@ export default function Footer() {
                 variant="contained"
                 color="primary"
                 sx={{ flexShrink: 0 }}
+                aria-label="subscribe to newsletter"
               >
                 Subscribe
               </Button>

--- a/src/components/talentforge/Hero.tsx
+++ b/src/components/talentforge/Hero.tsx
@@ -350,6 +350,7 @@ export default function Hero() {
         <OutlinedInput
           ref={userQuestionInputRef}
           placeholder="Ask talentforge anything about your PDF..."
+          aria-label="user question input"
           fullWidth
           value={userQuestion}
           onChange={(event) => setUserQuestion(event.target.value)}

--- a/src/components/talentforge/JobApplications.tsx
+++ b/src/components/talentforge/JobApplications.tsx
@@ -64,6 +64,7 @@ export default function JobApplications() {
               size="small"
               value={app.status}
               onChange={(e) => handleStatusChange(app.id, e)}
+              aria-label="application status"
             >
               {STATUS_OPTIONS.map((status) => (
                 <MenuItem key={status} value={status}>


### PR DESCRIPTION
## Summary
- add ARIA labels for navigation, buttons, and form fields on TalentForge pages
- document accessibility audit status

## Testing
- `npm run lint`
- `npx @axe-core/cli http://localhost:3000/talentforge` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c64c54b7f8833089262b00252477ec