### PR TITLE
test: handle invalid JSON in loadItem

### DIFF
--- a/src/tests/talentforge/storage.test.ts
+++ b/src/tests/talentforge/storage.test.ts
@@ -29,6 +29,15 @@ describe("storage utilities", () => {
     expect(loadItem(key, 2)).toEqual({ name: "old2" });
   });
 
+  test("loadItem returns undefined for invalid JSON", () => {
+    localStorage.setItem("bad", "{not json");
+    let result: unknown;
+    expect(() => {
+      result = loadItem("bad", 1);
+    }).not.toThrow();
+    expect(result).toBeUndefined();
+  });
+
   test("deleteItem removes value", () => {
     saveItem("tmp", 123, 1);
     deleteItem("tmp");


### PR DESCRIPTION
## Summary
- add unit test ensuring storage `loadItem` handles malformed JSON without throwing

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*

------
https://chatgpt.com/codex/tasks/task_e_68c65a1664308330a9058766f3d3d09b