### PR TITLE
Add TalentForge resumes page

### DIFF
--- a/src/app/talentforge/resumes/page.tsx
+++ b/src/app/talentforge/resumes/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import TalentForgeLayout from "../layout";
+import ResumeManager from "@/components/talentforge/ResumeManager";
+
+export default function ResumesPage() {
+  return (
+    <TalentForgeLayout>
+      <ResumeManager />
+    </TalentForgeLayout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add resumes page using TalentForgeLayout and ResumeManager

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Unexpected any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c64e5974ac8330b422f97920a4fd0d