### PR TITLE
feat: add grouped prompt selector

### DIFF
--- a/src/components/talentforge/ChatAssistant.tsx
+++ b/src/components/talentforge/ChatAssistant.tsx
@@ -1,21 +1,14 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import {
-  Box,
-  Button,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { Box, Button, Stack, Typography } from "@mui/material";
 
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
 import { ChatMessage } from "@/types/talentforge/types";
+import PromptSelector from "./PromptSelector";
 
 export default function ChatAssistant() {
   const [selectedPrompt, setSelectedPrompt] = useState<string>("");
@@ -39,10 +32,6 @@ export default function ChatAssistant() {
   }, [chatHistory]);
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const chatRef = useRef<HTMLDivElement>(null);
-
-  const handleChange = (event: SelectChangeEvent) => {
-    setSelectedPrompt(event.target.value as string);
-  };
 
   const handleSubmit = () => {
     if (!selectedPrompt) return;
@@ -70,21 +59,7 @@ export default function ChatAssistant() {
         onClose={() => setOpenKeyModal(false)}
       />
       <Stack spacing={2}>
-        <Select
-          value={selectedPrompt}
-          onChange={handleChange}
-          displayEmpty
-          fullWidth
-        >
-          <MenuItem value="" disabled>
-            Select a prompt
-          </MenuItem>
-          {Object.entries(PROMPT_TEMPLATES).map(([key, { displayText }]) => (
-            <MenuItem key={key} value={key}>
-              {displayText}
-            </MenuItem>
-          ))}
-        </Select>
+        <PromptSelector value={selectedPrompt} onChange={setSelectedPrompt} />
         <Button
           variant="contained"
           onClick={handleSubmit}

--- a/src/components/talentforge/PromptSelector.tsx
+++ b/src/components/talentforge/PromptSelector.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React from "react";
+import {
+  MenuItem,
+  Select,
+  ListSubheader,
+  SelectChangeEvent,
+} from "@mui/material";
+
+import { PROMPT_TEMPLATES, PROMPT_GROUPS } from "@/consts/prompts";
+
+interface PromptSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function PromptSelector({ value, onChange }: PromptSelectorProps) {
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    onChange(event.target.value as string);
+  };
+
+  return (
+    <Select value={value} onChange={handleChange} displayEmpty fullWidth>
+      <MenuItem value="" disabled>
+        Select a prompt
+      </MenuItem>
+      {Object.entries(PROMPT_GROUPS).map(([group, keys]) => (
+        <React.Fragment key={group}>
+          <ListSubheader>{group}</ListSubheader>
+          {keys.map((key) => {
+            const template = PROMPT_TEMPLATES[key];
+            if (!template) return null;
+            return (
+              <MenuItem key={key} value={key}>
+                {template.displayText}
+              </MenuItem>
+            );
+          })}
+        </React.Fragment>
+      ))}
+    </Select>
+  );
+}
+

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -70,3 +70,16 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
       "Provide tips to optimize your LinkedIn profile so recruiters in your field can find you more easily.",
   },
 };
+
+export const PROMPT_GROUPS: Record<string, string[]> = {
+  Resumes: ["resumeSummary", "coverLetter", "portfolioReview", "projectSummary"],
+  Offers: ["negotiateOffer", "salaryResearch"],
+  "Recruiter Replies": ["interviewPreparation", "networkingOutreach"],
+  "Career Growth": [
+    "skillGapAnalysis",
+    "jobDescriptionRewrite",
+    "careerGoals",
+    "elevatorPitch",
+    "linkedinProfileOptimization",
+  ],
+};


### PR DESCRIPTION
## Summary
- add prompt groups for resumes, offers, recruiter replies, and career growth
- introduce `PromptSelector` component for grouped prompt selection
- integrate `PromptSelector` into `ChatAssistant`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c659a3c600833095e16e15a3ce77ea