### PR TITLE
fix: satisfy ResumeEntry requirements

### DIFF
--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -5,7 +5,6 @@ import { v4 as uuid } from "uuid";
 import {
   Box,
   Button,
-  Chip,
   CircularProgress,
   Skeleton,
   Stack,
@@ -48,7 +47,15 @@ export default function ResumeManager() {
     if (!text.trim()) return;
     const tags = await tagResume(text);
     const parsed = parseResumeText(text);
-    const newResume = { id: uuid(), content: text, parsed, tags };
+    const newResume: ResumeEntry = {
+      id: uuid(),
+      userId: "",
+      label: "",
+      url: "",
+      content: text,
+      parsed,
+      tags,
+    };
     const updated = addResume(newResume);
     setResumes(updated);
     setText("");


### PR DESCRIPTION
## Summary
- remove unused MUI Chip import
- provide required ResumeEntry fields when saving resumes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c66deb08948330971eefc7e3b66fce