### PR TITLE
Fix dealer bust winnings calculation

### DIFF
--- a/go/blackjack/dealer/dealer.go
+++ b/go/blackjack/dealer/dealer.go
@@ -519,7 +519,7 @@ func PayWinners(payBlackjacks bool, payAllOthers bool, updateStats bool) {
 							game.State.Wins += 1
 							currPlayer.LastHandWon = true
 							currPlayer.LastHandPushed = false
-							currPlayer.Winnings += 2 * hand.Wager
+							currPlayer.Winnings += hand.Wager
 							currPlayer.WinStreak += 1
 						}
 					} else if dealerValue == playerValue {


### PR DESCRIPTION
## Summary
- correct player winnings when dealer busts so payout matches wager

## Testing
- `cd go/blackjack && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c654570b7883309c5036d603a1f7b8