### PR TITLE
Add placeholder pages for TalentForge sections

### DIFF
--- a/src/app/talentforge/inbox/page.tsx
+++ b/src/app/talentforge/inbox/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import Inbox from "@/components/talentforge/Inbox";
+
+export default function InboxPage() {
+  return <Inbox />;
+}
+

--- a/src/app/talentforge/offers/page.tsx
+++ b/src/app/talentforge/offers/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import OfferCompare from "@/components/talentforge/OfferCompare";
+
+export default function OffersPage() {
+  return <OfferCompare />;
+}
+

--- a/src/app/talentforge/resumes/page.tsx
+++ b/src/app/talentforge/resumes/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import ResumeManager from "@/components/talentforge/ResumeManager";
+
+export default function ResumesPage() {
+  return <ResumeManager />;
+}
+

--- a/src/app/talentforge/settings/page.tsx
+++ b/src/app/talentforge/settings/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import OpenAiKeyModal from "@/components/talentforge/OpenAiKeyModal";
+
+export default function SettingsPage() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box>
+      <Typography variant="h5" gutterBottom>
+        Settings
+      </Typography>
+      <Button variant="contained" onClick={() => setOpen(true)}>
+        Set OpenAI API Key
+      </Button>
+      <OpenAiKeyModal open={open} onClose={() => setOpen(false)} />
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add Resumes, Offers, Inbox, and Settings routes to TalentForge using existing shared components.
- Enable setting an OpenAI API key from the Settings page.

## Testing
- `npm run lint` *(fails: Unexpected any in existing tests)*
- `npm test` *(fails: jest not found; `npm install` returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c64e57a47483309e886618a1d04524