### PR TITLE
feat: add talentforge error boundaries and skeleton loaders

### DIFF
--- a/src/app/talentforge/applications/page.tsx
+++ b/src/app/talentforge/applications/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import JobApplications from "@/components/talentforge/JobApplications";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 export default function ApplicationsPage() {
-  return <JobApplications />;
+  return (
+    <ErrorBoundary>
+      <JobApplications />
+    </ErrorBoundary>
+  );
 }
 

--- a/src/app/talentforge/inbox/page.tsx
+++ b/src/app/talentforge/inbox/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import Inbox from "@/components/talentforge/Inbox";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 export default function InboxPage() {
-  return <Inbox />;
+  return (
+    <ErrorBoundary>
+      <Inbox />
+    </ErrorBoundary>
+  );
 }
 

--- a/src/app/talentforge/offers/page.tsx
+++ b/src/app/talentforge/offers/page.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 import OfferCompare from "@/components/talentforge/OfferCompare";
 import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
@@ -23,33 +24,35 @@ export default function OffersPage() {
   }, []);
 
   return (
-    <Box>
-      <OfferCompare onSave={refreshOffers} />
-      {offers.length > 0 && (
-        <Stack spacing={2} sx={{ mt: 4 }}>
-          <Typography variant="h6">Past Offers</Typography>
-          {offers.map((offer) => (
-            <Box
-              key={offer.id}
-              sx={{ border: "1px solid", borderColor: "divider", p: 2, borderRadius: 1 }}
-            >
-              <Typography variant="subtitle2" gutterBottom>
-                Current Compensation
-              </Typography>
-              <Typography variant="body2" gutterBottom>
-                {offer.compensation}
-              </Typography>
-              <Typography variant="subtitle2" gutterBottom>
-                Draft Response
-              </Typography>
-              <Typography variant="body2" component="div">
-                <Markdown>{offer.result}</Markdown>
-              </Typography>
-            </Box>
-          ))}
-        </Stack>
-      )}
-    </Box>
+    <ErrorBoundary>
+      <Box>
+        <OfferCompare onSave={refreshOffers} />
+        {offers.length > 0 && (
+          <Stack spacing={2} sx={{ mt: 4 }}>
+            <Typography variant="h6">Past Offers</Typography>
+            {offers.map((offer) => (
+              <Box
+                key={offer.id}
+                sx={{ border: "1px solid", borderColor: "divider", p: 2, borderRadius: 1 }}
+              >
+                <Typography variant="subtitle2" gutterBottom>
+                  Current Compensation
+                </Typography>
+                <Typography variant="body2" gutterBottom>
+                  {offer.compensation}
+                </Typography>
+                <Typography variant="subtitle2" gutterBottom>
+                  Draft Response
+                </Typography>
+                <Typography variant="body2" component="div">
+                  <Markdown>{offer.result}</Markdown>
+                </Typography>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </ErrorBoundary>
   );
 }
 

--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Dashboard from "@/components/talentforge/Dashboard";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import insertMockData from "@/utils/mockData";
 
@@ -13,6 +14,10 @@ export default function TalentForgePage() {
     setDocumentTitle("TalentForge");
   }, [setDocumentTitle]);
 
-  return <Dashboard />;
+  return (
+    <ErrorBoundary>
+      <Dashboard />
+    </ErrorBoundary>
+  );
 }
 

--- a/src/app/talentforge/resumes/page.tsx
+++ b/src/app/talentforge/resumes/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import TalentForgeLayout from "../layout";
 import ResumeManager from "@/components/talentforge/ResumeManager";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 export default function ResumesPage() {
   return (
-    <TalentForgeLayout>
+    <ErrorBoundary>
       <ResumeManager />
-    </TalentForgeLayout>
+    </ErrorBoundary>
   );
 }
 

--- a/src/app/talentforge/settings/page.tsx
+++ b/src/app/talentforge/settings/page.tsx
@@ -12,6 +12,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 import OpenAiKeyModal from "@/components/talentforge/OpenAiKeyModal";
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
@@ -64,75 +65,77 @@ export default function TalentForgeSettingsPage() {
   };
 
   return (
-    <Stack spacing={4}>
-      <Card>
-        <CardContent>
-          <Typography variant="h6" gutterBottom>
-            OpenAI API Key
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {openAiKeySet ? "A key is currently stored." : "No key has been set."}
-          </Typography>
-        </CardContent>
-        <CardActions>
-          <Button variant="contained" onClick={() => setOpenKeyModal(true)}>
-            {openAiKeySet ? "Update Key" : "Set Key"}
-          </Button>
-          {openAiKeySet && (
-            <Button onClick={handleRemoveKey}>Remove Key</Button>
-          )}
-        </CardActions>
-      </Card>
+    <ErrorBoundary>
+      <Stack spacing={4}>
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              OpenAI API Key
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {openAiKeySet ? "A key is currently stored." : "No key has been set."}
+            </Typography>
+          </CardContent>
+          <CardActions>
+            <Button variant="contained" onClick={() => setOpenKeyModal(true)}>
+              {openAiKeySet ? "Update Key" : "Set Key"}
+            </Button>
+            {openAiKeySet && (
+              <Button onClick={handleRemoveKey}>Remove Key</Button>
+            )}
+          </CardActions>
+        </Card>
 
-      <Card>
-        <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Connectors
-          </Typography>
-          <List>
-            <ListItem>
-              <ListItemText
-                primary="LinkedIn"
-                secondary="Configuration coming soon"
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              Connectors
+            </Typography>
+            <List>
+              <ListItem>
+                <ListItemText
+                  primary="LinkedIn"
+                  secondary="Configuration coming soon"
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary="Indeed"
+                  secondary="Configuration coming soon"
+                />
+              </ListItem>
+            </List>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              Data
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Export or import your stored TalentForge data.
+            </Typography>
+          </CardContent>
+          <CardActions>
+            <Button onClick={handleExport} variant="contained">
+              Export Data
+            </Button>
+            <Button component="label">
+              Import Data
+              <input
+                type="file"
+                accept="application/json"
+                hidden
+                onChange={handleImport}
               />
-            </ListItem>
-            <ListItem>
-              <ListItemText
-                primary="Indeed"
-                secondary="Configuration coming soon"
-              />
-            </ListItem>
-          </List>
-        </CardContent>
-      </Card>
+            </Button>
+          </CardActions>
+        </Card>
 
-      <Card>
-        <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Data
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Export or import your stored TalentForge data.
-          </Typography>
-        </CardContent>
-        <CardActions>
-          <Button onClick={handleExport} variant="contained">
-            Export Data
-          </Button>
-          <Button component="label">
-            Import Data
-            <input
-              type="file"
-              accept="application/json"
-              hidden
-              onChange={handleImport}
-            />
-          </Button>
-        </CardActions>
-      </Card>
-
-      <OpenAiKeyModal open={openKeyModal} onClose={handleCloseModal} />
-    </Stack>
+        <OpenAiKeyModal open={openKeyModal} onClose={handleCloseModal} />
+      </Stack>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/talentforge/Dashboard.tsx
+++ b/src/components/talentforge/Dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Card, CardContent, Grid, Typography } from "@mui/material";
+import { Box, Card, CardContent, Grid, Typography, Skeleton } from "@mui/material";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 
 interface Counts {
@@ -19,6 +19,7 @@ export default function Dashboard() {
     offers: 0,
     messages: 0,
   });
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setCounts({
@@ -27,6 +28,7 @@ export default function Dashboard() {
       offers: data.getOffers().length,
       messages: data.getMessages().length,
     });
+    setLoading(false);
   }, [data]);
 
   const items = [
@@ -42,18 +44,29 @@ export default function Dashboard() {
         Dashboard
       </Typography>
       <Grid container spacing={2}>
-        {items.map((item) => (
-          <Grid key={item.label} item xs={12} sm={6} md={3}>
-            <Card>
-              <CardContent>
-                <Typography color="text.secondary" gutterBottom>
-                  {item.label}
-                </Typography>
-                <Typography variant="h4">{item.value}</Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
+        {loading
+          ? Array.from({ length: 4 }).map((_, idx) => (
+              <Grid key={idx} item xs={12} sm={6} md={3}>
+                <Card>
+                  <CardContent>
+                    <Skeleton width="60%" />
+                    <Skeleton height={40} />
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))
+          : items.map((item) => (
+              <Grid key={item.label} item xs={12} sm={6} md={3}>
+                <Card>
+                  <CardContent>
+                    <Typography color="text.secondary" gutterBottom>
+                      {item.label}
+                    </Typography>
+                    <Typography variant="h4">{item.value}</Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
       </Grid>
     </Box>
   );

--- a/src/components/talentforge/ErrorBoundary.tsx
+++ b/src/components/talentforge/ErrorBoundary.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Component, ReactNode, useEffect, useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import { usePathname } from 'next/navigation';
+
+interface BoundaryProps {
+  children: ReactNode;
+}
+
+interface BoundaryState {
+  hasError: boolean;
+}
+
+class InnerErrorBoundary extends Component<BoundaryProps, BoundaryState> {
+  state: BoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): BoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  reset = () => this.setState({ hasError: false });
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box role="alert" sx={{ p: 2 }}>
+          <Typography variant="h6" gutterBottom>
+            Something went wrong.
+          </Typography>
+          <Button variant="contained" onClick={this.reset}>
+            Try again
+          </Button>
+        </Box>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default function ErrorBoundary({ children }: BoundaryProps) {
+  const pathname = usePathname();
+  const [key, setKey] = useState(0);
+
+  useEffect(() => {
+    setKey((k) => k + 1);
+  }, [pathname]);
+
+  return <InnerErrorBoundary key={key}>{children}</InnerErrorBoundary>;
+}
+

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Skeleton,
   Stack,
   TextField,
   Typography,
@@ -60,9 +61,11 @@ export default function ResumeManager() {
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const [searchText, setSearchText] = useState("");
   const [searchTag, setSearchTag] = useState("");
+  const [loadingResumes, setLoadingResumes] = useState(true);
 
   useEffect(() => {
     setResumes(getResumes());
+    setLoadingResumes(false);
   }, []);
 
   const handleSave = async () => {
@@ -183,29 +186,33 @@ export default function ResumeManager() {
           value={searchTag}
           onChange={(e) => setSearchTag(e.target.value)}
         />
-        {filteredResumes.map((resume) => (
-          <Box key={resume.id}>
-            <Typography variant="subtitle1" gutterBottom>
-              {resume.id}
-            </Typography>
-            <Stack direction="row" spacing={1} flexWrap="wrap">
-              {resume.tags.map((tag) => (
-                <Chip key={tag} label={tag} sx={{ mb: 1 }} />
-              ))}
-            </Stack>
-            <Button
-              size="small"
-              sx={{ mt: 1 }}
-              onClick={() => {
-                const temp = document.createElement("div");
-                temp.textContent = resume.content;
-                exportElementToPdf(temp, `${resume.id}.pdf`);
-              }}
-            >
-              Export
-            </Button>
-          </Box>
-        ))}
+        {loadingResumes
+          ? Array.from({ length: 3 }).map((_, idx) => (
+              <Skeleton key={idx} variant="rectangular" height={60} />
+            ))
+          : filteredResumes.map((resume) => (
+              <Box key={resume.id}>
+                <Typography variant="subtitle1" gutterBottom>
+                  {resume.id}
+                </Typography>
+                <Stack direction="row" spacing={1} flexWrap="wrap">
+                  {resume.tags.map((tag) => (
+                    <Chip key={tag} label={tag} sx={{ mb: 1 }} />
+                  ))}
+                </Stack>
+                <Button
+                  size="small"
+                  sx={{ mt: 1 }}
+                  onClick={() => {
+                    const temp = document.createElement("div");
+                    temp.textContent = resume.content;
+                    exportElementToPdf(temp, `${resume.id}.pdf`);
+                  }}
+                >
+                  Export
+                </Button>
+              </Box>
+            ))}
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component that resets on navigation
- wrap TalentForge pages with error boundaries
- show MUI Skeleton placeholders in Dashboard and ResumeManager

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c665b1b4308330a0a039cdece8b2da