### PR TITLE
feat: add cover letter generator

### DIFF
--- a/src/app/talentforge/cover-letter/page.tsx
+++ b/src/app/talentforge/cover-letter/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
+import CoverLetter from "@/components/talentforge/CoverLetter";
+
+export default function CoverLetterPage() {
+  return (
+    <ErrorBoundary>
+      <CoverLetter />
+    </ErrorBoundary>
+  );
+}
+

--- a/src/app/talentforge/layout.tsx
+++ b/src/app/talentforge/layout.tsx
@@ -26,6 +26,7 @@ export default function TalentForgeLayout({
     { label: "Dashboard", href: "/talentforge" },
     { label: "Applications", href: "/talentforge/applications" },
     { label: "Resumes", href: "/talentforge/resumes" },
+    { label: "Cover Letter", href: "/talentforge/cover-letter" },
     { label: "Offers", href: "/talentforge/offers" },
     { label: "Inbox", href: "/talentforge/inbox" },
     { label: "Settings", href: "/talentforge/settings" },

--- a/src/components/talentforge/CoverLetter.tsx
+++ b/src/components/talentforge/CoverLetter.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, useRef } from "react";
+import {
+  Box,
+  Button,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { getResumes } from "@/utils/talentforge/dataStore";
+import { exportElementToPdf } from "@/utils/pdfExport";
+import OpenAiKeyModal from "./OpenAiKeyModal";
+
+export default function CoverLetter() {
+  const [resumeVariantId, setResumeVariantId] = useState("");
+  const [jobDescription, setJobDescription] = useState("");
+  const [coverLetter, setCoverLetter] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [openKeyModal, setOpenKeyModal] = useState(false);
+  const coverRef = useRef<HTMLDivElement>(null);
+
+  const resumes = getResumes();
+
+  const handleGenerate = async () => {
+    if (!resumeVariantId || !jobDescription) return;
+    if (!hasOpenAIKey()) {
+      setOpenKeyModal(true);
+      return;
+    }
+    const resume = resumes.find((r) => r.id === resumeVariantId);
+    if (!resume) return;
+    setLoading(true);
+    const context = `Resume:\n${resume.content}\n\nJob Description:\n${jobDescription}`;
+    const response = await askOpenAI({
+      context,
+      user:
+        "Write a professional cover letter with exactly three paragraphs, using the resume to highlight relevant experience.",
+      system:
+        "You are an assistant that crafts polished three-paragraph cover letters based on a resume and job description.",
+      chatHistory: [],
+      returnFirstResponse: true,
+      logMessagesToChatHistory: false,
+    });
+    setCoverLetter(response?.message || "");
+    setLoading(false);
+  };
+
+  return (
+    <Box>
+      <OpenAiKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+      <Stack spacing={2}>
+        <TextField
+          select
+          label="Resume Variant"
+          value={resumeVariantId}
+          onChange={(e) => setResumeVariantId(e.target.value)}
+        >
+          {resumes.map((r) => (
+            <MenuItem key={r.id} value={r.id}>
+              {r.id}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          label="Job Description"
+          multiline
+          minRows={6}
+          value={jobDescription}
+          onChange={(e) => setJobDescription(e.target.value)}
+        />
+        <Stack direction="row" spacing={2}>
+          <Button
+            variant="contained"
+            onClick={handleGenerate}
+            disabled={!resumeVariantId || !jobDescription || loading}
+          >
+            Generate
+          </Button>
+          <Button
+            variant="outlined"
+            disabled={!coverLetter}
+            onClick={() =>
+              coverRef.current &&
+              exportElementToPdf(coverRef.current, "cover-letter.pdf")
+            }
+          >
+            Export
+          </Button>
+        </Stack>
+        {coverLetter && (
+          <Box ref={coverRef}>
+            <Typography sx={{ whiteSpace: "pre-wrap" }}>{coverLetter}</Typography>
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  );
+}
+

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -12,7 +12,7 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
   coverLetter: {
     displayText: "Cover Letter",
     fullText:
-      "Draft a concise cover letter highlighting why you are a great fit for the role.",
+      "Write a professional cover letter with exactly three paragraphs tailored to the job description.",
   },
   negotiateOffer: {
     displayText: "Negotiate Offer",


### PR DESCRIPTION
## Summary
- add CoverLetter component requiring resume variant and job description
- generate 3-paragraph professional cover letters and export to PDF
- expose cover letter page and update prompts

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c66e92832c83308f60e8bd05ba44bd