### PR TITLE
feat: add resume-job comparison

### DIFF
--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Button,
   Chip,
+  CircularProgress,
   Stack,
   TextField,
   Typography,
@@ -19,6 +20,7 @@ import {
 } from "@/utils/talentforge/dataStore";
 
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
 
@@ -46,6 +48,9 @@ const suggestTags = async (content: string): Promise<string[]> => {
 export default function ResumeManager() {
   const [resumes, setResumes] = useState<ResumeEntry[]>([]);
   const [text, setText] = useState("");
+  const [jobDescription, setJobDescription] = useState("");
+  const [comparison, setComparison] = useState("");
+  const [loadingCompare, setLoadingCompare] = useState(false);
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const [searchText, setSearchText] = useState("");
   const [searchTag, setSearchTag] = useState("");
@@ -67,6 +72,28 @@ export default function ResumeManager() {
     setText("");
   };
 
+  const handleCompare = async () => {
+    if (!hasOpenAIKey()) {
+      setOpenKeyModal(true);
+      return;
+    }
+    if (!text.trim() || !jobDescription.trim()) return;
+    const context = `Resume:\n${text}\n\nJob Description:\n${jobDescription}`;
+    const prompt = PROMPT_TEMPLATES.compareResumeToJob?.fullText || "";
+    setLoadingCompare(true);
+    const response = await askOpenAI({
+      context,
+      user: prompt,
+      system:
+        "You are an assistant that compares resumes to job descriptions and highlights matches and gaps.",
+      chatHistory: [],
+      returnFirstResponse: true,
+      logMessagesToChatHistory: false,
+    });
+    setComparison(response?.message || "");
+    setLoadingCompare(false);
+  };
+
   const filteredResumes = filterByTag(
     filterByText(resumes, searchText, ["content"]),
     searchTag,
@@ -86,9 +113,42 @@ export default function ResumeManager() {
         value={text}
         onChange={(e) => setText(e.target.value)}
       />
-      <Button variant="contained" sx={{ mt: 2 }} onClick={handleSave}>
-        Save
-      </Button>
+      <TextField
+        label="Paste job description"
+        multiline
+        minRows={6}
+        fullWidth
+        sx={{ mt: 2 }}
+        value={jobDescription}
+        onChange={(e) => setJobDescription(e.target.value)}
+      />
+      <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
+        <Button variant="contained" onClick={handleSave}>
+          Save
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={handleCompare}
+          disabled={!text || !jobDescription || loadingCompare}
+        >
+          Compare to Job
+        </Button>
+      </Stack>
+      {loadingCompare && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+          <CircularProgress />
+        </Box>
+      )}
+      {comparison && (
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="h6" gutterBottom>
+            Comparison Result
+          </Typography>
+          <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+            {comparison}
+          </Typography>
+        </Box>
+      )}
       <Stack spacing={2} sx={{ mt: 4 }}>
         <TextField
           label="Filter by text"

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -34,6 +34,11 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Analyze the job description and highlight any skills you may need to develop to be competitive.",
   },
+  compareResumeToJob: {
+    displayText: "Compare Resume to Job",
+    fullText:
+      "Compare your resume to the job description, highlighting strong matches and gaps to address.",
+  },
   jobDescriptionRewrite: {
     displayText: "Job Description Rewrite",
     fullText:


### PR DESCRIPTION
## Summary
- add "Compare Resume to Job" prompt template for reuse across TalentForge tools
- extend ResumeManager to accept job descriptions and request a resume-vs-job analysis from OpenAI

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c659a920508330bb2122ac2eb23e4a