### PR TITLE
Add expanded prompt templates

### DIFF
--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -44,7 +44,7 @@ export default function OfferCompare() {
       return;
     }
     const context = `Offer Letter:\n${offerText}\n\nCurrent Compensation:\n${compensation}`;
-    const prompt = PROMPT_TEMPLATES["Negotiate Offer"]?.fullText || "";
+    const prompt = PROMPT_TEMPLATES.negotiateOffer?.fullText || "";
     setLoading(true);
     const response = await askOpenAI({
       context,

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -14,9 +14,59 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Draft a concise cover letter highlighting why you are a great fit for the role.",
   },
-  "Negotiate Offer": {
+  negotiateOffer: {
     displayText: "Negotiate Offer",
     fullText:
       "Review the job offer alongside the current compensation and suggest negotiation strategies. Draft a polite response to the employer summarizing your position.",
+  },
+  interviewPreparation: {
+    displayText: "Interview Preparation",
+    fullText:
+      "Suggest five common interview questions for this role and tips on how to answer them.",
+  },
+  salaryResearch: {
+    displayText: "Salary Research",
+    fullText:
+      "Provide a market salary range for this role in the specified location based on recent data.",
+  },
+  skillGapAnalysis: {
+    displayText: "Skill Gap Analysis",
+    fullText:
+      "Analyze the job description and highlight any skills you may need to develop to be competitive.",
+  },
+  jobDescriptionRewrite: {
+    displayText: "Job Description Rewrite",
+    fullText:
+      "Rewrite the job description to emphasize candidate requirements and key deliverables for internal sharing.",
+  },
+  networkingOutreach: {
+    displayText: "Networking Outreach",
+    fullText:
+      "Draft a message to connect with professionals in this industry or company for networking purposes.",
+  },
+  portfolioReview: {
+    displayText: "Portfolio Review",
+    fullText:
+      "Review your project portfolio and suggest improvements or missing pieces that would strengthen it.",
+  },
+  elevatorPitch: {
+    displayText: "Elevator Pitch",
+    fullText:
+      "Craft a concise elevator pitch summarizing your background and career aspirations.",
+  },
+  projectSummary: {
+    displayText: "Project Summary",
+    fullText:
+      "Summarize this project in a paragraph highlighting challenges, solutions, and outcomes.",
+  },
+  careerGoals: {
+    displayText: "Career Goals",
+    fullText:
+      "Outline your short-term and long-term career goals along with actionable steps to achieve them.",
+  },
+  linkedinProfileOptimization: {
+    displayText: "LinkedIn Profile Optimization",
+    fullText:
+      "Provide tips to optimize your LinkedIn profile so recruiters in your field can find you more easily.",
   },
 };


### PR DESCRIPTION
## Summary
- expand prompt template library with negotiation, interview, networking, and other career prompts
- rename Negotiate Offer key for clearer mapping and update usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6569bb8b083309d1aee525a234c91