### PR TITLE
docs: clarify RandomCardUniform test on cards.One exclusion

### DIFF
--- a/go/blackjack/random/random_test.go
+++ b/go/blackjack/random/random_test.go
@@ -8,7 +8,9 @@ import (
 	"blackjack/cards"
 )
 
-// TestRandomCardUniform ensures each rank is equally likely.
+// TestRandomCardUniform ensures each rank is equally likely, intentionally
+// excluding cards.One from the distribution. The value cards.One represents a
+// demoted ace and should never be dealt by RandomCard.
 func TestRandomCardUniform(t *testing.T) {
 	defer rand.Seed(time.Now().UnixNano())
 	rand.Seed(1)


### PR DESCRIPTION
## Summary
- mention that `cards.One` is intentionally skipped when sampling random cards
- explain that `cards.One` represents a demoted ace and should not appear

## Testing
- `go test ./...` in `go/blackjack`


------
https://chatgpt.com/codex/tasks/task_e_68c6545c28688330b069b8a70ca39c52