### PR TITLE
Add drag-and-drop application board with status history

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@mui/icons-material": "^6.5.0",
     "@mui/lab": "^6.0.1-beta.36",
     "@mui/material": "^6.5.0",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/utilities": "^3.2.1",
     "bio-parsers": "^9.3.6",
     "dnaviz": "^1.1.1",
     "lodash": "^4.17.21",

--- a/src/app/talentforge/applications/page.tsx
+++ b/src/app/talentforge/applications/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import JobApplications from "@/components/talentforge/JobApplications";
+import ApplicationBoard from "@/components/talentforge/ApplicationBoard";
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 export default function ApplicationsPage() {
   return (
     <ErrorBoundary>
-      <JobApplications />
+      <ApplicationBoard />
     </ErrorBoundary>
   );
 }

--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { v4 as uuid } from "uuid";
+import {
+  DndContext,
+  useDraggable,
+  useDroppable,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import type { ApplicationStatus, JobApplication } from "@/types/talentforge";
+import {
+  addJobApplication,
+  getJobApplications,
+  updateJobApplicationStatus,
+} from "@/utils/talentforge/applicationStore";
+import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
+
+const STATUSES: ApplicationStatus[] = [
+  "applied",
+  "interview",
+  "offer",
+  "rejected",
+];
+
+function Column({
+  id,
+  title,
+  children,
+}: {
+  id: ApplicationStatus;
+  title: string;
+  children: React.ReactNode;
+}) {
+  const { setNodeRef } = useDroppable({ id });
+  return (
+    <Paper
+      ref={setNodeRef}
+      sx={{ p: 2, width: 260, minHeight: 400, bgcolor: "background.paper" }}
+    >
+      <Typography variant="h6" gutterBottom>
+        {title}
+      </Typography>
+      <Stack spacing={1}>{children}</Stack>
+    </Paper>
+  );
+}
+
+function Card({ app }: { app: JobApplication }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: app.id });
+  const style = {
+    transform: transform ? CSS.Translate.toString(transform) : undefined,
+    opacity: isDragging ? 0.5 : 1,
+    cursor: "grab",
+  } as const;
+
+  return (
+    <Box
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      sx={{
+        p: 1,
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1,
+        bgcolor: "background.default",
+        ...style,
+      }}
+    >
+      <Typography fontWeight="bold">{app.title}</Typography>
+      <Typography variant="body2" color="text.secondary">
+        {app.company} – {app.location}
+      </Typography>
+    </Box>
+  );
+}
+
+export default function ApplicationBoard() {
+  const [applications, setApplications] = useState<JobApplication[]>([]);
+
+  useEffect(() => {
+    const existing = getJobApplications();
+    if (existing.length === 0) {
+      fetchAllListings().then((listings) => {
+        let apps = existing;
+        listings.forEach((listing) => {
+          apps = addJobApplication({
+            ...listing,
+            id: uuid(),
+            status: "applied",
+            history: [
+              { status: "applied", changedAt: new Date().toISOString() },
+            ],
+          });
+        });
+        setApplications(apps);
+      });
+    } else {
+      setApplications(existing);
+    }
+  }, []);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const newStatus = over.id as ApplicationStatus;
+    const updated = updateJobApplicationStatus(active.id as string, newStatus);
+    setApplications(updated);
+  };
+
+  return (
+    <DndContext onDragEnd={handleDragEnd}>
+      <Box sx={{ display: "flex", gap: 2 }}>
+        {STATUSES.map((status) => (
+          <Column
+            key={status}
+            id={status}
+            title={status.charAt(0).toUpperCase() + status.slice(1)}
+          >
+            {applications
+              .filter((app) => app.status === status)
+              .map((app) => (
+                <Card key={app.id} app={app} />
+              ))}
+          </Column>
+        ))}
+      </Box>
+    </DndContext>
+  );
+}
+

--- a/src/components/talentforge/JobApplications.tsx
+++ b/src/components/talentforge/JobApplications.tsx
@@ -42,6 +42,9 @@ export default function JobApplications() {
             ...listing,
             id: uuid(),
             status: "applied",
+            history: [
+              { status: "applied", changedAt: new Date().toISOString() },
+            ],
           });
         });
         setApplications(apps);

--- a/src/types/talentforge/job.ts
+++ b/src/types/talentforge/job.ts
@@ -17,9 +17,18 @@ export type ApplicationStatus =
   | "offer"
   | "rejected";
 
+export interface StatusChange {
+  /** Status the application transitioned to. */
+  status: ApplicationStatus;
+  /** ISO timestamp when the status changed. */
+  changedAt: string;
+}
+
 export interface JobApplication extends JobListing {
   /** Unique identifier for the job application */
   id: string;
   /** Current status of the job application */
   status: ApplicationStatus;
+  /** History of status changes for this application */
+  history: StatusChange[];
 }

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -1,4 +1,4 @@
-import type { ApplicationStatus } from "./job";
+import type { ApplicationStatus, StatusChange } from "./job";
 
 export interface User {
   /** Unique identifier for the user. */
@@ -56,6 +56,8 @@ export interface ApplicationRecord {
   resumeVariant?: ResumeVariant;
   /** Current status of the application. */
   status: ApplicationStatus;
+  /** History of status changes for the application. */
+  history: StatusChange[];
   /** Recruiters associated with this application. */
   recruiters?: Recruiter[];
   /** Conversation threads about this application. */

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -47,6 +47,9 @@ export const mockApplications: JobApplication[] = [
     url: "https://example.com/jobs/frontend",
     source: "linkedin",
     status: "applied",
+    history: [
+      { status: "applied", changedAt: new Date().toISOString() },
+    ],
   },
   {
     id: "app-2",
@@ -56,6 +59,9 @@ export const mockApplications: JobApplication[] = [
     url: "https://example.com/jobs/backend",
     source: "indeed",
     status: "interview",
+    history: [
+      { status: "interview", changedAt: new Date().toISOString() },
+    ],
   },
 ];
 

--- a/src/utils/talentforge/applicationStore.ts
+++ b/src/utils/talentforge/applicationStore.ts
@@ -25,15 +25,29 @@ export function updateJobApplicationStatus(
   id: string,
   status: ApplicationStatus,
 ): JobApplication[] {
-  const apps = getJobApplications().map((app) =>
-    app.id === id ? { ...app, status } : app,
-  );
+  const apps = getJobApplications().map((app) => {
+    if (app.id === id) {
+      const history = [
+        ...(app.history ?? []),
+        { status, changedAt: new Date().toISOString() },
+      ];
+      return { ...app, status, history };
+    }
+    return app;
+  });
   setJobApplications(apps);
   return apps;
 }
 
 export function addJobApplication(app: JobApplication): JobApplication[] {
-  const apps = [...getJobApplications(), app];
+  const appWithHistory = {
+    ...app,
+    history: [
+      ...(app.history ?? []),
+      { status: app.status, changedAt: new Date().toISOString() },
+    ],
+  };
+  const apps = [...getJobApplications(), appWithHistory];
   setJobApplications(apps);
   return apps;
 }

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -249,7 +249,14 @@ export function getJobApplications(): JobApplication[] {
   return load("applications", []);
 }
 export function addJobApplication(app: JobApplication): JobApplication[] {
-  const updated = [...getJobApplications(), app];
+  const withHistory = {
+    ...app,
+    history: [
+      ...(app.history ?? []),
+      { status: app.status, changedAt: new Date().toISOString() },
+    ],
+  } as JobApplication;
+  const updated = [...getJobApplications(), withHistory];
   save("applications", updated);
   return updated;
 }
@@ -257,9 +264,16 @@ export function updateJobApplicationStatus(
   id: string,
   status: ApplicationStatus,
 ): JobApplication[] {
-  const updated = getJobApplications().map((app) =>
-    app.id === id ? { ...app, status } : app,
-  );
+  const updated = getJobApplications().map((app) => {
+    if (app.id === id) {
+      const history = [
+        ...(app.history || []),
+        { status, changedAt: new Date().toISOString() },
+      ];
+      return { ...app, status, history };
+    }
+    return app;
+  });
   save("applications", updated);
   return updated;
 }

--- a/src/utils/talentforge/demoData.ts
+++ b/src/utils/talentforge/demoData.ts
@@ -49,6 +49,9 @@ export function getDemoData(): {
     role,
     resumeVariant: resume as ResumeVariant,
     status: "applied",
+    history: [
+      { status: "applied", changedAt: new Date().toISOString() },
+    ],
     recruiters: [],
     threads: [],
   };


### PR DESCRIPTION
## Summary
- add application board component with @dnd-kit drag-and-drop between status columns
- persist application status changes and track history on records
- expose board in applications page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67169594c83309ed4abeaa09fb62f