### PR TITLE
refactor: rename sample content variable

### DIFF
--- a/src/components/dna/AddSequenceCard.tsx
+++ b/src/components/dna/AddSequenceCard.tsx
@@ -64,11 +64,13 @@ export default function AddSequenceCard({
   const loadSampleMenuOpen = Boolean(loadSampleMenuEl);
 
   const loadSample = async (sample: string) => {
-    const rawSequenceContent = await (
+    const sampleContent = await (
       await fetch(withBasePath(`/dna/examples/${sample}`))
     ).text();
 
-    parseSequence(rawSequenceContent, sample, (parsedSequence) => {
+    setRawSequenceContent(sampleContent);
+
+    parseSequence(sampleContent, sample, (parsedSequence) => {
       parsedSequence.sequence = parsedSequence.sequence.trim();
 
       onAddSequence?.(parsedSequence);


### PR DESCRIPTION
## Summary
- rename sample content variable in AddSequenceCard.loadSample
- populate textarea with fetched sample

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden installing dependencies)*
- `npm run lint` *(fails: missing @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68c65a0706e483308bd40ee7fd1e25c9