### PR TITLE
feat: enhance resume variant management

### DIFF
--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -27,9 +27,9 @@ import {
 } from "@/utils/talentforge/utils";
 import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
-import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
 import FileUploader from "./FileUploader";
+import ResumeVariantList from "./ResumeVariants/List";
 
 const suggestTags = async (content: string): Promise<string[]> => {
   try {
@@ -186,33 +186,16 @@ export default function ResumeManager() {
           value={searchTag}
           onChange={(e) => setSearchTag(e.target.value)}
         />
-        {loadingResumes
-          ? Array.from({ length: 3 }).map((_, idx) => (
-              <Skeleton key={idx} variant="rectangular" height={60} />
-            ))
-          : filteredResumes.map((resume) => (
-              <Box key={resume.id}>
-                <Typography variant="subtitle1" gutterBottom>
-                  {resume.id}
-                </Typography>
-                <Stack direction="row" spacing={1} flexWrap="wrap">
-                  {resume.tags.map((tag) => (
-                    <Chip key={tag} label={tag} sx={{ mb: 1 }} />
-                  ))}
-                </Stack>
-                <Button
-                  size="small"
-                  sx={{ mt: 1 }}
-                  onClick={() => {
-                    const temp = document.createElement("div");
-                    temp.textContent = resume.content;
-                    exportElementToPdf(temp, `${resume.id}.pdf`);
-                  }}
-                >
-                  Export
-                </Button>
-              </Box>
-            ))}
+        {loadingResumes ? (
+          Array.from({ length: 3 }).map((_, idx) => (
+            <Skeleton key={idx} variant="rectangular" height={60} />
+          ))
+        ) : (
+          <ResumeVariantList
+            resumes={filteredResumes}
+            setResumes={setResumes}
+          />
+        )}
       </Stack>
     </Box>
   );

--- a/src/components/talentforge/ResumeVariants/Detail.tsx
+++ b/src/components/talentforge/ResumeVariants/Detail.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Stack,
+  Chip,
+} from "@mui/material";
+import { type ResumeEntry } from "@/utils/talentforge/dataStore";
+import Diff from "./Diff";
+
+interface Props {
+  resume: ResumeEntry;
+  onClose: () => void;
+  onSave: (resume: ResumeEntry) => void;
+  onClone: (resume: ResumeEntry) => void;
+}
+
+export default function Detail({
+  resume,
+  onClose,
+  onSave,
+  onClone,
+}: Props) {
+  const [content, setContent] = useState(resume.content);
+  const [tagsText, setTagsText] = useState(resume.tags.join(", "));
+  const [showDiff, setShowDiff] = useState(false);
+
+  const tags = tagsText
+    .split(/,|\n/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const updatedResume: ResumeEntry = { ...resume, content, tags };
+
+  return (
+  <Dialog open onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle>{resume.id}</DialogTitle>
+      <DialogContent dividers>
+        {showDiff ? (
+          <Diff original={resume.content} updated={content} />
+        ) : (
+          <Stack spacing={2}>
+            <TextField
+              label="Content"
+              multiline
+              minRows={10}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+            <TextField
+              label="Tags"
+              value={tagsText}
+              onChange={(e) => setTagsText(e.target.value)}
+              helperText="Comma separated"
+            />
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              {tags.map((t) => (
+                <Chip key={t} label={t} />
+              ))}
+            </Stack>
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setShowDiff(!showDiff)}>
+          {showDiff ? "Edit" : "Diff"}
+        </Button>
+        <Button onClick={() => onClone(updatedResume)}>Clone</Button>
+        <Button onClick={() => onSave(updatedResume)}>Save</Button>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+

--- a/src/components/talentforge/ResumeVariants/Diff.tsx
+++ b/src/components/talentforge/ResumeVariants/Diff.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+
+interface DiffPart {
+  type: "same" | "added" | "removed";
+  text: string;
+}
+
+interface Props {
+  original: string;
+  updated: string;
+}
+
+function computeDiff(a: string, b: string): DiffPart[] {
+  const aLines = a.split("\n");
+  const bLines = b.split("\n");
+  const max = Math.max(aLines.length, bLines.length);
+  const result: DiffPart[] = [];
+  for (let i = 0; i < max; i++) {
+    const lineA = aLines[i];
+    const lineB = bLines[i];
+    if (lineA === lineB) {
+      if (lineA !== undefined) result.push({ type: "same", text: lineA });
+    } else {
+      if (lineA !== undefined) result.push({ type: "removed", text: lineA });
+      if (lineB !== undefined) result.push({ type: "added", text: lineB });
+    }
+  }
+  return result;
+}
+
+export default function Diff({ original, updated }: Props) {
+  const diff = computeDiff(original, updated);
+  return (
+    <Box component="pre" sx={{ whiteSpace: "pre-wrap", fontFamily: "monospace" }}>
+      {diff.map((part, idx) => (
+        <Typography
+          component="span"
+          key={idx}
+          color={
+            part.type === "added"
+              ? "success.main"
+              : part.type === "removed"
+              ? "error.main"
+              : undefined
+          }
+        >
+          {part.text}
+          {"\n"}
+        </Typography>
+      ))}
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/ResumeVariants/List.tsx
+++ b/src/components/talentforge/ResumeVariants/List.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Stack,
+  Typography,
+  Chip,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+} from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import DeleteIcon from "@mui/icons-material/Delete";
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import {
+  type ResumeEntry,
+  deleteResume,
+  updateResume,
+  cloneResume,
+} from "@/utils/talentforge/dataStore";
+import { exportElementToPdf } from "@/utils/pdfExport";
+import Detail from "./Detail";
+
+interface Props {
+  resumes: ResumeEntry[];
+  setResumes: (resumes: ResumeEntry[]) => void;
+}
+
+export default function List({ resumes, setResumes }: Props) {
+  const [selected, setSelected] = useState<ResumeEntry | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<ResumeEntry | null>(null);
+
+  const handleSave = (resume: ResumeEntry) => {
+    const updated = updateResume(resume);
+    setResumes(updated);
+  };
+
+  const handleClone = (resume: ResumeEntry) => {
+    const updated = cloneResume(resume);
+    setResumes(updated);
+  };
+
+  const handleDelete = (id: string) => {
+    const updated = deleteResume(id);
+    setResumes(updated);
+  };
+
+  return (
+    <Box>
+      {resumes.map((r) => (
+        <Box key={r.id} sx={{ mb: 2 }}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
+              {r.id}
+            </Typography>
+            <IconButton size="small" onClick={() => setSelected(r)} aria-label="edit">
+              <EditIcon fontSize="small" />
+            </IconButton>
+            <IconButton size="small" onClick={() => handleClone(r)} aria-label="clone">
+              <ContentCopyIcon fontSize="small" />
+            </IconButton>
+            <IconButton
+              size="small"
+              onClick={() => setConfirmDelete(r)}
+              aria-label="delete"
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+            <IconButton
+              size="small"
+              onClick={() => {
+                const temp = document.createElement("div");
+                temp.textContent = r.content;
+                exportElementToPdf(temp, `${r.id}.pdf`);
+              }}
+              aria-label="export"
+            >
+              <FileDownloadIcon fontSize="small" />
+            </IconButton>
+          </Stack>
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            {r.tags.map((tag) => (
+              <Chip key={tag} label={tag} sx={{ mb: 1 }} />
+            ))}
+          </Stack>
+        </Box>
+      ))}
+      {selected && (
+        <Detail
+          resume={selected}
+          onClose={() => setSelected(null)}
+          onSave={(res) => {
+            handleSave(res);
+            setSelected(null);
+          }}
+          onClone={(res) => handleClone(res)}
+        />
+      )}
+      {confirmDelete && (
+        <Dialog open onClose={() => setConfirmDelete(null)}>
+          <DialogTitle>Delete Resume</DialogTitle>
+          <DialogContent>
+            Are you sure you want to delete {confirmDelete.id}?
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setConfirmDelete(null)}>Cancel</Button>
+            <Button
+              color="error"
+              onClick={() => {
+                handleDelete(confirmDelete.id);
+                setConfirmDelete(null);
+              }}
+            >
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
+    </Box>
+  );
+}
+

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -5,6 +5,7 @@ import {
   saveItem,
   deleteItem,
 } from "@/utils/storage";
+import { v4 as uuid } from "uuid";
 import { ConnectorToken } from "@/types/connector";
 import type { ApplicationStatus } from "@/types/talentforge/job";
 import type {
@@ -161,6 +162,12 @@ export function updateResume(resume: ResumeEntry): ResumeEntry[] {
 }
 export function deleteResume(id: string): ResumeEntry[] {
   const updated = getResumes().filter((r) => r.id !== id);
+  saveResumes(updated);
+  return updated;
+}
+export function cloneResume(resume: ResumeEntry): ResumeEntry[] {
+  const clone = { ...resume, id: uuid() };
+  const updated = [...getResumes(), clone];
   saveResumes(updated);
   return updated;
 }


### PR DESCRIPTION
## Summary
- add ResumeVariants components (List, Detail, Diff) for managing resumes
- support cloning and editing resumes via dataStore
- replace ResumeManager list with new ResumeVariantList

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c6693d2d208330b928b8293a9e88c8