### PR TITLE
test: cover autoReply fetch errors

### DIFF
--- a/src/tests/talentforge/autoReply.test.ts
+++ b/src/tests/talentforge/autoReply.test.ts
@@ -15,6 +15,14 @@ describe("autoReply utilities", () => {
     setOpenAIKey("");
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    delete globalWithFetch.fetch;
+  });
+
   test("setOpenAIKey and hasOpenAIKey", () => {
     expect(hasOpenAIKey()).toBe(false);
     setOpenAIKey("abc");
@@ -42,6 +50,18 @@ describe("autoReply utilities", () => {
     setOpenAIKey("key");
     const result = await autoReply([] as AutoReplyMessage[]);
     expect(result).toBe("foo bar ");
+  });
+
+  test("autoReply throws on failed fetch response", async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: false, json: async () => ({}) });
+    setOpenAIKey("key");
+    await expect(autoReply([])).rejects.toThrow("Failed to fetch auto reply");
+  });
+
+  test("autoReply propagates fetch rejection", async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error("network error"));
+    setOpenAIKey("key");
+    await expect(autoReply([])).rejects.toThrow("network error");
   });
 
   test("buildAutoReplyMessages creates system and user messages", () => {

--- a/src/utils/autoReply.ts
+++ b/src/utils/autoReply.ts
@@ -35,19 +35,29 @@ export const hasOpenAIKey = () => apiKey.trim().length > 0;
 export async function autoReply(
   messages: AutoReplyMessage[],
 ): Promise<string> {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: "gpt-3.5-turbo",
-      temperature: 0.7,
-      top_p: 0.9,
-      messages,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        temperature: 0.7,
+        top_p: 0.9,
+        messages,
+      }),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to fetch auto reply: ${message}`);
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch auto reply");
+  }
 
   const data = await response.json();
   const content = data?.choices?.[0]?.message?.content;


### PR DESCRIPTION
## Summary
- add response.ok and catch blocks in autoReply to surface fetch failures
- extend autoReply tests for failed or rejected fetch and clean up mocks

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66023d7c48330aa771d2458e1cdce