### PR TITLE
feat: add resume file uploader

### DIFF
--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -18,9 +18,14 @@ import {
   type ResumeEntry,
 } from "@/utils/talentforge/dataStore";
 
-import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import {
+  askOpenAI,
+  hasOpenAIKey,
+  pdfToMarkdown,
+} from "@/utils/talentforge/utils";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
+import FileUploader from "./FileUploader";
 
 const suggestTags = async (content: string): Promise<string[]> => {
   try {
@@ -77,6 +82,22 @@ export default function ResumeManager() {
       <OpenAiKeyModal
         open={openKeyModal}
         onClose={() => setOpenKeyModal(false)}
+      />
+      <FileUploader
+        accept=".pdf,.txt,.md"
+        label="Upload your resume"
+        outputType="files"
+        sx={{ mb: 2 }}
+        onChange={async (filesFromParam) => {
+          const files = filesFromParam as File[];
+          if (!files || files.length === 0) return;
+          const file = files[0];
+          const content =
+            file.type === "application/pdf"
+              ? await pdfToMarkdown(file)
+              : await file.text();
+          setText(content);
+        }}
       />
       <TextField
         label="Paste your resume"


### PR DESCRIPTION
## Summary
- allow resume uploads with FileUploader
- parse uploaded PDFs to markdown and populate textarea

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*

------
https://chatgpt.com/codex/tasks/task_e_68c659a5f5c883309931aa41ab02cb75