### PR TITLE
feat: add TalentForge data context

### DIFF
--- a/src/app/talentforge/layout.tsx
+++ b/src/app/talentforge/layout.tsx
@@ -10,6 +10,7 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import { ThemeProvider } from '@mui/material/styles';
 import talentforgeTheme from '@/themes/talentforgeTheme';
+import { TalentForgeDataProvider } from '@/contexts/TalentForgeDataContext';
 
 export default function TalentForgeLayout({
   children,
@@ -26,24 +27,26 @@ export default function TalentForgeLayout({
   ];
 
   return (
-    <ThemeProvider theme={talentforgeTheme}>
-      <CssBaseline />
-      <Box sx={{ display: 'flex' }}>
-        <Box component="nav" sx={{ width: 240, flexShrink: 0 }}>
-          <List>
-            {navItems.map(({ label, href }) => (
-              <ListItem key={label} disablePadding>
-                <ListItemButton component={Link} href={href}>
-                  <ListItemText primary={label} />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
+    <TalentForgeDataProvider>
+      <ThemeProvider theme={talentforgeTheme}>
+        <CssBaseline />
+        <Box sx={{ display: 'flex' }}>
+          <Box component="nav" sx={{ width: 240, flexShrink: 0 }}>
+            <List>
+              {navItems.map(({ label, href }) => (
+                <ListItem key={label} disablePadding>
+                  <ListItemButton component={Link} href={href}>
+                    <ListItemText primary={label} />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+          </Box>
+          <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+            {children}
+          </Box>
         </Box>
-        <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-          {children}
-        </Box>
-      </Box>
-    </ThemeProvider>
+      </ThemeProvider>
+    </TalentForgeDataProvider>
   );
 }

--- a/src/contexts/TalentForgeDataContext.tsx
+++ b/src/contexts/TalentForgeDataContext.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import * as dataStore from '@/utils/talentforge/dataStore';
+
+const TalentForgeDataContext = React.createContext<typeof dataStore | undefined>(undefined);
+
+export function TalentForgeDataProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <TalentForgeDataContext.Provider value={dataStore}>
+      {children}
+    </TalentForgeDataContext.Provider>
+  );
+}
+
+export function useTalentForgeData() {
+  const context = React.useContext(TalentForgeDataContext);
+  if (!context) {
+    throw new Error('useTalentForgeData must be used within a TalentForgeDataProvider');
+  }
+  return context;
+}
+
+export default TalentForgeDataContext;


### PR DESCRIPTION
## Summary
- create `TalentForgeDataContext` to expose `dataStore` via React context
- wrap `TalentForgeLayout` with `TalentForgeDataProvider`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65177eb108330b561dc788e150a93