### PR TITLE
feat: add offer management components

### DIFF
--- a/src/app/talentforge/offers/page.tsx
+++ b/src/app/talentforge/offers/page.tsx
@@ -1,65 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Markdown from "react-markdown";
-import {
-  Box,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { useState } from "react";
+import { Box } from "@mui/material";
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
-
-import OfferCompare from "@/components/talentforge/OfferCompare";
-import OfferComparison from "@/components/talentforge/OfferComparison";
-import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
+import OfferDetail from "@/components/talentforge/Offers/OfferDetail";
+import OfferList from "@/components/talentforge/Offers/OfferList";
 
 export default function OffersPage() {
-  const [offers, setOffers] = useState<Offer[]>([]);
-
-  const refreshOffers = () => {
-    setOffers(getOffers());
-  };
-
-  useEffect(() => {
-    refreshOffers();
-  }, []);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   return (
     <ErrorBoundary>
       <Box>
-        <OfferComparison />
-        <OfferCompare onSave={refreshOffers} />
-        {offers.length > 0 && (
-          <Stack spacing={2} sx={{ mt: 4 }}>
-            <Typography variant="h6">Past Offers</Typography>
-            {offers.map((offer) => (
-              <Box
-                key={offer.id}
-                sx={{ border: "1px solid", borderColor: "divider", p: 2, borderRadius: 1 }}
-              >
-                <Typography variant="subtitle2" gutterBottom>
-                  Compensation
-                </Typography>
-                {offer.compensation.map((c, idx) => (
-                  <Typography key={idx} variant="body2" gutterBottom>
-                    {c.type}: {c.amount}
-                    {c.notes ? ` (${c.notes})` : ""}
-                  </Typography>
-                ))}
-                {offer.summary && (
-                  <>
-                    <Typography variant="subtitle2" gutterBottom>
-                      Draft Response
-                    </Typography>
-                    <Typography variant="body2" component="div">
-                      <Markdown>{offer.summary}</Markdown>
-                    </Typography>
-                  </>
-                )}
-              </Box>
-            ))}
-          </Stack>
-        )}
+        <OfferDetail onSave={() => setRefreshKey((k) => k + 1)} />
+        <OfferList refreshKey={refreshKey} />
       </Box>
     </ErrorBoundary>
   );

--- a/src/components/talentforge/Offers/OfferDetail.tsx
+++ b/src/components/talentforge/Offers/OfferDetail.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { v4 as uuid } from "uuid";
+import {
+  Box,
+  Button,
+  Stack,
+  TextField,
+} from "@mui/material";
+import {
+  addOffer,
+  updateOffer,
+  type Offer,
+} from "@/utils/talentforge/dataStore";
+import type { OfferComp } from "@/types";
+
+interface OfferDetailProps {
+  offer?: Offer;
+  onSave?: () => void;
+}
+
+const getAmount = (offer: Offer | undefined, type: string): string => {
+  return (
+    offer?.compensation.find((c) => c.type === type)?.amount.toString() || ""
+  );
+};
+
+export default function OfferDetail({ offer, onSave }: OfferDetailProps) {
+  const [salary, setSalary] = useState(getAmount(offer, "salary"));
+  const [bonus, setBonus] = useState(getAmount(offer, "bonus"));
+  const [equity, setEquity] = useState(getAmount(offer, "equity"));
+  const [summary, setSummary] = useState(offer?.summary || "");
+
+  const handleSave = () => {
+    const compensation: OfferComp[] = [
+      { type: "salary", amount: parseFloat(salary) || 0 },
+      { type: "bonus", amount: parseFloat(bonus) || 0 },
+      { type: "equity", amount: parseFloat(equity) || 0 },
+    ];
+
+    const newOffer: Offer = {
+      id: offer?.id || uuid(),
+      application: offer?.application || ({} as any),
+      compensation,
+      summary,
+    };
+
+    if (offer) {
+      updateOffer(newOffer);
+    } else {
+      addOffer(newOffer);
+    }
+    onSave?.();
+  };
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Stack spacing={2}>
+        <TextField
+          label="Salary"
+          type="number"
+          value={salary}
+          onChange={(e) => setSalary(e.target.value)}
+        />
+        <TextField
+          label="Bonus"
+          type="number"
+          value={bonus}
+          onChange={(e) => setBonus(e.target.value)}
+        />
+        <TextField
+          label="Equity"
+          type="number"
+          value={equity}
+          onChange={(e) => setEquity(e.target.value)}
+        />
+        <TextField
+          label="Notes"
+          multiline
+          minRows={3}
+          value={summary}
+          onChange={(e) => setSummary(e.target.value)}
+        />
+        <Button variant="contained" onClick={handleSave}>
+          Save Offer
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/Offers/OfferList.tsx
+++ b/src/components/talentforge/Offers/OfferList.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from "@mui/material";
+import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
+import { exportElementToPdf } from "@/utils/pdfExport";
+
+interface OfferListProps {
+  refreshKey?: number;
+}
+
+export default function OfferList({ refreshKey }: OfferListProps) {
+  const [offers, setOffers] = useState<Offer[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const markdownRef = useRef<HTMLPreElement>(null);
+
+  useEffect(() => {
+    setOffers(getOffers());
+  }, [refreshKey]);
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const selectedOffers = offers.filter((o) => selected.has(o.id));
+
+  const getComp = (offer: Offer, type: string) => {
+    return offer.compensation.find((c) => c.type === type)?.amount || 0;
+  };
+
+  const exportMarkdown = () => {
+    const headers = ["Component", ...selectedOffers.map((_, i) => `Offer ${i + 1}`)];
+    const comps = ["salary", "bonus", "equity"] as const;
+    const rows = comps.map((c) => [
+      c.charAt(0).toUpperCase() + c.slice(1),
+      ...selectedOffers.map((o) => getComp(o, c)),
+    ]);
+    const markdown = [
+      `| ${headers.join(" | ")} |`,
+      `| ${headers.map(() => "---").join(" | ")} |`,
+      ...rows.map((r) => `| ${r.join(" | ")} |`),
+    ].join("\n");
+    if (markdownRef.current) {
+      markdownRef.current.innerText = markdown;
+      exportElementToPdf(markdownRef.current, "offer-comparison.md");
+    }
+  };
+
+  return (
+    <Box>
+      <List>
+        {offers.map((offer, index) => (
+          <ListItem
+            key={offer.id}
+            button
+            onClick={() => toggleSelect(offer.id)}
+          >
+            <ListItemIcon>
+              <Checkbox edge="start" checked={selected.has(offer.id)} />
+            </ListItemIcon>
+            <ListItemText
+              primary={`Offer ${index + 1}`}
+              secondary={
+                offer.summary ||
+                offer.compensation
+                  .map((c) => `${c.type}: ${c.amount}`)
+                  .join(", ")
+              }
+            />
+          </ListItem>
+        ))}
+      </List>
+      {selectedOffers.length > 0 && (
+        <Box sx={{ mt: 2 }}>
+          <TableContainer component={Paper} sx={{ mb: 2 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Component</TableCell>
+                  {selectedOffers.map((_, i) => (
+                    <TableCell key={i}>{`Offer ${i + 1}`}</TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {(["salary", "bonus", "equity"] as const).map((c) => (
+                  <TableRow key={c}>
+                    <TableCell>{c.charAt(0).toUpperCase() + c.slice(1)}</TableCell>
+                    {selectedOffers.map((o) => (
+                      <TableCell key={o.id}>{getComp(o, c)}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <Button variant="contained" onClick={exportMarkdown}>
+            Export to Markdown
+          </Button>
+          <pre ref={markdownRef} style={{ display: "none" }} />
+        </Box>
+      )}
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add OfferDetail form to capture salary, bonus, and equity using unified model
- list and compare offers with table export to markdown via pdfExport
- integrate new offer components into offers page

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c6716dca248330952156a7ac3b2215