### PR TITLE
feat: add job requirements tile

### DIFF
--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Button, Stack, TextField, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Stack,
+  TextField,
+  Typography,
+  IconButton,
+  Tooltip,
+} from "@mui/material";
+import { ContentCopy } from "@mui/icons-material";
+import Markdown from "react-markdown";
 
 import OpenAiKeyModal from "../OpenAiKeyModal";
 import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
@@ -73,9 +83,22 @@ export default function Tile({
           {loading ? "Running..." : "Run"}
         </Button>
         {response && (
-          <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-            {response}
-          </Typography>
+          <Box>
+            <Box display="flex" justifyContent="flex-end">
+              {navigator.clipboard && (
+                <Tooltip title="copy to clipboard" arrow>
+                  <IconButton
+                    aria-label="copy response to clipboard"
+                    onClick={() => navigator.clipboard.writeText(response)}
+                    size="small"
+                  >
+                    <ContentCopy fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Box>
+            <Markdown>{response}</Markdown>
+          </Box>
         )}
       </Stack>
     </Box>

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -35,5 +35,11 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Craft a short elevator pitch for a professional with experience in {{experience}} looking for {{goal}}.",
     inputs: ["experience", "goal"],
   },
+  jobRequirements: {
+    ...BASE_TILES.jobRequirements,
+    fullPrompt:
+      "From the following job description, list the key job requirements as bullet points:\n\n{{jobDescription}}",
+    inputs: ["jobDescription"],
+  },
 };
 

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -44,6 +44,11 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Rewrite the job description to emphasize candidate requirements and key deliverables for internal sharing.",
   },
+  jobRequirements: {
+    displayText: "Job Requirements",
+    fullText:
+      "List the key job requirements from the provided job description in bullet points.",
+  },
   networkingOutreach: {
     displayText: "Networking Outreach",
     fullText:
@@ -83,6 +88,7 @@ export const PROMPT_GROUPS: Record<string, string[]> = {
   "Career Growth": [
     "skillGapAnalysis",
     "jobDescriptionRewrite",
+    "jobRequirements",
     "careerGoals",
     "elevatorPitch",
     "linkedinProfileOptimization",


### PR DESCRIPTION
## Summary
- add `jobRequirements` prompt template and register in prompt groups
- register tile with `jobDescription` input and bullet-point requirement prompt
- render tile output in Markdown with copy-to-clipboard button

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c66e8eb45483308d3347fdd2b10875