### PR TITLE
feat: add auto reply templates and selection

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -16,7 +16,11 @@ import {
 } from "@mui/material";
 import { filterByText } from "@/utils/search";
 
-import { autoReply } from "@/utils/autoReply";
+import {
+  autoReply,
+  buildAutoReplyMessages,
+  AutoReplyTemplate,
+} from "@/utils/autoReply";
 
 interface ConnectorMessage {
   id: string;
@@ -50,6 +54,7 @@ export default function Inbox() {
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [templates, setTemplates] = useState<Record<string, AutoReplyTemplate>>({});
   const [search, setSearch] = useState("");
 
   const handleFilterChange = (event: SelectChangeEvent) => {
@@ -62,14 +67,10 @@ export default function Inbox() {
   ]).filter((message) => filter === "all" || message.status === filter);
 
   const handleAutoReply = async (message: ConnectorMessage) => {
-    const reply = await autoReply([
-      {
-        role: "system",
-        content:
-          "You are a helpful assistant crafting concise professional replies to incoming messages.",
-      },
-      { role: "user", content: message.content },
-    ]);
+    const template = templates[message.id] || "general";
+    const reply = await autoReply(
+      buildAutoReplyMessages(template, message.content),
+    );
     setDrafts((d) => ({ ...d, [message.id]: reply }));
   };
 
@@ -122,6 +123,21 @@ export default function Inbox() {
                         setDrafts((d) => ({ ...d, [message.id]: e.target.value }))
                       }
                     />
+                    <Select
+                      size="small"
+                      value={templates[message.id] || "general"}
+                      onChange={(e) =>
+                        setTemplates((t) => ({
+                          ...t,
+                          [message.id]: e.target.value as AutoReplyTemplate,
+                        }))
+                      }
+                      sx={{ maxWidth: 200 }}
+                    >
+                      <MenuItem value="general">General</MenuItem>
+                      <MenuItem value="politeDecline">Politely decline</MenuItem>
+                      <MenuItem value="requestMoreInfo">Request more info</MenuItem>
+                    </Select>
                     <Button
                       size="small"
                       onClick={() => handleAutoReply(message)}

--- a/src/tests/talentforge/autoReply.test.ts
+++ b/src/tests/talentforge/autoReply.test.ts
@@ -1,4 +1,11 @@
-import { setOpenAIKey, hasOpenAIKey, autoReply, AutoReplyMessage } from "../../utils/autoReply";
+import {
+  setOpenAIKey,
+  hasOpenAIKey,
+  autoReply,
+  AutoReplyMessage,
+  buildAutoReplyMessages,
+  AUTO_REPLY_TEMPLATES,
+} from "../../utils/autoReply";
 
 describe("autoReply utilities", () => {
   const globalWithFetch = global as unknown as { fetch: jest.Mock };
@@ -35,5 +42,19 @@ describe("autoReply utilities", () => {
     setOpenAIKey("key");
     const result = await autoReply([] as AutoReplyMessage[]);
     expect(result).toBe("foo bar ");
+  });
+
+  test("buildAutoReplyMessages creates system and user messages", () => {
+    const messages = buildAutoReplyMessages(
+      "politeDecline",
+      "We are unable to proceed.",
+    );
+    expect(messages).toEqual([
+      {
+        role: "system",
+        content: AUTO_REPLY_TEMPLATES.politeDecline,
+      },
+      { role: "user", content: "We are unable to proceed." },
+    ]);
   });
 });

--- a/src/utils/autoReply.ts
+++ b/src/utils/autoReply.ts
@@ -5,6 +5,25 @@ export interface AutoReplyMessage {
   content: string;
 }
 
+export const AUTO_REPLY_TEMPLATES = {
+  general:
+    "You are a helpful assistant crafting concise professional replies to incoming messages.",
+  politeDecline:
+    "You are a helpful assistant that politely declines opportunities while maintaining professionalism.",
+  requestMoreInfo:
+    "You are a helpful assistant that requests more information when needed while remaining courteous.",
+} as const;
+
+export type AutoReplyTemplate = keyof typeof AUTO_REPLY_TEMPLATES;
+
+export const buildAutoReplyMessages = (
+  template: AutoReplyTemplate,
+  content: string,
+): AutoReplyMessage[] => [
+  { role: "system", content: AUTO_REPLY_TEMPLATES[template] },
+  { role: "user", content },
+];
+
 let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || "";
 
 export const setOpenAIKey = (key: string) => {


### PR DESCRIPTION
## Summary
- add predefined auto reply templates and builder for system prompts
- allow Inbox replies to choose a template before generating content
- test message builder for auto replies

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c659bd9bf883308ca84f8dd34b414a