### PR TITLE
feat: aggregate job listings and seed initial applications

### DIFF
--- a/src/components/talentforge/JobApplications.tsx
+++ b/src/components/talentforge/JobApplications.tsx
@@ -9,14 +9,17 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
+import { v4 as uuid } from "uuid";
 import type {
   ApplicationStatus,
   JobApplication,
 } from "@/types/talentforge";
 import {
+  addJobApplication,
   getJobApplications,
   updateJobApplicationStatus,
 } from "@/utils/talentforge/applicationStore";
+import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
 
 const STATUS_OPTIONS: ApplicationStatus[] = [
   "applied",
@@ -29,7 +32,23 @@ export default function JobApplications() {
   const [applications, setApplications] = useState<JobApplication[]>([]);
 
   useEffect(() => {
-    setApplications(getJobApplications());
+    const existing = getJobApplications();
+    if (existing.length === 0) {
+      // Seed applications using aggregated listings from connectors
+      fetchAllListings().then((listings) => {
+        let apps = existing;
+        listings.forEach((listing) => {
+          apps = addJobApplication({
+            ...listing,
+            id: uuid(),
+            status: "applied",
+          });
+        });
+        setApplications(apps);
+      });
+    } else {
+      setApplications(existing);
+    }
   }, []);
 
   const handleStatusChange = (

--- a/src/utils/talentforge/jobAggregator.ts
+++ b/src/utils/talentforge/jobAggregator.ts
@@ -1,0 +1,30 @@
+import type { JobListing } from "@/types/talentforge/job";
+import { LinkedInConnector, type LinkedInData } from "./connectors/linkedin";
+import { IndeedConnector } from "./connectors/indeed";
+
+/**
+ * Fetch job listings from all supported connectors and combine the results.
+ *
+ * This utility currently aggregates listings from the mocked LinkedIn and
+ * Indeed connectors used within TalentForge. Each connector returns listings in
+ * the {@link JobListing} format, or data that contains such listings. The
+ * aggregator normalises these responses into a single array.
+ */
+export async function fetchAllListings(): Promise<JobListing[]> {
+  const linkedin = new LinkedInConnector();
+  const indeed = new IndeedConnector();
+
+  // Fetch data from both connectors in parallel.
+  const [linkedinData, indeedListings] = await Promise.all<[
+    LinkedInData,
+    JobListing[],
+  ]>([linkedin.fetchData(), indeed.fetchData()]);
+
+  // LinkedIn returns an object with a `listings` property whereas Indeed
+  // returns the listings array directly. Combine and return them.
+  return [...linkedinData.listings, ...indeedListings];
+}
+
+export default {
+  fetchAllListings,
+};


### PR DESCRIPTION
## Summary
- add TalentForge jobAggregator to combine LinkedIn and Indeed listings
- seed job applications using aggregated listings on first visit

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*

------
https://chatgpt.com/codex/tasks/task_e_68c6568bb5448330b5374082cc7a3ba3