### PR TITLE
feat: persist messages and add thread view

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   Button,
@@ -17,51 +17,32 @@ import {
 import { filterByText } from "@/utils/search";
 
 import { autoReply } from "@/utils/autoReply";
-
-interface ConnectorMessage {
-  id: string;
-  connector: string;
-  content: string;
-  status: "unread" | "read";
-}
-
-const MOCK_MESSAGES: ConnectorMessage[] = [
-  {
-    id: "1",
-    connector: "LinkedIn",
-    content: "Hi, we'd like to connect with you regarding an opportunity.",
-    status: "unread",
-  },
-  {
-    id: "2",
-    connector: "Email",
-    content: "Your application has been received.",
-    status: "read",
-  },
-  {
-    id: "3",
-    connector: "Github",
-    content: "Invitation to collaborate on a project.",
-    status: "unread",
-  },
-];
+import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import { Message } from "@/utils/talentforge/dataStore";
+import { v4 as uuidv4 } from "uuid";
 
 export default function Inbox() {
+  const data = useTalentForgeData();
+  const [messages, setMessages] = useState<Message[]>([]);
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [search, setSearch] = useState("");
 
+  useEffect(() => {
+    setMessages(data.getMessages());
+  }, [data]);
+
   const handleFilterChange = (event: SelectChangeEvent) => {
     setFilter(event.target.value as "all" | "unread" | "read");
   };
 
-  const filteredMessages = filterByText(MOCK_MESSAGES, search, [
+  const filteredMessages = filterByText(messages, search, [
     "content",
     "connector",
   ]).filter((message) => filter === "all" || message.status === filter);
 
-  const handleAutoReply = async (message: ConnectorMessage) => {
+  const handleAutoReply = async (message: Message) => {
     const reply = await autoReply([
       {
         role: "system",
@@ -71,6 +52,31 @@ export default function Inbox() {
       { role: "user", content: message.content },
     ]);
     setDrafts((d) => ({ ...d, [message.id]: reply }));
+  };
+
+  const handleSendReply = (message: Message) => {
+    const text = drafts[message.id];
+    if (!text) return;
+    const reply = { id: uuidv4(), content: text, sentAt: new Date().toISOString() };
+    const updated = data.addMessageReply(message.id, reply);
+    setMessages(updated);
+    setDrafts((d) => ({ ...d, [message.id]: "" }));
+  };
+
+  const handleToggleStatus = (message: Message) => {
+    const updated = data.updateMessageStatus(
+      message.id,
+      message.status === "unread" ? "read" : "unread",
+    );
+    setMessages(updated);
+  };
+
+  const handleOpenThread = (message: Message) => {
+    setReplyingTo((current) => (current === message.id ? null : message.id));
+    if (message.status === "unread") {
+      const updated = data.updateMessageStatus(message.id, "read");
+      setMessages(updated);
+    }
   };
 
   return (
@@ -100,18 +106,21 @@ export default function Inbox() {
                   }
                   secondary={message.content}
                 />
-                <Button
-                  size="small"
-                  onClick={() =>
-                    setReplyingTo((current) =>
-                      current === message.id ? null : message.id,
-                    )
-                  }
-                >
-                  Reply
-                </Button>
+                <Stack direction="row" spacing={1}>
+                  <Button size="small" onClick={() => handleOpenThread(message)}>
+                    Reply
+                  </Button>
+                  <Button size="small" onClick={() => handleToggleStatus(message)}>
+                    {message.status === "unread" ? "Mark read" : "Mark unread"}
+                  </Button>
+                </Stack>
                 {replyingTo === message.id && (
                   <Stack spacing={2} sx={{ mt: 1 }}>
+                    {message.replies.map((r) => (
+                      <Typography key={r.id} variant="body2">
+                        {r.content}
+                      </Typography>
+                    ))}
                     <TextField
                       label="Your reply"
                       multiline
@@ -122,13 +131,15 @@ export default function Inbox() {
                         setDrafts((d) => ({ ...d, [message.id]: e.target.value }))
                       }
                     />
-                    <Button
-                      size="small"
-                      onClick={() => handleAutoReply(message)}
-                    >
+                    <Button size="small" onClick={() => handleAutoReply(message)}>
                       Generate Reply
                     </Button>
-                    <Button variant="contained">Send</Button>
+                    <Button
+                      variant="contained"
+                      onClick={() => handleSendReply(message)}
+                    >
+                      Send
+                    </Button>
                   </Stack>
                 )}
               </Stack>

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -15,12 +15,18 @@ export interface ResumeEntry {
   tags: string[];
 }
 
+export interface MessageReply {
+  id: string;
+  content: string;
+  sentAt: string;
+}
+
 export interface Message {
   id: string;
-  from: string;
-  to: string;
-  sentAt: string;
-  body: string;
+  connector: string;
+  content: string;
+  status: "unread" | "read";
+  replies: MessageReply[];
 }
 
 export interface Offer {
@@ -124,6 +130,25 @@ export function addMessage(message: Message): Message[] {
 }
 export function deleteMessage(id: string): Message[] {
   const updated = getMessages().filter((m) => m.id !== id);
+  save(KEYS.messages, updated);
+  return updated;
+}
+
+export function addMessageReply(id: string, reply: MessageReply): Message[] {
+  const updated = getMessages().map((m) =>
+    m.id === id ? { ...m, replies: [...m.replies, reply] } : m,
+  );
+  save(KEYS.messages, updated);
+  return updated;
+}
+
+export function updateMessageStatus(
+  id: string,
+  status: "unread" | "read",
+): Message[] {
+  const updated = getMessages().map((m) =>
+    m.id === id ? { ...m, status } : m,
+  );
   save(KEYS.messages, updated);
   return updated;
 }
@@ -272,6 +297,8 @@ const dataStore = {
   getMessages,
   addMessage,
   deleteMessage,
+  addMessageReply,
+  updateMessageStatus,
   getOffers,
   addOffer,
   updateOffer,


### PR DESCRIPTION
## Summary
- load inbox messages from dataStore instead of mock data
- persist replies and read/unread status in dataStore
- show threaded conversations with reply composer

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c659b529b8833096b2fa3d2b46e9cb