### PR TITLE
Add data export/import support

### DIFF
--- a/src/app/talentforge/settings/page.tsx
+++ b/src/app/talentforge/settings/page.tsx
@@ -15,6 +15,7 @@ import {
 
 import OpenAiKeyModal from "@/components/talentforge/OpenAiKeyModal";
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
+import { exportToJson, importFromJson } from "@/utils/talentforge/dataStore";
 
 export default function TalentForgeSettingsPage() {
   const [openKeyModal, setOpenKeyModal] = React.useState(false);
@@ -30,6 +31,31 @@ export default function TalentForgeSettingsPage() {
       window.localStorage.removeItem("talentforge-openai-key");
     }
     setOpenAiKeySet(false);
+  };
+
+  const handleExport = () => {
+    const data = exportToJson();
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "talentforge-data.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result;
+      if (typeof text === "string") {
+        importFromJson(text);
+        setOpenAiKeySet(hasOpenAIKey());
+      }
+    };
+    reader.readAsText(file);
   };
 
   const handleCloseModal = () => {
@@ -78,6 +104,31 @@ export default function TalentForgeSettingsPage() {
             </ListItem>
           </List>
         </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Data
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Export or import your stored TalentForge data.
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button onClick={handleExport} variant="contained">
+            Export Data
+          </Button>
+          <Button component="label">
+            Import Data
+            <input
+              type="file"
+              accept="application/json"
+              hidden
+              onChange={handleImport}
+            />
+          </Button>
+        </CardActions>
       </Card>
 
       <OpenAiKeyModal open={openKeyModal} onClose={handleCloseModal} />

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -192,6 +192,41 @@ export function deleteOpenAIKey(): void {
   remove(KEYS.openai);
 }
 
+// Export / Import
+export function exportToJson(): string {
+  if (typeof window === "undefined") return "{}";
+  const data: Record<string, unknown> = {};
+  for (const key of Object.values(KEYS)) {
+    const raw = window.localStorage.getItem(key);
+    if (raw !== null) {
+      try {
+        data[key] = JSON.parse(raw);
+      } catch {
+        data[key] = raw;
+      }
+    }
+  }
+  return JSON.stringify(data, null, 2);
+}
+
+export function importFromJson(json: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const data = JSON.parse(json) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(data)) {
+      if (Object.values(KEYS).includes(key as any)) {
+        try {
+          window.localStorage.setItem(key, JSON.stringify(value));
+        } catch {
+          // ignore write errors
+        }
+      }
+    }
+  } catch {
+    // ignore parse errors
+  }
+}
+
 export default {
   getUserProfile,
   saveUserProfile,
@@ -217,5 +252,7 @@ export default {
   getOpenAIKey,
   setOpenAIKey,
   deleteOpenAIKey,
+  exportToJson,
+  importFromJson,
 };
 


### PR DESCRIPTION
## Summary
- allow data store to serialize and import JSON
- add export/import controls to TalentForge settings

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c653f081e483308df4b6e80b2839e3