### PR TITLE
fix: allow state update function in bullet variants

### DIFF
--- a/src/components/talentforge/ResumeVariants/BulletVariants.tsx
+++ b/src/components/talentforge/ResumeVariants/BulletVariants.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import { Stack, TextField, Button, Typography } from "@mui/material";
 import RequireAIKey from "../RequireAIKey";
 import { askOpenAI } from "@/utils/talentforge/utils";
 
 interface Props {
-  content: string;
-  setContent: (content: string) => void;
+  setContent: Dispatch<SetStateAction<string>>;
 }
 
-export default function BulletVariants({ content, setContent }: Props) {
+export default function BulletVariants({ setContent }: Props) {
   const [bulletText, setBulletText] = useState("");
   const [variants, setVariants] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
## Summary
- remove unused `content` prop and type `setContent` to accept updater functions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67153682883308c182de0e31d8552