### PR TITLE
docs: standardize OPENAI env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ TalentForge integrates with several external services. Copy `.env.local.example`
 
 Launch the TalentForge page and follow the onboarding wizard for initial configuration steps.
 
-For a minimal setup you can copy `talentforge.env.example` to `talentforge.env` and provide:
+For quick configuration, you can copy `talentforge.env.example` to `talentforge.env` and provide:
 
-- `NEXT_PUBLIC_OPENAI_KEY` – OpenAI API key.
+- `NEXT_PUBLIC_OPENAI_API_KEY` – OpenAI API key.
 - `NEXT_PUBLIC_APP_NAME` – application name displayed in the UI.
 
 ## Getting Started

--- a/talentforge.env.example
+++ b/talentforge.env.example
@@ -1,3 +1,3 @@
 # Example environment variables for TalentForge
-NEXT_PUBLIC_OPENAI_KEY=your_openai_key
+NEXT_PUBLIC_OPENAI_API_KEY=your_openai_api_key
 NEXT_PUBLIC_APP_NAME=TalentForge


### PR DESCRIPTION
## Summary
- Reference `NEXT_PUBLIC_OPENAI_API_KEY` consistently in README and env example
- Note `talentforge.env.example` as a quick configuration option

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c65a177a588330a14754431b6852ed