### PR TITLE
feat: add centralized talentforge data store

### DIFF
--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -3,27 +3,23 @@
 import { useEffect, useState } from "react";
 import { Box, Button, Step, StepLabel, Stepper, Typography } from "@mui/material";
 
+import {
+  getOnboardingStep,
+  setOnboardingStep,
+  clearOnboardingStep,
+} from "@/utils/talentforge/dataStore";
+
 const steps = ["Profile Info", "Upload Resume", "Connect Accounts", "Finish"];
 
 export default function OnboardingStepper() {
   const [activeStep, setActiveStep] = useState(0);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const saved = window.localStorage.getItem("onboardingStep");
-      if (saved !== null) {
-        const parsed = parseInt(saved, 10);
-        if (!Number.isNaN(parsed)) {
-          setActiveStep(parsed);
-        }
-      }
-    }
+    setActiveStep(getOnboardingStep());
   }, []);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem("onboardingStep", activeStep.toString());
-    }
+    setOnboardingStep(activeStep);
   }, [activeStep]);
 
   const handleNext = () => {
@@ -36,9 +32,7 @@ export default function OnboardingStepper() {
 
   const handleReset = () => {
     setActiveStep(0);
-    if (typeof window !== "undefined") {
-      window.localStorage.removeItem("onboardingStep");
-    }
+    clearOnboardingStep();
   };
 
   return (

--- a/src/components/talentforge/OpenAiKeyModal.tsx
+++ b/src/components/talentforge/OpenAiKeyModal.tsx
@@ -31,9 +31,6 @@ export default function OpenAiKeyModal({
     const trimmed = key.trim();
     if (!trimmed) return;
     setOpenAIKey(trimmed);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem("talentforge-openai-key", trimmed);
-    }
     handleClose();
   };
 

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -12,17 +12,15 @@ import {
 } from "@mui/material";
 import { filterByTag, filterByText } from "@/utils/search";
 
+import {
+  getResumes,
+  addResume,
+  type ResumeEntry,
+} from "@/utils/talentforge/dataStore";
+
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
-
-interface StoredResume {
-  id: string;
-  content: string;
-  tags: string[];
-}
-
-const STORAGE_KEY = "resumes";
 
 const suggestTags = async (content: string): Promise<string[]> => {
   try {
@@ -46,21 +44,14 @@ const suggestTags = async (content: string): Promise<string[]> => {
 };
 
 export default function ResumeManager() {
-  const [resumes, setResumes] = useState<StoredResume[]>([]);
+  const [resumes, setResumes] = useState<ResumeEntry[]>([]);
   const [text, setText] = useState("");
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const [searchText, setSearchText] = useState("");
   const [searchTag, setSearchTag] = useState("");
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      try {
-        setResumes(JSON.parse(stored));
-      } catch {
-        setResumes([]);
-      }
-    }
+    setResumes(getResumes());
   }, []);
 
   const handleSave = async () => {
@@ -70,10 +61,9 @@ export default function ResumeManager() {
     }
     if (!text.trim()) return;
     const tags = await suggestTags(text);
-    const newResume: StoredResume = { id: uuid(), content: text, tags };
-    const updated = [...resumes, newResume];
+    const newResume = { id: uuid(), content: text, tags };
+    const updated = addResume(newResume);
     setResumes(updated);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
     setText("");
   };
 

--- a/src/tests/talentforge/autoReply.test.ts
+++ b/src/tests/talentforge/autoReply.test.ts
@@ -2,7 +2,7 @@ import { setOpenAIKey, hasOpenAIKey, autoReply, AutoReplyMessage } from "../../u
 
 describe("autoReply utilities", () => {
   beforeEach(() => {
-    (global as any).fetch = jest.fn();
+    (global as unknown as { fetch: jest.Mock }).fetch = jest.fn();
     setOpenAIKey("");
   });
 

--- a/src/tests/talentforge/storage.test.ts
+++ b/src/tests/talentforge/storage.test.ts
@@ -19,7 +19,7 @@ describe("storage utilities", () => {
     const migrated = loadItem<{ name: string }>(
       key,
       2,
-      (data) => ({ name: String((data as any).name) + "2" })
+      (data) => ({ name: String((data as { name: unknown }).name) + "2" })
     );
     expect(migrated).toEqual({ name: "old2" });
     // migrated value should be stored with new version

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -1,0 +1,221 @@
+"use client";
+
+export interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  resumes: ResumeEntry[];
+}
+
+export interface ResumeEntry {
+  id: string;
+  content: string;
+  tags: string[];
+}
+
+export interface Message {
+  id: string;
+  from: string;
+  to: string;
+  sentAt: string;
+  body: string;
+}
+
+export interface Offer {
+  id: string;
+  applicationId: string;
+  compensation: string;
+  accepted: boolean;
+}
+
+export interface JobApplication {
+  id: string;
+  title: string;
+  company: string;
+  location: string;
+  url: string;
+  source: string;
+  status: ApplicationStatus;
+}
+
+export type ApplicationStatus =
+  | "applied"
+  | "interview"
+  | "offer"
+  | "rejected";
+
+const KEYS = {
+  user: "userProfile",
+  resumes: "resumes",
+  messages: "messages",
+  offers: "offers",
+  applications: "jobApplications",
+  onboarding: "onboardingStep",
+  openai: "talentforge-openai-key",
+} as const;
+
+function load<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  const raw = window.localStorage.getItem(key);
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function save<T>(key: string, value: T): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore write errors
+  }
+}
+
+function remove(key: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(key);
+}
+
+// User profile
+export function getUserProfile(): UserProfile | undefined {
+  return load<UserProfile | undefined>(KEYS.user, undefined);
+}
+export function saveUserProfile(profile: UserProfile): void {
+  save(KEYS.user, profile);
+}
+
+// Resumes
+export function getResumes(): ResumeEntry[] {
+  return load<ResumeEntry[]>(KEYS.resumes, []);
+}
+export function saveResumes(resumes: ResumeEntry[]): void {
+  save(KEYS.resumes, resumes);
+}
+export function addResume(resume: ResumeEntry): ResumeEntry[] {
+  const updated = [...getResumes(), resume];
+  saveResumes(updated);
+  return updated;
+}
+export function updateResume(resume: ResumeEntry): ResumeEntry[] {
+  const updated = getResumes().map((r) => (r.id === resume.id ? resume : r));
+  saveResumes(updated);
+  return updated;
+}
+export function deleteResume(id: string): ResumeEntry[] {
+  const updated = getResumes().filter((r) => r.id !== id);
+  saveResumes(updated);
+  return updated;
+}
+
+// Messages
+export function getMessages(): Message[] {
+  return load<Message[]>(KEYS.messages, []);
+}
+export function addMessage(message: Message): Message[] {
+  const updated = [...getMessages(), message];
+  save(KEYS.messages, updated);
+  return updated;
+}
+export function deleteMessage(id: string): Message[] {
+  const updated = getMessages().filter((m) => m.id !== id);
+  save(KEYS.messages, updated);
+  return updated;
+}
+
+// Offers
+export function getOffers(): Offer[] {
+  return load<Offer[]>(KEYS.offers, []);
+}
+export function addOffer(offer: Offer): Offer[] {
+  const updated = [...getOffers(), offer];
+  save(KEYS.offers, updated);
+  return updated;
+}
+export function updateOffer(offer: Offer): Offer[] {
+  const updated = getOffers().map((o) => (o.id === offer.id ? offer : o));
+  save(KEYS.offers, updated);
+  return updated;
+}
+export function deleteOffer(id: string): Offer[] {
+  const updated = getOffers().filter((o) => o.id !== id);
+  save(KEYS.offers, updated);
+  return updated;
+}
+
+// Job applications
+export function getJobApplications(): JobApplication[] {
+  return load<JobApplication[]>(KEYS.applications, []);
+}
+export function addJobApplication(app: JobApplication): JobApplication[] {
+  const updated = [...getJobApplications(), app];
+  save(KEYS.applications, updated);
+  return updated;
+}
+export function updateJobApplicationStatus(
+  id: string,
+  status: ApplicationStatus,
+): JobApplication[] {
+  const updated = getJobApplications().map((app) =>
+    app.id === id ? { ...app, status } : app,
+  );
+  save(KEYS.applications, updated);
+  return updated;
+}
+export function deleteJobApplication(id: string): JobApplication[] {
+  const updated = getJobApplications().filter((a) => a.id !== id);
+  save(KEYS.applications, updated);
+  return updated;
+}
+
+// Onboarding step
+export function getOnboardingStep(): number {
+  return load<number>(KEYS.onboarding, 0);
+}
+export function setOnboardingStep(step: number): void {
+  save(KEYS.onboarding, step);
+}
+export function clearOnboardingStep(): void {
+  remove(KEYS.onboarding);
+}
+
+// OpenAI key
+export function getOpenAIKey(): string | undefined {
+  return load<string | undefined>(KEYS.openai, undefined);
+}
+export function setOpenAIKey(key: string): void {
+  save(KEYS.openai, key);
+}
+export function deleteOpenAIKey(): void {
+  remove(KEYS.openai);
+}
+
+export default {
+  getUserProfile,
+  saveUserProfile,
+  getResumes,
+  saveResumes,
+  addResume,
+  updateResume,
+  deleteResume,
+  getMessages,
+  addMessage,
+  deleteMessage,
+  getOffers,
+  addOffer,
+  updateOffer,
+  deleteOffer,
+  getJobApplications,
+  addJobApplication,
+  updateJobApplicationStatus,
+  deleteJobApplication,
+  getOnboardingStep,
+  setOnboardingStep,
+  clearOnboardingStep,
+  getOpenAIKey,
+  setOpenAIKey,
+  deleteOpenAIKey,
+};
+

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -6,28 +6,27 @@ import { ChatMessage } from "@/types/talentforge/types";
 import { aiBufferSize } from "@/consts/talentforge/consts";
 
 import { Buffer } from "buffer";
+import {
+  getOpenAIKey as loadOpenAIKey,
+  setOpenAIKey as storeOpenAIKey,
+} from "./dataStore";
 
-const OPENAI_STORAGE_KEY = "talentforge-openai-key";
 let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || "";
 if (typeof window !== "undefined" && !apiKey) {
-  apiKey = window.localStorage.getItem(OPENAI_STORAGE_KEY) || "";
+  apiKey = loadOpenAIKey() || "";
 }
 
 export const setOpenAIKey = (key: string) => {
   apiKey = key;
-  if (typeof window !== "undefined") {
-    window.localStorage.setItem(OPENAI_STORAGE_KEY, key);
-  }
+  storeOpenAIKey(key);
 };
 
 export const hasOpenAIKey = () => {
   if (apiKey.trim().length > 0) return true;
-  if (typeof window !== "undefined") {
-    const stored = window.localStorage.getItem(OPENAI_STORAGE_KEY);
-    if (stored) {
-      apiKey = stored;
-      return true;
-    }
+  const stored = loadOpenAIKey();
+  if (stored) {
+    apiKey = stored;
+    return true;
   }
   return false;
 };


### PR DESCRIPTION
## Summary
- implement a typed `dataStore` with UserProfile, ResumeEntry, Message, Offer and JobApplication records backed by `localStorage`
- replace direct `localStorage` calls in onboarding and resume manager with dataStore helpers
- manage OpenAI API key through the shared store

## Testing
- `npm run lint` *(fails: 4 warnings)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c64e7711148330ab42c802c9b52ca0