### PR TITLE
feat: add TalentForge snapshot import/export

### DIFF
--- a/src/app/talentforge/settings/page.tsx
+++ b/src/app/talentforge/settings/page.tsx
@@ -16,7 +16,7 @@ import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 import OpenAiKeyModal from "@/components/talentforge/OpenAiKeyModal";
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
-import { exportToJson, importFromJson } from "@/utils/talentforge/dataStore";
+import { exportSnapshot, importSnapshot } from "@/utils/talentforge/snapshot";
 
 export default function TalentForgeSettingsPage() {
   const [openKeyModal, setOpenKeyModal] = React.useState(false);
@@ -35,7 +35,7 @@ export default function TalentForgeSettingsPage() {
   };
 
   const handleExport = () => {
-    const data = exportToJson();
+    const data = exportSnapshot();
     const blob = new Blob([data], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -52,7 +52,7 @@ export default function TalentForgeSettingsPage() {
     reader.onload = () => {
       const text = reader.result;
       if (typeof text === "string") {
-        importFromJson(text);
+        importSnapshot(text);
         setOpenAiKeySet(hasOpenAIKey());
       }
     };

--- a/src/utils/talentforge/snapshot.ts
+++ b/src/utils/talentforge/snapshot.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  exportToJson,
+  importFromJson,
+  getUserProfile,
+  getResumes,
+  getMessages,
+  getOffers,
+  getJobApplications,
+  getOnboardingStep,
+  getOpenAIKey,
+} from "./dataStore";
+
+const SNAPSHOT_SCHEMA_VERSION = 1;
+
+interface SnapshotPayload {
+  schemaVersion: number;
+  data: Record<string, unknown>;
+}
+
+function migrateSnapshot(
+  fromVersion: number,
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  let migrated = data;
+  // Future snapshot migrations can be handled here
+  if (fromVersion < 1) {
+    // No changes needed for initial version
+    migrated = data;
+  }
+  return migrated;
+}
+
+export function exportSnapshot(): string {
+  const raw = exportToJson();
+  const payload: SnapshotPayload = {
+    schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+    data: JSON.parse(raw),
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+export function importSnapshot(json: string): void {
+  try {
+    const parsed = JSON.parse(json) as Partial<SnapshotPayload> | Record<string, unknown>;
+    let version: number;
+    let data: Record<string, unknown>;
+
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "schemaVersion" in parsed &&
+      typeof (parsed as any).schemaVersion === "number" &&
+      "data" in parsed
+    ) {
+      version = (parsed as SnapshotPayload).schemaVersion;
+      data = (parsed as SnapshotPayload).data;
+    } else {
+      // Legacy snapshot without schemaVersion
+      version = 0;
+      data = parsed as Record<string, unknown>;
+    }
+
+    if (version < SNAPSHOT_SCHEMA_VERSION) {
+      data = migrateSnapshot(version, data);
+    }
+
+    importFromJson(JSON.stringify(data));
+
+    // Trigger dataStore migrations
+    getUserProfile();
+    getResumes();
+    getMessages();
+    getOffers();
+    getJobApplications();
+    getOnboardingStep();
+    getOpenAIKey();
+  } catch {
+    // Ignore parse errors
+  }
+}
+


### PR DESCRIPTION
## Summary
- add snapshot utilities with schema version support and auto-migration
- expose snapshot import/export on TalentForge settings page

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden retrieving @types/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c668e948a08330b3a52b59ba73b5fd