### PR TITLE
Improve error handling in autoReply utility

### DIFF
--- a/src/tests/talentforge/autoReply.test.ts
+++ b/src/tests/talentforge/autoReply.test.ts
@@ -25,6 +25,7 @@ describe("autoReply utilities", () => {
 
   test("autoReply returns trimmed string content", async () => {
     (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
       json: async () => ({ choices: [{ message: { content: " hello " } }] }),
     });
     setOpenAIKey("key");
@@ -35,6 +36,7 @@ describe("autoReply utilities", () => {
 
   test("autoReply joins array content", async () => {
     (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
       json: async () => ({
         choices: [{ message: { content: ["foo ", { text: "bar" }, { other: "" }] } }],
       }),
@@ -42,6 +44,27 @@ describe("autoReply utilities", () => {
     setOpenAIKey("key");
     const result = await autoReply([] as AutoReplyMessage[]);
     expect(result).toBe("foo bar ");
+  });
+
+  test("autoReply throws on non-ok response", async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "bad",
+    });
+    setOpenAIKey("key");
+    await expect(autoReply([])).rejects.toThrow("OpenAI request failed");
+  });
+
+  test("autoReply throws on invalid JSON", async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("invalid json");
+      },
+    });
+    setOpenAIKey("key");
+    await expect(autoReply([])).rejects.toThrow("Failed to parse OpenAI response");
   });
 
   test("buildAutoReplyMessages creates system and user messages", () => {

--- a/src/utils/autoReply.ts
+++ b/src/utils/autoReply.ts
@@ -48,8 +48,19 @@ export async function autoReply(
       messages,
     }),
   });
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(
+      `OpenAI request failed: ${response.status} ${errorText}`.trim(),
+    );
+  }
 
-  const data = await response.json();
+  let data: any;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error("Failed to parse OpenAI response");
+  }
   const content = data?.choices?.[0]?.message?.content;
   if (Array.isArray(content)) {
     return (


### PR DESCRIPTION
## Summary
- Throw descriptive errors when autoReply receives a non-OK response or invalid JSON
- Expand autoReply tests to cover HTTP failures and JSON parse errors

## Testing
- `npm test` (fails: command not found)
- `npm run lint` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c66018618483308c44244080c48480