### PR TITLE
Add offers comparison page for TalentForge

### DIFF
--- a/src/app/talentforge/offers/page.tsx
+++ b/src/app/talentforge/offers/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import OfferCompare from "@/components/talentforge/OfferCompare";
+
+export default function OffersPage() {
+  return <OfferCompare />;
+}
+


### PR DESCRIPTION
## Summary
- add /talentforge/offers page rendering `OfferCompare`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c64e5dc6ec8330ab3d16a368c114e2