### PR TITLE
docs: clarify listItems comment

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -66,8 +66,9 @@ export function deleteItem(key: string): void {
 }
 
 /**
- * List all stored values whose keys start with the provided prefix. Only
- * entries matching `currentVersion` are returned.
+ * Return a map of key–value pairs from `localStorage` filtered by key prefix
+ * and version. Only entries whose keys start with `prefix` and whose stored
+ * version equals `currentVersion` are included.
  */
 export function listItems<T>(
   prefix = "",


### PR DESCRIPTION
## Summary
- clarify `listItems` comment to explain returning prefixed and version-filtered key–value pairs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c6601ea1d0833095609396879e0307