### PR TITLE
feat: add STAR bullet generator

### DIFF
--- a/src/components/talentforge/ResumeVariants/BulletVariants.tsx
+++ b/src/components/talentforge/ResumeVariants/BulletVariants.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { Stack, TextField, Button, Typography } from "@mui/material";
+import RequireAIKey from "../RequireAIKey";
+import { askOpenAI } from "@/utils/talentforge/utils";
+
+interface Props {
+  content: string;
+  setContent: (content: string) => void;
+}
+
+export default function BulletVariants({ content, setContent }: Props) {
+  const [bulletText, setBulletText] = useState("");
+  const [variants, setVariants] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const generateVariants = async () => {
+    if (!bulletText) return;
+    setLoading(true);
+    const response = await askOpenAI({
+      context: "",
+      user: `Original resume bullet: ${bulletText}`,
+      system:
+        "You are an expert resume writer. Rewrite the resume bullet in STAR (Situation, Task, Action, Result) format with quantifiable metrics. Provide three distinct bullet point variants separated by newlines.",
+      returnFirstResponse: true,
+      chatHistory: [],
+    });
+    const lines = response.message
+      .split(/\n+/)
+      .map((l) => l.replace(/^[-*\d\.\)]+\s*/, "").trim())
+      .filter(Boolean)
+      .slice(0, 3);
+    setVariants(lines);
+    setLoading(false);
+  };
+
+  const replaceOriginal = (variant: string) => {
+    setContent((c) => c.replace(bulletText, variant));
+    setBulletText(variant);
+    setVariants([]);
+  };
+
+  return (
+    <RequireAIKey>
+      <Stack spacing={1}>
+        <TextField
+          label="Original Bullet"
+          value={bulletText}
+          onChange={(e) => setBulletText(e.target.value)}
+          multiline
+        />
+        <Button
+          variant="contained"
+          onClick={generateVariants}
+          disabled={!bulletText || loading}
+        >
+          Generate Variants
+        </Button>
+        {variants.map((v, idx) => (
+          <Stack key={idx} direction="row" spacing={1} alignItems="center">
+            <Typography variant="body2" sx={{ flexGrow: 1 }}>
+              {v}
+            </Typography>
+            <Button onClick={() => replaceOriginal(v)}>Replace Original</Button>
+          </Stack>
+        ))}
+      </Stack>
+    </RequireAIKey>
+  );
+}
+

--- a/src/components/talentforge/ResumeVariants/Detail.tsx
+++ b/src/components/talentforge/ResumeVariants/Detail.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import { type ResumeEntry } from "@/utils/talentforge/dataStore";
 import Diff from "./Diff";
+import BulletVariants from "./BulletVariants";
 
 interface Props {
   resume: ResumeEntry;
@@ -53,6 +54,7 @@ export default function Detail({
               value={content}
               onChange={(e) => setContent(e.target.value)}
             />
+            <BulletVariants content={content} setContent={setContent} />
             <TextField
               label="Tags"
               value={tagsText}


### PR DESCRIPTION
## Summary
- add BulletVariants component to generate STAR-formatted bullet variants with metrics
- integrate bullet variant generator into resume variant detail

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: E403 Forbidden)*
- `npm run lint` *(fails: missing @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68c66ea3c14c83309f9097b98b052464