### PR TITLE
fix: align offer mock data and remove unused type

### DIFF
--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -25,15 +25,15 @@ export const mockResumes: Resume[] = [
 export const mockOffers: Offer[] = [
   {
     id: "offer-1",
-    applicationId: "app-1",
+    offerText: "Offer details for job application app-1",
     compensation: "$120,000",
-    accepted: false,
+    result: "",
   },
   {
     id: "offer-2",
-    applicationId: "app-2",
+    offerText: "Offer details for job application app-2",
     compensation: "$135,000 + stock",
-    accepted: true,
+    result: "",
   },
 ];
 

--- a/src/utils/talentforge/jobAggregator.ts
+++ b/src/utils/talentforge/jobAggregator.ts
@@ -1,5 +1,5 @@
 import type { JobListing } from "@/types/talentforge/job";
-import { LinkedInConnector, type LinkedInData } from "./connectors/linkedin";
+import { LinkedInConnector } from "./connectors/linkedin";
 import { IndeedConnector } from "./connectors/indeed";
 
 /**


### PR DESCRIPTION
## Summary
- align mock offer data with Offer interface
- remove unused LinkedInData import from job aggregator

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65e1958a48330a4d02abf938c5741