### PR TITLE
feat: add resume rewrite prompt tile

### DIFF
--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -5,6 +5,10 @@ import { Box, Button, Stack, TextField, Typography } from "@mui/material";
 
 import OpenAiKeyModal from "../OpenAiKeyModal";
 import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
+import { getResumes, addResume, type ResumeEntry } from "@/utils/talentforge/dataStore";
+import { tagResume } from "@/utils/talentforge/tagging";
+import { parseResumeText } from "@/utils/talentforge/pdfParser";
+import { v4 as uuid } from "uuid";
 
 export interface PromptTileProps {
   id: string;
@@ -23,6 +27,7 @@ export default function Tile({
   const [response, setResponse] = useState("");
   const [loading, setLoading] = useState(false);
   const [openKeyModal, setOpenKeyModal] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   const handleChange = (key: string, value: string) => {
     setValues((prev) => ({ ...prev, [key]: value }));
@@ -34,14 +39,24 @@ export default function Tile({
       setOpenKeyModal(true);
       return;
     }
-
-    let prompt = fullPrompt;
-    for (const key of inputs) {
-      prompt = prompt.replaceAll(`{{${key}}}`, values[key] || "");
-    }
-
     setLoading(true);
     try {
+      let prompt = fullPrompt;
+      for (const key of inputs) {
+        prompt = prompt.replaceAll(`{{${key}}}`, values[key] || "");
+      }
+
+      if (id === "resumeRewrite") {
+        const resume = getResumes().find(
+          (r) => r.id === values["resumeVariantId"],
+        );
+        if (!resume) {
+          setResponse("Resume not found");
+          return;
+        }
+        prompt = `${prompt}\n\nJob Description:\n${values["jobDescription"]}\n\nResume:\n${resume.content}`;
+      }
+
       const res = await askOpenAI({
         context: "",
         user: prompt,
@@ -52,6 +67,29 @@ export default function Tile({
       setResponse(res?.message || "");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleSaveVariant = async () => {
+    if (id !== "resumeRewrite" || !response) return;
+    const resume = getResumes().find(
+      (r) => r.id === values["resumeVariantId"],
+    );
+    if (!resume) return;
+    setSaving(true);
+    try {
+      const tags = await tagResume(response);
+      const parsed = parseResumeText(response);
+      const newResume: ResumeEntry = {
+        ...resume,
+        id: uuid(),
+        content: response,
+        parsed,
+        tags,
+      };
+      addResume(newResume);
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -73,9 +111,20 @@ export default function Tile({
           {loading ? "Running..." : "Run"}
         </Button>
         {response && (
-          <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-            {response}
-          </Typography>
+          <>
+            <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+              {response}
+            </Typography>
+            {id === "resumeRewrite" && (
+              <Button
+                variant="outlined"
+                onClick={handleSaveVariant}
+                disabled={saving}
+              >
+                {saving ? "Saving..." : "Save as new variant"}
+              </Button>
+            )}
+          </>
         )}
       </Stack>
     </Box>

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -35,5 +35,13 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Craft a short elevator pitch for a professional with experience in {{experience}} looking for {{goal}}.",
     inputs: ["experience", "goal"],
   },
+  resumeRewrite: {
+    ...BASE_TILES.resumeSummary,
+    id: "resumeRewrite",
+    display: "Resume Rewrite",
+    fullPrompt:
+      "Rewrite this resume to emphasize how the candidate meets the role requirements.",
+    inputs: ["resumeVariantId", "jobDescription"],
+  },
 };
 


### PR DESCRIPTION
## Summary
- add Resume Rewrite tile that accepts resumeVariantId and jobDescription inputs
- rewrite resume content based on role requirements and allow saving as new variant

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66e8b425883309eece0ceff75cacc