### PR TITLE
feat: validate OpenAI key before rendering AI features

### DIFF
--- a/src/components/talentforge/ChatAssistant.tsx
+++ b/src/components/talentforge/ChatAssistant.tsx
@@ -4,9 +4,13 @@ import { useEffect, useRef, useState } from "react";
 import { Box, Button, Stack, Typography } from "@mui/material";
 
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
-import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import {
+  askOpenAI,
+  hasValidOpenAIKey,
+} from "@/utils/talentforge/utils";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
+import RequireAIKey from "./RequireAIKey";
 import { ChatMessage } from "@/types/talentforge/types";
 import PromptSelector from "./PromptSelector";
 
@@ -33,11 +37,12 @@ export default function ChatAssistant() {
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const chatRef = useRef<HTMLDivElement>(null);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!selectedPrompt) return;
     const fullText = PROMPT_TEMPLATES[selectedPrompt]?.fullText;
     if (!fullText) return;
-    if (!hasOpenAIKey()) {
+    const valid = await hasValidOpenAIKey();
+    if (!valid) {
       setOpenKeyModal(true);
       return;
     }
@@ -53,57 +58,59 @@ export default function ChatAssistant() {
   };
 
   return (
-    <Box>
-      <OpenAiKeyModal
-        open={openKeyModal}
-        onClose={() => setOpenKeyModal(false)}
-      />
-      <Stack spacing={2}>
-        <PromptSelector value={selectedPrompt} onChange={setSelectedPrompt} />
-        <Button
-          variant="contained"
-          onClick={handleSubmit}
-          disabled={!selectedPrompt}
-        >
-          Send
-        </Button>
-        <Button
-          variant="outlined"
-          onClick={() =>
-            chatRef.current &&
-            exportElementToPdf(chatRef.current, "chat-history.pdf")
-          }
-          disabled={chatHistory.length === 0}
-        >
-          Export
-        </Button>
-        <Button
-          variant="text"
-          onClick={() => {
-            setChatHistory([]);
-            localStorage.removeItem("chatHistory");
-          }}
-          disabled={chatHistory.length === 0}
-        >
-          Clear
-        </Button>
-        <Stack spacing={1} ref={chatRef}>
-          {chatHistory.map(
-            (chat, index) =>
-              chat && (
-                <Box key={index}>
-                  <Typography variant="subtitle2">
-                    {chat.role === "user" ? "You" : "Assistant"}
-                  </Typography>
-                  <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-                    {chat.message}
-                  </Typography>
-                </Box>
-              )
-          )}
+    <RequireAIKey>
+      <Box>
+        <OpenAiKeyModal
+          open={openKeyModal}
+          onClose={() => setOpenKeyModal(false)}
+        />
+        <Stack spacing={2}>
+          <PromptSelector value={selectedPrompt} onChange={setSelectedPrompt} />
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={!selectedPrompt}
+          >
+            Send
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() =>
+              chatRef.current &&
+              exportElementToPdf(chatRef.current, "chat-history.pdf")
+            }
+            disabled={chatHistory.length === 0}
+          >
+            Export
+          </Button>
+          <Button
+            variant="text"
+            onClick={() => {
+              setChatHistory([]);
+              localStorage.removeItem("chatHistory");
+            }}
+            disabled={chatHistory.length === 0}
+          >
+            Clear
+          </Button>
+          <Stack spacing={1} ref={chatRef}>
+            {chatHistory.map(
+              (chat, index) =>
+                chat && (
+                  <Box key={index}>
+                    <Typography variant="subtitle2">
+                      {chat.role === "user" ? "You" : "Assistant"}
+                    </Typography>
+                    <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                      {chat.message}
+                    </Typography>
+                  </Box>
+                )
+            )}
+          </Stack>
         </Stack>
-      </Stack>
-    </Box>
+      </Box>
+    </RequireAIKey>
   );
 }
 

--- a/src/components/talentforge/RequireAIKey.tsx
+++ b/src/components/talentforge/RequireAIKey.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import { Alert, Box } from "@mui/material";
+
+import { hasValidOpenAIKey } from "@/utils/talentforge/utils";
+
+interface RequireAIKeyProps {
+  children: ReactNode;
+}
+
+export default function RequireAIKey({ children }: RequireAIKeyProps) {
+  const [hasKey, setHasKey] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const checkKey = async () => {
+      const valid = await hasValidOpenAIKey();
+      setHasKey(valid);
+    };
+    checkKey();
+  }, []);
+
+  if (hasKey === null) return null;
+  if (!hasKey) {
+    return (
+      <Box>
+        <Alert severity="warning">
+          OpenAI API key not found. Please add your key to use this feature.
+        </Alert>
+      </Box>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -31,6 +31,18 @@ export const hasOpenAIKey = () => {
   return false;
 };
 
+export const hasValidOpenAIKey = async () => {
+  if (!hasOpenAIKey()) return false;
+  try {
+    const res = await fetch("https://api.openai.com/v1/models", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
 const requestCompletion = async (systemMessage: string) => {
   const response = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",


### PR DESCRIPTION
## Summary
- add `RequireAIKey` component to hide AI features without an API key
- validate key via new `hasValidOpenAIKey` utility
- wrap chat assistant with key validation

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*


------
https://chatgpt.com/codex/tasks/task_e_68c665e935248330a6b1c181aa30206a