### PR TITLE
fix: use valid color for uracil base

### DIFF
--- a/src/utils/dna/sequenceUtils.tsx
+++ b/src/utils/dna/sequenceUtils.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/types/dna/types";
 import { CODONS_TO_AMINO_ACIDS } from "@/consts/dna/consts";
 
+// Map each nucleotide base to a representative color for display purposes.
+// A -> lightblue, T -> lightyellow, G -> lightgreen, C -> lightpink, U -> violet.
 export function baseToColor(base: string): string {
   switch (base.toUpperCase()) {
     case "A":
@@ -19,7 +21,7 @@ export function baseToColor(base: string): string {
     case "C":
       return "lightpink";
     case "U":
-      return "lightpurple";
+      return "violet";
     default:
       return "white";
   }


### PR DESCRIPTION
## Summary
- map nucleotide bases to colors and use `violet` for uracil

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c659f913bc8330ac131fe19f3ad1df