### PR TITLE
Refactor TalentForge data store for typed models

### DIFF
--- a/src/app/talentforge/offers/page.tsx
+++ b/src/app/talentforge/offers/page.tsx
@@ -36,17 +36,24 @@ export default function OffersPage() {
                 sx={{ border: "1px solid", borderColor: "divider", p: 2, borderRadius: 1 }}
               >
                 <Typography variant="subtitle2" gutterBottom>
-                  Current Compensation
+                  Compensation
                 </Typography>
-                <Typography variant="body2" gutterBottom>
-                  {offer.compensation}
-                </Typography>
-                <Typography variant="subtitle2" gutterBottom>
-                  Draft Response
-                </Typography>
-                <Typography variant="body2" component="div">
-                  <Markdown>{offer.result}</Markdown>
-                </Typography>
+                {offer.compensation.map((c, idx) => (
+                  <Typography key={idx} variant="body2" gutterBottom>
+                    {c.type}: {c.amount}
+                    {c.notes ? ` (${c.notes})` : ""}
+                  </Typography>
+                ))}
+                {offer.summary && (
+                  <>
+                    <Typography variant="subtitle2" gutterBottom>
+                      Draft Response
+                    </Typography>
+                    <Typography variant="body2" component="div">
+                      <Markdown>{offer.summary}</Markdown>
+                    </Typography>
+                  </>
+                )}
               </Box>
             ))}
           </Stack>

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -22,12 +22,6 @@ import {
   AutoReplyTemplate,
 } from "@/utils/autoReply";
 
-interface ConnectorMessage {
-  id: string;
-  connector: string;
-  content: string;
-  status: "unread" | "read";
-}
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import { Message } from "@/utils/talentforge/dataStore";
 import { v4 as uuidv4 } from "uuid";
@@ -50,14 +44,14 @@ export default function Inbox() {
   };
 
   const filteredMessages = filterByText(messages, search, [
-    "content",
+    "body",
     "connector",
   ]).filter((message) => filter === "all" || message.status === filter);
 
-  const handleAutoReply = async (message: ConnectorMessage) => {
+  const handleAutoReply = async (message: Message) => {
     const template = templates[message.id] || "general";
     const reply = await autoReply(
-      buildAutoReplyMessages(template, message.content),
+      buildAutoReplyMessages(template, message.body),
     );
     setDrafts((d) => ({ ...d, [message.id]: reply }));
   };
@@ -65,7 +59,7 @@ export default function Inbox() {
   const handleSendReply = (message: Message) => {
     const text = drafts[message.id];
     if (!text) return;
-    const reply = { id: uuidv4(), content: text, sentAt: new Date().toISOString() };
+    const reply = { id: uuidv4(), body: text, sentAt: new Date().toISOString() };
     const updated = data.addMessageReply(message.id, reply);
     setMessages(updated);
     setDrafts((d) => ({ ...d, [message.id]: "" }));
@@ -116,7 +110,7 @@ export default function Inbox() {
                       {message.connector}
                     </Typography>
                   }
-                  secondary={message.content}
+                  secondary={message.body}
                 />
                 <Stack direction="row" spacing={1}>
                   <Button size="small" onClick={() => handleOpenThread(message)}>
@@ -130,7 +124,7 @@ export default function Inbox() {
                   <Stack spacing={2} sx={{ mt: 1 }}>
                     {message.replies.map((r) => (
                       <Typography key={r.id} variant="body2">
-                        {r.content}
+                        {r.body}
                       </Typography>
                     ))}
                     <TextField

--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -18,6 +18,7 @@ import { askOpenAI, pdfToMarkdown, hasOpenAIKey } from "@/utils/talentforge/util
 import OpenAiKeyModal from "./OpenAiKeyModal";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import { addOffer } from "@/utils/talentforge/dataStore";
+import type { Offer } from "@/utils/talentforge/dataStore";
 
 interface OfferCompareProps {
   onSave?: () => void;
@@ -62,7 +63,13 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
     });
     const message = response?.message || "";
     setResult(message);
-    addOffer({ id: uuid(), offerText, compensation, result: message });
+    const offer: Offer = {
+      id: uuid(),
+      application: {} as any,
+      compensation: [{ type: "note", amount: 0, notes: compensation }],
+      summary: message,
+    };
+    addOffer(offer);
     setLoading(false);
     onSave?.();
   };

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -1,60 +1,58 @@
 "use client";
 
+import {
+  loadItem,
+  saveItem,
+  deleteItem,
+} from "@/utils/storage";
 import { ConnectorToken } from "@/types/connector";
+import type { ApplicationStatus } from "@/types/talentforge/job";
+import type {
+  User,
+  ResumeVariant,
+  Message as ModelMessage,
+  Offer as ModelOffer,
+  ApplicationRecord,
+  OfferComp,
+} from "@/types";
 import { ParsedResume } from "@/types/talentforge/resume";
 
-export interface UserProfile {
-  id: string;
-  name: string;
-  email: string;
-  resumes: ResumeEntry[];
-}
+export type UserProfile = User;
 
-export interface ResumeEntry {
-  id: string;
+export type ResumeEntry = ResumeVariant & {
   content: string;
   parsed: ParsedResume;
   tags: string[];
-}
+};
 
-export interface MessageReply {
+export type MessageReply = {
   id: string;
-  content: string;
+  body: string;
   sentAt: string;
-}
+};
 
-export interface Message {
-  id: string;
+export interface Message extends ModelMessage {
   connector: string;
-  content: string;
   status: "unread" | "read";
   replies: MessageReply[];
 }
 
-export interface Offer {
-  id: string;
-  offerText: string;
-  compensation: string;
-  result: string;
+export type Offer = ModelOffer;
+
+export type JobApplication = ApplicationRecord;
+
+interface StoreSchema {
+  user: UserProfile | undefined;
+  resumes: ResumeEntry[];
+  messages: Message[];
+  offers: Offer[];
+  applications: JobApplication[];
+  onboarding: number;
+  openai: string | undefined;
+  connectorTokens: Record<string, ConnectorToken>;
 }
 
-export interface JobApplication {
-  id: string;
-  title: string;
-  company: string;
-  location: string;
-  url: string;
-  source: string;
-  status: ApplicationStatus;
-}
-
-export type ApplicationStatus =
-  | "applied"
-  | "interview"
-  | "offer"
-  | "rejected";
-
-const KEYS = {
+const KEYS: { [K in keyof StoreSchema]: string } = {
   user: "userProfile",
   resumes: "resumes",
   messages: "messages",
@@ -65,45 +63,91 @@ const KEYS = {
   connectorTokens: "connectorTokens",
 } as const;
 
-function load<T>(key: string, fallback: T): T {
-  if (typeof window === "undefined") return fallback;
-  const raw = window.localStorage.getItem(key);
-  if (!raw) return fallback;
-  try {
-    return JSON.parse(raw) as T;
-  } catch {
-    return fallback;
+const VERSION: { [K in keyof StoreSchema]: number } = {
+  user: 1,
+  resumes: 1,
+  messages: 2,
+  offers: 2,
+  applications: 1,
+  onboarding: 1,
+  openai: 1,
+  connectorTokens: 1,
+} as const;
+
+function load<K extends keyof StoreSchema>(
+  key: K,
+  fallback: StoreSchema[K],
+  migrateLegacy?: (data: unknown) => StoreSchema[K],
+): StoreSchema[K] {
+  const value = loadItem<StoreSchema[K]>(KEYS[key], VERSION[key]);
+  if (value !== undefined) return value;
+  if (migrateLegacy && typeof window !== "undefined") {
+    const raw = window.localStorage.getItem(KEYS[key]);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        const migrated = migrateLegacy(parsed);
+        saveItem(KEYS[key], migrated, VERSION[key]);
+        return migrated;
+      } catch {
+        return fallback;
+      }
+    }
   }
+  return fallback;
 }
 
-function save<T>(key: string, value: T): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    // ignore write errors
-  }
+function save<K extends keyof StoreSchema>(key: K, value: StoreSchema[K]): void {
+  saveItem(KEYS[key], value, VERSION[key]);
 }
 
-function remove(key: string): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.removeItem(key);
+function remove<K extends keyof StoreSchema>(key: K): void {
+  deleteItem(KEYS[key]);
+}
+
+// Migrations
+function migrateLegacyOffers(data: unknown): Offer[] {
+  if (!Array.isArray(data)) return [];
+  return (data as any[]).map((o) => ({
+    id: o.id,
+    application: {} as ApplicationRecord,
+    compensation: [
+      { type: "note", amount: 0, notes: o.compensation } as OfferComp,
+    ],
+    summary: o.result,
+  }));
+}
+
+function migrateLegacyMessages(data: unknown): Message[] {
+  if (!Array.isArray(data)) return [];
+  return (data as any[]).map((m) => ({
+    id: m.id,
+    threadId: m.id,
+    senderId: m.connector,
+    sentAt: new Date().toISOString(),
+    body: m.content,
+    connector: m.connector,
+    status: m.status,
+    replies: Array.isArray(m.replies)
+      ? m.replies.map((r: any) => ({ id: r.id, body: r.content, sentAt: r.sentAt }))
+      : [],
+  }));
 }
 
 // User profile
 export function getUserProfile(): UserProfile | undefined {
-  return load<UserProfile | undefined>(KEYS.user, undefined);
+  return load("user", undefined);
 }
 export function saveUserProfile(profile: UserProfile): void {
-  save(KEYS.user, profile);
+  save("user", profile);
 }
 
 // Resumes
 export function getResumes(): ResumeEntry[] {
-  return load<ResumeEntry[]>(KEYS.resumes, []);
+  return load("resumes", []);
 }
 export function saveResumes(resumes: ResumeEntry[]): void {
-  save(KEYS.resumes, resumes);
+  save("resumes", resumes);
 }
 export function addResume(resume: ResumeEntry): ResumeEntry[] {
   const updated = [...getResumes(), resume];
@@ -123,27 +167,25 @@ export function deleteResume(id: string): ResumeEntry[] {
 
 // Messages
 export function getMessages(): Message[] {
-  return load<Message[]>(KEYS.messages, []);
+  return load("messages", [], migrateLegacyMessages);
 }
 export function addMessage(message: Message): Message[] {
   const updated = [...getMessages(), message];
-  save(KEYS.messages, updated);
+  save("messages", updated);
   return updated;
 }
 export function deleteMessage(id: string): Message[] {
   const updated = getMessages().filter((m) => m.id !== id);
-  save(KEYS.messages, updated);
+  save("messages", updated);
   return updated;
 }
-
 export function addMessageReply(id: string, reply: MessageReply): Message[] {
   const updated = getMessages().map((m) =>
     m.id === id ? { ...m, replies: [...m.replies, reply] } : m,
   );
-  save(KEYS.messages, updated);
+  save("messages", updated);
   return updated;
 }
-
 export function updateMessageStatus(
   id: string,
   status: "unread" | "read",
@@ -151,37 +193,37 @@ export function updateMessageStatus(
   const updated = getMessages().map((m) =>
     m.id === id ? { ...m, status } : m,
   );
-  save(KEYS.messages, updated);
+  save("messages", updated);
   return updated;
 }
 
 // Offers
 export function getOffers(): Offer[] {
-  return load<Offer[]>(KEYS.offers, []);
+  return load("offers", [], migrateLegacyOffers);
 }
 export function addOffer(offer: Offer): Offer[] {
   const updated = [...getOffers(), offer];
-  save(KEYS.offers, updated);
+  save("offers", updated);
   return updated;
 }
 export function updateOffer(offer: Offer): Offer[] {
   const updated = getOffers().map((o) => (o.id === offer.id ? offer : o));
-  save(KEYS.offers, updated);
+  save("offers", updated);
   return updated;
 }
 export function deleteOffer(id: string): Offer[] {
   const updated = getOffers().filter((o) => o.id !== id);
-  save(KEYS.offers, updated);
+  save("offers", updated);
   return updated;
 }
 
 // Job applications
 export function getJobApplications(): JobApplication[] {
-  return load<JobApplication[]>(KEYS.applications, []);
+  return load("applications", []);
 }
 export function addJobApplication(app: JobApplication): JobApplication[] {
   const updated = [...getJobApplications(), app];
-  save(KEYS.applications, updated);
+  save("applications", updated);
   return updated;
 }
 export function updateJobApplicationStatus(
@@ -191,35 +233,35 @@ export function updateJobApplicationStatus(
   const updated = getJobApplications().map((app) =>
     app.id === id ? { ...app, status } : app,
   );
-  save(KEYS.applications, updated);
+  save("applications", updated);
   return updated;
 }
 export function deleteJobApplication(id: string): JobApplication[] {
   const updated = getJobApplications().filter((a) => a.id !== id);
-  save(KEYS.applications, updated);
+  save("applications", updated);
   return updated;
 }
 
 // Onboarding step
 export function getOnboardingStep(): number {
-  return load<number>(KEYS.onboarding, 0);
+  return load("onboarding", 0);
 }
 export function setOnboardingStep(step: number): void {
-  save(KEYS.onboarding, step);
+  save("onboarding", step);
 }
 export function clearOnboardingStep(): void {
-  remove(KEYS.onboarding);
+  remove("onboarding");
 }
 
 // OpenAI key
 export function getOpenAIKey(): string | undefined {
-  return load<string | undefined>(KEYS.openai, undefined);
+  return load("openai", undefined);
 }
 export function setOpenAIKey(key: string): void {
-  save(KEYS.openai, key);
+  save("openai", key);
 }
 export function deleteOpenAIKey(): void {
-  remove(KEYS.openai);
+  remove("openai");
 }
 
 // Connector tokens
@@ -228,7 +270,7 @@ interface ConnectorTokenMap {
 }
 
 function getConnectorTokens(): ConnectorTokenMap {
-  return load<ConnectorTokenMap>(KEYS.connectorTokens, {});
+  return load("connectorTokens", {});
 }
 
 export function getConnectorToken(
@@ -243,13 +285,13 @@ export function saveConnectorToken(
 ): void {
   const tokens = getConnectorTokens();
   tokens[connector] = token;
-  save(KEYS.connectorTokens, tokens);
+  save("connectorTokens", tokens);
 }
 
 export function deleteConnectorToken(connector: string): void {
   const tokens = getConnectorTokens();
   delete tokens[connector];
-  save(KEYS.connectorTokens, tokens);
+  save("connectorTokens", tokens);
 }
 
 // Export / Import
@@ -321,6 +363,8 @@ const dataStore = {
   exportToJson,
   importFromJson,
 };
+
+export type { ResumeEntry, Message, Offer, JobApplication };
 
 export default dataStore;
 


### PR DESCRIPTION
## Summary
- Replace ad-hoc interfaces with model types in `dataStore` and add versioned, typed storage keys
- Provide migration helpers for legacy offers and messages and drop obsolete `offerText`/`result` fields
- Update TalentForge inbox and offer components to use new message and offer shapes

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden for @types/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c66760b6408330903cec54bd9f7aea