### PR TITLE
Fix typo in blackjack payout comment

### DIFF
--- a/go/blackjack/dealer/dealer.go
+++ b/go/blackjack/dealer/dealer.go
@@ -480,7 +480,7 @@ func PayWinners(payBlackjacks bool, payAllOthers bool, updateStats bool) {
 				} else {
 					if rules.IsBlackjack(*hand) {
 						if payBlackjacks {
-							// you win time and a half + orignal bet
+							// you win time and a half + original bet
 							winnings := hand.Wager + (hand.Wager / 2.0) + hand.Wager
 							currPlayer.Stack += winnings
 							game.State.House -= winnings


### PR DESCRIPTION
## Summary
- fix spelling in blackjack payout comment

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68c6545093b88330b8bebbeffa0c9902