### PR TITLE
feat: add prompt tile components

### DIFF
--- a/src/components/talentforge/promptTiles/PromptTileGrid.tsx
+++ b/src/components/talentforge/promptTiles/PromptTileGrid.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Grid } from "@mui/material";
+
+import Tile from "./Tile";
+import { PROMPT_TILES } from "@/consts/promptTiles";
+
+export default function PromptTileGrid() {
+  return (
+    <Grid container spacing={2}>
+      {Object.values(PROMPT_TILES).map((tile) => (
+        <Grid item xs={12} sm={6} md={4} key={tile.id}>
+          <Tile {...tile} />
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, Stack, TextField, Typography } from "@mui/material";
+
+import OpenAiKeyModal from "../OpenAiKeyModal";
+import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
+
+export interface PromptTileProps {
+  id: string;
+  display: string;
+  fullPrompt: string;
+  inputs: string[];
+}
+
+export default function Tile({
+  id,
+  display,
+  fullPrompt,
+  inputs,
+}: PromptTileProps) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [response, setResponse] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [openKeyModal, setOpenKeyModal] = useState(false);
+
+  const handleChange = (key: string, value: string) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleRun = async () => {
+    const valid = await hasValidOpenAIKey();
+    if (!valid) {
+      setOpenKeyModal(true);
+      return;
+    }
+
+    let prompt = fullPrompt;
+    for (const key of inputs) {
+      prompt = prompt.replaceAll(`{{${key}}}`, values[key] || "");
+    }
+
+    setLoading(true);
+    try {
+      const res = await askOpenAI({
+        context: "",
+        user: prompt,
+        system: "You are a helpful assistant.",
+        returnFirstResponse: true,
+        chatHistory: [],
+      });
+      setResponse(res?.message || "");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box>
+      <OpenAiKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+      <Stack spacing={1}>
+        <Typography variant="subtitle1">{display}</Typography>
+        {inputs.map((name) => (
+          <TextField
+            key={name}
+            label={name}
+            value={values[name] || ""}
+            onChange={(e) => handleChange(name, e.target.value)}
+            size="small"
+          />
+        ))}
+        <Button variant="contained" onClick={handleRun} disabled={loading}>
+          {loading ? "Running..." : "Run"}
+        </Button>
+        {response && (
+          <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+            {response}
+          </Typography>
+        )}
+      </Stack>
+    </Box>
+  );
+}
+

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -1,0 +1,39 @@
+import { PROMPT_TEMPLATES } from "./prompts";
+
+export interface PromptTileDefinition {
+  id: string;
+  display: string;
+  fullPrompt: string;
+  inputs: string[];
+}
+
+// Base tiles derived from existing prompt templates (no inputs by default)
+const BASE_TILES: Record<string, PromptTileDefinition> = Object.fromEntries(
+  Object.entries(PROMPT_TEMPLATES).map(([id, template]) => [
+    id,
+    {
+      id,
+      display: template.displayText,
+      fullPrompt: template.fullText,
+      inputs: [],
+    },
+  ])
+);
+
+// Overrides/additional metadata for specific tiles
+export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
+  ...BASE_TILES,
+  coverLetter: {
+    ...BASE_TILES.coverLetter,
+    fullPrompt:
+      "Write a cover letter for the position of {{position}} at {{company}}. Highlight relevant skills and enthusiasm.",
+    inputs: ["position", "company"],
+  },
+  elevatorPitch: {
+    ...BASE_TILES.elevatorPitch,
+    fullPrompt:
+      "Craft a short elevator pitch for a professional with experience in {{experience}} looking for {{goal}}.",
+    inputs: ["experience", "goal"],
+  },
+};
+


### PR DESCRIPTION
## Summary
- define reusable prompt `Tile` component for Talentforge that collects inputs and queries OpenAI
- add a prompt tile registry and grid renderer
- derive tile definitions from existing prompt templates so all prompts appear as tiles

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c66ad67b648330884ea63e1bdfc7d5