### PR TITLE
Add mocked LinkedIn connector for TalentForge

### DIFF
--- a/src/utils/talentforge/connectors/linkedin.ts
+++ b/src/utils/talentforge/connectors/linkedin.ts
@@ -1,0 +1,53 @@
+import { Connector } from "@/types/connector";
+import type { JobListing } from "@/types/talentforge/job";
+
+export interface LinkedInProfile {
+  id: string;
+  firstName: string;
+  lastName: string;
+  headline: string;
+}
+
+export interface LinkedInData {
+  profile: LinkedInProfile;
+  listings: JobListing[];
+}
+
+export class LinkedInConnector implements Connector {
+  async authenticate(): Promise<void> {
+    // Mocked connector does not require authentication
+  }
+
+  async fetchData(): Promise<LinkedInData> {
+    return {
+      profile: {
+        id: "ln-123",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        headline: "Pioneer of Computing",
+      },
+      listings: [
+        {
+          title: "Software Engineer",
+          company: "LinkedIn",
+          location: "Remote",
+          url: "https://www.linkedin.com/jobs/123",
+          source: "linkedin",
+        },
+        {
+          title: "Product Manager",
+          company: "LinkedIn",
+          location: "San Francisco, CA",
+          url: "https://www.linkedin.com/jobs/456",
+          source: "linkedin",
+        },
+      ],
+    };
+  }
+
+  async sendMessage(message: string): Promise<void> {
+    void message; // mock does nothing
+  }
+}
+
+export default LinkedInConnector;


### PR DESCRIPTION
## Summary
- implement LinkedIn connector under TalentForge utilities
- return mock profile and job listings for development use

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c653f829a88330b845ba8d7538a4de