### PR TITLE
refactor: remove explicit any

### DIFF
--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -19,6 +19,7 @@ import OpenAiKeyModal from "./OpenAiKeyModal";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import { addOffer } from "@/utils/talentforge/dataStore";
 import type { Offer } from "@/utils/talentforge/dataStore";
+import type { ApplicationRecord } from "@/types";
 
 interface OfferCompareProps {
   onSave?: () => void;
@@ -65,7 +66,7 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
     setResult(message);
     const offer: Offer = {
       id: uuid(),
-      application: {} as any,
+      application: {} as ApplicationRecord,
       compensation: [{ type: "note", amount: 0, notes: compensation }],
       summary: message,
     };

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -106,9 +106,29 @@ function remove<K extends keyof StoreSchema>(key: K): void {
 }
 
 // Migrations
+interface LegacyOffer {
+  id: string;
+  compensation: string;
+  result: string;
+}
+
+interface LegacyMessageReply {
+  id: string;
+  content: string;
+  sentAt: string;
+}
+
+interface LegacyMessage {
+  id: string;
+  connector: string;
+  content: string;
+  status: "unread" | "read";
+  replies?: LegacyMessageReply[];
+}
+
 function migrateLegacyOffers(data: unknown): Offer[] {
   if (!Array.isArray(data)) return [];
-  return (data as any[]).map((o) => ({
+  return (data as LegacyOffer[]).map((o) => ({
     id: o.id,
     application: {} as ApplicationRecord,
     compensation: [
@@ -120,7 +140,7 @@ function migrateLegacyOffers(data: unknown): Offer[] {
 
 function migrateLegacyMessages(data: unknown): Message[] {
   if (!Array.isArray(data)) return [];
-  return (data as any[]).map((m) => ({
+  return (data as LegacyMessage[]).map((m) => ({
     id: m.id,
     threadId: m.id,
     senderId: m.connector,
@@ -129,7 +149,7 @@ function migrateLegacyMessages(data: unknown): Message[] {
     connector: m.connector,
     status: m.status,
     replies: Array.isArray(m.replies)
-      ? m.replies.map((r: any) => ({ id: r.id, body: r.content, sentAt: r.sentAt }))
+      ? m.replies.map((r) => ({ id: r.id, body: r.content, sentAt: r.sentAt }))
       : [],
   }));
 }


### PR DESCRIPTION
## Summary
- remove explicit `any` in OfferCompare by using `ApplicationRecord`
- type legacy migration helpers to avoid `any`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c6697ac1f883309e799d5382c87439