### PR TITLE
Fix unused prop and resume addition type

### DIFF
--- a/src/components/talentforge/ResumePaste.tsx
+++ b/src/components/talentforge/ResumePaste.tsx
@@ -47,7 +47,15 @@ export default function ResumePaste() {
     setInput(text);
     setFields(extractFields(text));
     const parsed = parseResumeText(text);
-    addResume({ id: uuid(), content: text, parsed, tags: [] });
+    addResume({
+      id: uuid(),
+      userId: "",
+      label: "",
+      url: "",
+      content: text,
+      parsed,
+      tags: [],
+    });
     setToastOpen(true);
   };
 

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -7,14 +7,12 @@ import OpenAiKeyModal from "../OpenAiKeyModal";
 import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
 
 export interface PromptTileProps {
-  id: string;
   display: string;
   fullPrompt: string;
   inputs: string[];
 }
 
 export default function Tile({
-  id,
   display,
   fullPrompt,
   inputs,


### PR DESCRIPTION
## Summary
- remove unused `id` prop in prompt Tile component
- include placeholder resume metadata when adding a parsed resume

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '/workspace/portfolio/node_modules/@eslint/eslintrc/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c66f29cc68833087808939ab4b3ae4