### PR TITLE
fix: remove duplicate autoReply import to resolve build error

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -28,8 +28,6 @@ interface ConnectorMessage {
   content: string;
   status: "unread" | "read";
 }
-
-import { autoReply } from "@/utils/autoReply";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import { Message } from "@/utils/talentforge/dataStore";
 import { v4 as uuidv4 } from "uuid";


### PR DESCRIPTION
## Summary
- remove duplicate `autoReply` import in `Inbox` component

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c65f2f9cf483308801c31dd479c620