### PR TITLE
feat: add connector token storage

### DIFF
--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -1,10 +1,25 @@
-export interface Connector {
-  /** Authenticate with the external service. */
-  authenticate(): Promise<void>;
+/**
+ * Token returned from authenticating with an external service.
+ */
+export interface ConnectorToken {
+  /** Access token used for API requests. */
+  accessToken: string;
+  /** Optional refresh token for renewing access. */
+  refreshToken?: string;
+  /** Epoch timestamp when the access token expires. */
+  expiresAt?: number;
+}
 
-  /** Fetch data from the service. */
-  fetchData(): Promise<unknown>;
+/**
+ * Generic connector interface for integrating external services.
+ */
+export interface Connector<T = unknown> {
+  /** Authenticate with the external service and return credentials. */
+  authenticate(): Promise<ConnectorToken>;
 
-  /** Send a message through the service. */
-  sendMessage(message: string): Promise<void>;
+  /** Fetch data from the service using the provided token. */
+  fetchData(token: ConnectorToken): Promise<T>;
+
+  /** Send a message through the service using the provided token. */
+  sendMessage(token: ConnectorToken, message: string): Promise<void>;
 }

--- a/src/utils/indeedConnector.ts
+++ b/src/utils/indeedConnector.ts
@@ -5,7 +5,7 @@
  * can be developed without access to the real Indeed services.
  */
 
-import { Connector } from "../types/connector";
+import { Connector, ConnectorToken } from "../types/connector";
 
 export interface IndeedProfile {
   id: string;
@@ -26,20 +26,21 @@ export interface IndeedMessage {
   body: string;
 }
 
-export class IndeedConnector implements Connector {
+export class IndeedConnector implements Connector<IndeedProfile> {
   /**
    * Authenticate with Indeed.
    *
    * This mock implementation performs no action.
    */
-  async authenticate(): Promise<void> {
-    // No authentication needed for mocked connector
+  async authenticate(): Promise<ConnectorToken> {
+    // Mocked connector returns a static token
+    return { accessToken: "mock-indeed-token" };
   }
 
   /**
    * Retrieve the user's profile from Indeed.
    */
-  async fetchData(): Promise<IndeedProfile> {
+  async fetchData(_: ConnectorToken): Promise<IndeedProfile> {
     return {
       id: "abc",
       name: "Grace Hopper",
@@ -52,8 +53,8 @@ export class IndeedConnector implements Connector {
    *
    * This mock simply resolves without performing any action.
    */
-  async sendMessage(message: string): Promise<void> {
-    void message; // silence unused parameter in mock implementation
+  async sendMessage(_: ConnectorToken, message: string): Promise<void> {
+    void message; // silence unused parameters in mock implementation
   }
 
   /**

--- a/src/utils/linkedinConnector.ts
+++ b/src/utils/linkedinConnector.ts
@@ -6,7 +6,7 @@
  * can be developed without live API access.
  */
 
-import { Connector } from "../types/connector";
+import { Connector, ConnectorToken } from "../types/connector";
 
 export interface LinkedInProfile {
   id: string;
@@ -28,14 +28,15 @@ export interface LinkedInMessage {
   body: string;
 }
 
-export class LinkedInConnector implements Connector {
+export class LinkedInConnector implements Connector<LinkedInProfile> {
   /**
    * Authenticate with LinkedIn.
    *
    * This mock implementation performs no action.
    */
-  async authenticate(): Promise<void> {
-    // No authentication needed for mocked connector
+  async authenticate(): Promise<ConnectorToken> {
+    // Mocked connector returns a static token
+    return { accessToken: "mock-linkedin-token" };
   }
 
   /**
@@ -43,7 +44,7 @@ export class LinkedInConnector implements Connector {
    *
    * Here we return sample data for development.
    */
-  async fetchData(): Promise<LinkedInProfile> {
+  async fetchData(_: ConnectorToken): Promise<LinkedInProfile> {
     return {
       id: "123",
       firstName: "Ada",
@@ -57,8 +58,8 @@ export class LinkedInConnector implements Connector {
    *
    * This mock simply resolves without performing any action.
    */
-  async sendMessage(message: string): Promise<void> {
-    void message; // silence unused parameter in mock implementation
+  async sendMessage(_: ConnectorToken, message: string): Promise<void> {
+    void message; // silence unused parameters in mock implementation
   }
 
   /**

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { ConnectorToken } from "@/types/connector";
+
 export interface UserProfile {
   id: string;
   name: string;
@@ -52,6 +54,7 @@ const KEYS = {
   applications: "jobApplications",
   onboarding: "onboardingStep",
   openai: "talentforge-openai-key",
+  connectorTokens: "connectorTokens",
 } as const;
 
 function load<T>(key: string, fallback: T): T {
@@ -192,6 +195,36 @@ export function deleteOpenAIKey(): void {
   remove(KEYS.openai);
 }
 
+// Connector tokens
+interface ConnectorTokenMap {
+  [name: string]: ConnectorToken;
+}
+
+function getConnectorTokens(): ConnectorTokenMap {
+  return load<ConnectorTokenMap>(KEYS.connectorTokens, {});
+}
+
+export function getConnectorToken(
+  connector: string,
+): ConnectorToken | undefined {
+  return getConnectorTokens()[connector];
+}
+
+export function saveConnectorToken(
+  connector: string,
+  token: ConnectorToken,
+): void {
+  const tokens = getConnectorTokens();
+  tokens[connector] = token;
+  save(KEYS.connectorTokens, tokens);
+}
+
+export function deleteConnectorToken(connector: string): void {
+  const tokens = getConnectorTokens();
+  delete tokens[connector];
+  save(KEYS.connectorTokens, tokens);
+}
+
 export default {
   getUserProfile,
   saveUserProfile,
@@ -217,5 +250,8 @@ export default {
   getOpenAIKey,
   setOpenAIKey,
   deleteOpenAIKey,
+  getConnectorToken,
+  saveConnectorToken,
+  deleteConnectorToken,
 };
 


### PR DESCRIPTION
## Summary
- define `ConnectorToken` and generic `Connector` interfaces
- persist connector tokens in TalentForge data store
- update mocked connectors to use token-aware methods

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c653f1e09c8330b4a97f28fe6e46a6