### PR TITLE
feat: add resume keyword tagging with openai fallback

### DIFF
--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -25,32 +25,12 @@ import {
   hasOpenAIKey,
   pdfToMarkdown,
 } from "@/utils/talentforge/utils";
+import { tagResume } from "@/utils/talentforge/tagging";
 import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
 import FileUploader from "./FileUploader";
-
-const suggestTags = async (content: string): Promise<string[]> => {
-  try {
-    const res = await askOpenAI({
-      context: content,
-      user: "Suggest tags for this resume",
-      system:
-        "You are an assistant that extracts up to 5 concise tags from resume text. Return tags separated by commas.",
-      logMessagesToChatHistory: false,
-      returnFirstResponse: true,
-      chatHistory: [],
-    });
-    const message = res?.message?.trim() ?? "";
-    return message
-      .split(/,|\n/)
-      .map((t) => t.trim())
-      .filter(Boolean);
-  } catch {
-    return [];
-  }
-};
 
 export default function ResumeManager() {
   const [resumes, setResumes] = useState<ResumeEntry[]>([]);
@@ -69,12 +49,8 @@ export default function ResumeManager() {
   }, []);
 
   const handleSave = async () => {
-    if (!hasOpenAIKey()) {
-      setOpenKeyModal(true);
-      return;
-    }
     if (!text.trim()) return;
-    const tags = await suggestTags(text);
+    const tags = await tagResume(text);
     const parsed = parseResumeText(text);
     const newResume = { id: uuid(), content: text, parsed, tags };
     const updated = addResume(newResume);

--- a/src/utils/talentforge/tagging.ts
+++ b/src/utils/talentforge/tagging.ts
@@ -1,0 +1,63 @@
+import { askOpenAI, hasOpenAIKey } from "./utils";
+
+const KEYWORD_RULES: Record<string, string[]> = {
+  React: ["react"],
+  Python: ["python"],
+  JavaScript: ["javascript", "js"],
+  TypeScript: ["typescript", "ts"],
+  Node: ["node", "node.js", "nodejs"],
+  Java: ["java"],
+  "C++": ["c++"],
+  "C#": ["c#"],
+  AWS: ["aws", "amazon web services"],
+  Docker: ["docker"],
+};
+
+const MIN_TAGS = 3;
+
+function keywordTagging(content: string): string[] {
+  const text = content.toLowerCase();
+  return Object.entries(KEYWORD_RULES)
+    .filter(([, triggers]) => triggers.some((t) => text.includes(t)))
+    .map(([tag]) => tag);
+}
+
+export async function tagResume(content: string): Promise<string[]> {
+  const tags = keywordTagging(content);
+  if (tags.length >= MIN_TAGS) {
+    return tags.slice(0, 5);
+  }
+
+  if (hasOpenAIKey()) {
+    try {
+      const res = await askOpenAI({
+        context: content,
+        user: "Suggest tags for this resume",
+        system:
+          "You are an assistant that extracts up to 5 concise tags from resume text. Return tags separated by commas.",
+        logMessagesToChatHistory: false,
+        returnFirstResponse: true,
+        chatHistory: [],
+      });
+      const message = res?.message?.trim() ?? "";
+      const aiTags = message
+        .split(/,|\n/)
+        .map((t) => t.trim())
+        .filter(Boolean);
+      for (const t of aiTags) {
+        if (!tags.some((existing) => existing.toLowerCase() === t.toLowerCase())) {
+          tags.push(t);
+        }
+      }
+    } catch {
+      // ignore errors from OpenAI
+    }
+  }
+
+  return tags.slice(0, 5);
+}
+
+export function getKeywordTags(content: string): string[] {
+  return keywordTagging(content);
+}
+


### PR DESCRIPTION
## Summary
- add rule-based keyword tagging for resumes with optional OpenAI enrichment
- integrate tagging pipeline into ResumeManager save flow

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c669264ae48330ac24ae77f0d63b96