### PR TITLE
feat: compare job offers and export markdown

### DIFF
--- a/src/app/talentforge/offers/page.tsx
+++ b/src/app/talentforge/offers/page.tsx
@@ -10,6 +10,7 @@ import {
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 import OfferCompare from "@/components/talentforge/OfferCompare";
+import OfferComparison from "@/components/talentforge/OfferComparison";
 import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
 
 export default function OffersPage() {
@@ -26,6 +27,7 @@ export default function OffersPage() {
   return (
     <ErrorBoundary>
       <Box>
+        <OfferComparison />
         <OfferCompare onSave={refreshOffers} />
         {offers.length > 0 && (
           <Stack spacing={2} sx={{ mt: 4 }}>

--- a/src/components/talentforge/OfferComparison.tsx
+++ b/src/components/talentforge/OfferComparison.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Stack,
+  TextField,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+} from "@mui/material";
+
+interface OfferDetails {
+  salary: string;
+  benefits: string;
+  equity: string;
+  notes: string;
+}
+
+export default function OfferComparison() {
+  const [offerA, setOfferA] = useState<OfferDetails>({
+    salary: "",
+    benefits: "",
+    equity: "",
+    notes: "",
+  });
+  const [offerB, setOfferB] = useState<OfferDetails>({
+    salary: "",
+    benefits: "",
+    equity: "",
+    notes: "",
+  });
+
+  const rows = [
+    { label: "Salary", a: offerA.salary, b: offerB.salary },
+    { label: "Benefits", a: offerA.benefits, b: offerB.benefits },
+    { label: "Equity", a: offerA.equity, b: offerB.equity },
+    { label: "Notes", a: offerA.notes, b: offerB.notes },
+  ];
+
+  const saveComparison = () => {
+    const header = "| Aspect | Offer A | Offer B |\n| --- | --- | --- |";
+    const body = rows
+      .map((r) => `| ${r.label} | ${r.a || ""} | ${r.b || ""} |`)
+      .join("\n");
+    const markdown = `${header}\n${body}\n`;
+    const blob = new Blob([markdown], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "offer-comparison.md";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Compare Offers
+      </Typography>
+      <Stack direction={{ xs: "column", md: "row" }} spacing={2} sx={{ mb: 2 }}>
+        <Stack spacing={2} flex={1}>
+          <Typography variant="subtitle1">Offer A</Typography>
+          <TextField
+            label="Salary"
+            value={offerA.salary}
+            onChange={(e) => setOfferA({ ...offerA, salary: e.target.value })}
+          />
+          <TextField
+            label="Benefits"
+            value={offerA.benefits}
+            onChange={(e) =>
+              setOfferA({ ...offerA, benefits: e.target.value })
+            }
+          />
+          <TextField
+            label="Equity"
+            value={offerA.equity}
+            onChange={(e) => setOfferA({ ...offerA, equity: e.target.value })}
+          />
+          <TextField
+            label="Notes"
+            multiline
+            minRows={3}
+            value={offerA.notes}
+            onChange={(e) => setOfferA({ ...offerA, notes: e.target.value })}
+          />
+        </Stack>
+        <Stack spacing={2} flex={1}>
+          <Typography variant="subtitle1">Offer B</Typography>
+          <TextField
+            label="Salary"
+            value={offerB.salary}
+            onChange={(e) => setOfferB({ ...offerB, salary: e.target.value })}
+          />
+          <TextField
+            label="Benefits"
+            value={offerB.benefits}
+            onChange={(e) =>
+              setOfferB({ ...offerB, benefits: e.target.value })
+            }
+          />
+          <TextField
+            label="Equity"
+            value={offerB.equity}
+            onChange={(e) => setOfferB({ ...offerB, equity: e.target.value })}
+          />
+          <TextField
+            label="Notes"
+            multiline
+            minRows={3}
+            value={offerB.notes}
+            onChange={(e) => setOfferB({ ...offerB, notes: e.target.value })}
+          />
+        </Stack>
+      </Stack>
+      <TableContainer component={Paper} sx={{ mb: 2 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Aspect</TableCell>
+              <TableCell>Offer A</TableCell>
+              <TableCell>Offer B</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.label}>
+                <TableCell>{row.label}</TableCell>
+                <TableCell>{row.a}</TableCell>
+                <TableCell>{row.b}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Button variant="contained" onClick={saveComparison}>
+        Save comparison
+      </Button>
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add OfferComparison component for manual job offer comparison
- export comparison table to markdown
- show new comparison tool on offers page

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c6707012848330b759efaddb0c2872