### PR TITLE
feat(talentforge): sanitize pasted resume content

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "pdfjs-dist": "^4.1.392",
     "marked": "^12.0.2",
     "pdf-lib": "^1.17.1",
+    "dompurify": "^3.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-markdown": "^10.1.0",

--- a/src/components/talentforge/ResumePaste.tsx
+++ b/src/components/talentforge/ResumePaste.tsx
@@ -6,11 +6,16 @@ import {
   Button,
   Card,
   CardContent,
+  Snackbar,
   TextField,
   Typography,
 } from "@mui/material";
 
 import useResumeParser from "@/hooks/useResumeParser";
+import { parsePastedHtml } from "@/utils/talentforge/pasteParser";
+import { parseResumeText } from "@/utils/talentforge/pdfParser";
+import { addResume } from "@/utils/talentforge/dataStore";
+import { v4 as uuid } from "uuid";
 
 interface ExtractedFields {
   name: string;
@@ -34,10 +39,16 @@ export default function ResumePaste() {
   const { resume, parseResume } = useResumeParser();
   const [input, setInput] = useState("");
   const [fields, setFields] = useState<ExtractedFields | null>(null);
+  const [toastOpen, setToastOpen] = useState(false);
 
   const handleParse = async () => {
-    const text = await parseResume(input);
+    const sanitized = parsePastedHtml(input);
+    const text = await parseResume(sanitized);
+    setInput(text);
     setFields(extractFields(text));
+    const parsed = parseResumeText(text);
+    addResume({ id: uuid(), content: text, parsed, tags: [] });
+    setToastOpen(true);
   };
 
   return (
@@ -75,6 +86,12 @@ export default function ResumePaste() {
           </CardContent>
         </Card>
       )}
+      <Snackbar
+        open={toastOpen}
+        autoHideDuration={3000}
+        message="Resume saved"
+        onClose={() => setToastOpen(false)}
+      />
     </Box>
   );
 }

--- a/src/utils/talentforge/pasteParser.ts
+++ b/src/utils/talentforge/pasteParser.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import DOMPurify from "dompurify";
+
+/**
+ * Sanitize HTML pasted by the user and return plain text.
+ */
+export function parsePastedHtml(html: string): string {
+  if (typeof window === "undefined") return html;
+  const clean = DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+  const temp = document.createElement("div");
+  temp.innerHTML = clean;
+  return temp.textContent || temp.innerText || "";
+}


### PR DESCRIPTION
## Summary
- add DOMPurify-based paste parser for Talentforge
- sanitize resume paste, save variant, and confirm with toast
- declare dompurify dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6691df734833090fc31accdaeb5a5