### PR TITLE
feat: add quick follow-up replies

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -33,6 +33,7 @@ export default function Inbox() {
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [templates, setTemplates] = useState<Record<string, AutoReplyTemplate>>({});
+  const [quickTones, setQuickTones] = useState<Record<string, AutoReplyTemplate>>({});
   const [search, setSearch] = useState("");
 
   useEffect(() => {
@@ -54,6 +55,16 @@ export default function Inbox() {
       buildAutoReplyMessages(template, message.body),
     );
     setDrafts((d) => ({ ...d, [message.id]: reply }));
+  };
+
+  const handleQuickInsert = async (message: Message) => {
+    const tone = quickTones[message.id] || "politeFollowUp";
+    const text = await autoReply(
+      buildAutoReplyMessages(tone, message.body),
+    );
+    const reply = { id: uuidv4(), body: text, sentAt: new Date().toISOString() };
+    const updated = data.addMessageReply(message.id, reply);
+    setMessages(updated);
   };
 
   const handleSendReply = (message: Message) => {
@@ -127,6 +138,29 @@ export default function Inbox() {
                         {r.body}
                       </Typography>
                     ))}
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Select
+                        size="small"
+                        value={quickTones[message.id] || "politeFollowUp"}
+                        onChange={(e) =>
+                          setQuickTones((t) => ({
+                            ...t,
+                            [message.id]: e.target.value as AutoReplyTemplate,
+                          }))
+                        }
+                        sx={{ maxWidth: 200 }}
+                      >
+                        <MenuItem value="politeFollowUp">Polite follow-up</MenuItem>
+                        <MenuItem value="politeDecline">Politely decline</MenuItem>
+                      </Select>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => void handleQuickInsert(message)}
+                      >
+                        Quick insert
+                      </Button>
+                    </Stack>
                     <TextField
                       label="Your reply"
                       multiline

--- a/src/tests/talentforge/autoReply.test.ts
+++ b/src/tests/talentforge/autoReply.test.ts
@@ -80,4 +80,18 @@ describe("autoReply utilities", () => {
       { role: "user", content: "We are unable to proceed." },
     ]);
   });
+
+  test("buildAutoReplyMessages supports polite follow-up", () => {
+    const messages = buildAutoReplyMessages(
+      "politeFollowUp",
+      "Just checking in.",
+    );
+    expect(messages).toEqual([
+      {
+        role: "system",
+        content: AUTO_REPLY_TEMPLATES.politeFollowUp,
+      },
+      { role: "user", content: "Just checking in." },
+    ]);
+  });
 });

--- a/src/utils/autoReply.ts
+++ b/src/utils/autoReply.ts
@@ -8,6 +8,8 @@ export interface AutoReplyMessage {
 export const AUTO_REPLY_TEMPLATES = {
   general:
     "You are a helpful assistant crafting concise professional replies to incoming messages.",
+  politeFollowUp:
+    "You are a helpful assistant that writes courteous follow-up messages to check in professionally.",
   politeDecline:
     "You are a helpful assistant that politely declines opportunities while maintaining professionalism.",
   requestMoreInfo:


### PR DESCRIPTION
## Summary
- allow polite follow-up tone in auto reply templates
- add quick-insert follow-up/decline replies to inbox threads
- cover follow-up template in unit tests

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c66eaa6394833084f11173985fdef4