### PR TITLE
feat: parse resume sections

### DIFF
--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -24,6 +24,7 @@ import {
   hasOpenAIKey,
   pdfToMarkdown,
 } from "@/utils/talentforge/utils";
+import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
@@ -71,7 +72,8 @@ export default function ResumeManager() {
     }
     if (!text.trim()) return;
     const tags = await suggestTags(text);
-    const newResume = { id: uuid(), content: text, tags };
+    const parsed = parseResumeText(text);
+    const newResume = { id: uuid(), content: text, parsed, tags };
     const updated = addResume(newResume);
     setResumes(updated);
     setText("");

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { ConnectorToken } from "@/types/connector";
+import { ParsedResume } from "@/types/talentforge/resume";
 
 export interface UserProfile {
   id: string;
@@ -12,6 +13,7 @@ export interface UserProfile {
 export interface ResumeEntry {
   id: string;
   content: string;
+  parsed: ParsedResume;
   tags: string[];
 }
 

--- a/src/utils/talentforge/pdfParser.ts
+++ b/src/utils/talentforge/pdfParser.ts
@@ -3,6 +3,7 @@
 import * as pdfjs from "pdfjs-dist";
 
 import { Buffer } from "buffer";
+import { ParsedResume } from "@/types/talentforge/resume";
 
 declare global {
   interface Window {
@@ -49,5 +50,60 @@ export async function pdfToMarkdown(file: File): Promise<string> {
   }
 
   return markdown;
+}
+
+/**
+ * Naively extract sections from resume text.
+ * Everything before the first recognized section header is treated as contact information.
+ */
+export function parseResumeText(text: string): ParsedResume {
+  const lines = text.split(/\r?\n/);
+  const parsed: ParsedResume = {
+    contact: "",
+    experience: [],
+    education: [],
+    skills: [],
+  };
+
+  let current: keyof Omit<ParsedResume, "contact"> | null = null;
+  const experienceHeader = /^(work\s+)?experience/i;
+  const educationHeader = /^education/i;
+  const skillsHeader = /^skills?/i;
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    if (experienceHeader.test(line)) {
+      current = "experience";
+      continue;
+    }
+    if (educationHeader.test(line)) {
+      current = "education";
+      continue;
+    }
+    if (skillsHeader.test(line)) {
+      current = "skills";
+      continue;
+    }
+
+    if (!current) {
+      parsed.contact += (parsed.contact ? "\n" : "") + line;
+    } else {
+      parsed[current].push(line);
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Convenience helper to convert a PDF file and parse its sections.
+ */
+export async function parsePdf(
+  file: File,
+): Promise<{ text: string; parsed: ParsedResume }> {
+  const text = await pdfToMarkdown(file);
+  return { text, parsed: parseResumeText(text) };
 }
 


### PR DESCRIPTION
## Summary
- add resume text parsing to extract contact info, experience, education, and skills
- store structured `ParsedResume` alongside raw resume text
- hook up ResumeManager to save parsed resume data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c65f84483c833098e78336a5077282