### PR TITLE
feat: add job description risk analyzer

### DIFF
--- a/src/app/talentforge/jobrisks/page.tsx
+++ b/src/app/talentforge/jobrisks/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import JobDescriptionRisk from "@/components/talentforge/JobDescriptionRisk";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
+
+export default function JobRisksPage() {
+  return (
+    <ErrorBoundary>
+      <JobDescriptionRisk />
+    </ErrorBoundary>
+  );
+}
+

--- a/src/app/talentforge/layout.tsx
+++ b/src/app/talentforge/layout.tsx
@@ -27,6 +27,7 @@ export default function TalentForgeLayout({
     { label: "Applications", href: "/talentforge/applications" },
     { label: "Resumes", href: "/talentforge/resumes" },
     { label: "Offers", href: "/talentforge/offers" },
+    { label: "Job Risks", href: "/talentforge/jobrisks" },
     { label: "Inbox", href: "/talentforge/inbox" },
     { label: "Settings", href: "/talentforge/settings" },
   ];

--- a/src/components/talentforge/JobDescriptionRisk.tsx
+++ b/src/components/talentforge/JobDescriptionRisk.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import OpenAiKeyModal from "./OpenAiKeyModal";
+import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { PROMPT_TEMPLATES } from "@/consts/prompts";
+
+interface Issue {
+  severity: "red" | "yellow";
+  message: string;
+}
+
+interface Analysis {
+  summary?: string;
+  issues: Issue[];
+}
+
+export default function JobDescriptionRisk() {
+  const [jobDescription, setJobDescription] = useState("");
+  const [analysis, setAnalysis] = useState<Analysis | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [openKeyModal, setOpenKeyModal] = useState(false);
+
+  const analyze = async () => {
+    if (!hasOpenAIKey()) {
+      setOpenKeyModal(true);
+      return;
+    }
+    if (!jobDescription.trim()) return;
+    const context = `Job Description:\n${jobDescription}`;
+    const prompt = PROMPT_TEMPLATES.jobDescriptionRisk?.fullText || "";
+    setLoading(true);
+    const response = await askOpenAI({
+      context,
+      user: prompt,
+      system:
+        "You are an assistant that reviews job descriptions and flags potential issues. Respond in JSON with a 'summary' and an array 'issues' with objects containing 'severity' (\"red\" or \"yellow\") and 'message'.",
+      chatHistory: [],
+      returnFirstResponse: true,
+    });
+    const message = response?.message || "";
+    try {
+      const parsed = JSON.parse(message);
+      setAnalysis({
+        summary: parsed.summary,
+        issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+      });
+    } catch {
+      setAnalysis({ summary: message, issues: [] });
+    }
+    setLoading(false);
+  };
+
+  return (
+    <Box>
+      <OpenAiKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+      <TextField
+        label="Paste job description"
+        multiline
+        minRows={6}
+        fullWidth
+        value={jobDescription}
+        onChange={(e) => setJobDescription(e.target.value)}
+      />
+      <Button
+        variant="contained"
+        sx={{ mt: 2 }}
+        onClick={analyze}
+        disabled={!jobDescription || loading}
+      >
+        Analyze
+      </Button>
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+          <CircularProgress />
+        </Box>
+      )}
+      {analysis && (
+        <Box sx={{ mt: 2 }}>
+          {analysis.issues.map((issue, idx) => (
+            <Stack
+              key={idx}
+              direction="row"
+              spacing={1}
+              alignItems="flex-start"
+              sx={{ mb: 1 }}
+            >
+              <Typography>{issue.severity === "red" ? "🚩" : "⚠️"}</Typography>
+              <Typography variant="body2">{issue.message}</Typography>
+            </Stack>
+          ))}
+          {analysis.summary && (
+            <Typography variant="body2" sx={{ mt: 2 }}>
+              {analysis.summary}
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -44,6 +44,11 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Rewrite the job description to emphasize candidate requirements and key deliverables for internal sharing.",
   },
+  jobDescriptionRisk: {
+    displayText: "Job Description Risk",
+    fullText:
+      "Identify potential issues in this job description like unpaid overtime, vague responsibilities, or compliance red flags. Return JSON with a 'summary' and an 'issues' array of objects with 'severity' ('red' or 'yellow') and 'message'.",
+  },
   networkingOutreach: {
     displayText: "Networking Outreach",
     fullText:


### PR DESCRIPTION
## Summary
- add prompt to detect risky job description language
- create JobDescriptionRisk component that flags red/yellow issues and summary
- expose analyzer on new Job Risks page and navigation

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66ea6533c8330807501536a9cc971