### PR TITLE
Persist offer analysis and list past offers

### DIFF
--- a/src/app/talentforge/offers/page.tsx
+++ b/src/app/talentforge/offers/page.tsx
@@ -1,8 +1,55 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import Markdown from "react-markdown";
+import {
+  Box,
+  Stack,
+  Typography,
+} from "@mui/material";
+
 import OfferCompare from "@/components/talentforge/OfferCompare";
+import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
 
 export default function OffersPage() {
-  return <OfferCompare />;
+  const [offers, setOffers] = useState<Offer[]>([]);
+
+  const refreshOffers = () => {
+    setOffers(getOffers());
+  };
+
+  useEffect(() => {
+    refreshOffers();
+  }, []);
+
+  return (
+    <Box>
+      <OfferCompare onSave={refreshOffers} />
+      {offers.length > 0 && (
+        <Stack spacing={2} sx={{ mt: 4 }}>
+          <Typography variant="h6">Past Offers</Typography>
+          {offers.map((offer) => (
+            <Box
+              key={offer.id}
+              sx={{ border: "1px solid", borderColor: "divider", p: 2, borderRadius: 1 }}
+            >
+              <Typography variant="subtitle2" gutterBottom>
+                Current Compensation
+              </Typography>
+              <Typography variant="body2" gutterBottom>
+                {offer.compensation}
+              </Typography>
+              <Typography variant="subtitle2" gutterBottom>
+                Draft Response
+              </Typography>
+              <Typography variant="body2" component="div">
+                <Markdown>{offer.result}</Markdown>
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
 }
 

--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Markdown from "react-markdown";
+import { v4 as uuid } from "uuid";
 
 import {
   Box,
@@ -16,8 +17,13 @@ import FileUploader from "./FileUploader";
 import { askOpenAI, pdfToMarkdown, hasOpenAIKey } from "@/utils/talentforge/utils";
 import OpenAiKeyModal from "./OpenAiKeyModal";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
+import { addOffer } from "@/utils/talentforge/dataStore";
 
-export default function OfferCompare() {
+interface OfferCompareProps {
+  onSave?: () => void;
+}
+
+export default function OfferCompare({ onSave }: OfferCompareProps) {
   const [offerText, setOfferText] = useState("");
   const [compensation, setCompensation] = useState("");
   const [result, setResult] = useState("");
@@ -54,8 +60,11 @@ export default function OfferCompare() {
       chatHistory: [],
       returnFirstResponse: true,
     });
-    setResult(response?.message || "");
+    const message = response?.message || "";
+    setResult(message);
+    addOffer({ id: uuid(), offerText, compensation, result: message });
     setLoading(false);
+    onSave?.();
   };
 
   return (

--- a/src/types/talentforge.ts
+++ b/src/types/talentforge.ts
@@ -42,12 +42,12 @@ export interface Message {
 export interface Offer {
   /** Unique identifier for the offer. */
   id: string;
-  /** Identifier of the related job application. */
-  applicationId: string;
-  /** Proposed salary or compensation. */
+  /** Original text of the offer letter. */
+  offerText: string;
+  /** Current compensation details provided by the user. */
   compensation: string;
-  /** Whether the offer has been accepted. */
-  accepted: boolean;
+  /** Generated negotiation draft or analysis. */
+  result: string;
 }
 
 export type { JobApplication, ApplicationStatus, JobListing };

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -25,9 +25,9 @@ export interface Message {
 
 export interface Offer {
   id: string;
-  applicationId: string;
+  offerText: string;
   compensation: string;
-  accepted: boolean;
+  result: string;
 }
 
 export interface JobApplication {


### PR DESCRIPTION
## Summary
- Save offer letter comparisons to local data store
- Display previously analyzed offers on the Offers page
- Document offer fields in shared TalentForge types

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c659b1376c8330a482f25a74aadcd3