### PR TITLE
feat: add recruiter management

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/utils/autoReply";
 
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-import { Message } from "@/utils/talentforge/dataStore";
+import { Message, RecruiterEntry } from "@/utils/talentforge/dataStore";
 import { v4 as uuidv4 } from "uuid";
 
 export default function Inbox() {
@@ -35,9 +35,11 @@ export default function Inbox() {
   const [templates, setTemplates] = useState<Record<string, AutoReplyTemplate>>({});
   const [quickTones, setQuickTones] = useState<Record<string, AutoReplyTemplate>>({});
   const [search, setSearch] = useState("");
+  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
 
   useEffect(() => {
     setMessages(data.getMessages());
+    setRecruiters(data.getRecruiters());
   }, [data]);
 
   const handleFilterChange = (event: SelectChangeEvent) => {
@@ -84,6 +86,12 @@ export default function Inbox() {
     setMessages(updated);
   };
 
+  const handleLinkRecruiter = (threadId: string, recruiterId: string) => {
+    const updated = data.linkThreadToRecruiter(threadId, recruiterId);
+    setMessages(updated);
+    setRecruiters(data.getRecruiters());
+  };
+
   const handleOpenThread = (message: Message) => {
     const isCurrent = replyingTo === message.id;
     setReplyingTo((current) => (current === message.id ? null : message.id));
@@ -123,13 +131,31 @@ export default function Inbox() {
                   }
                   secondary={message.body}
                 />
-                <Stack direction="row" spacing={1}>
+                <Stack direction="row" spacing={1} alignItems="center">
                   <Button size="small" onClick={() => handleOpenThread(message)}>
                     Reply
                   </Button>
                   <Button size="small" onClick={() => handleToggleStatus(message)}>
                     {message.status === "unread" ? "Mark read" : "Mark unread"}
                   </Button>
+                  <Select
+                    size="small"
+                    displayEmpty
+                    value={message.recruiterId || ""}
+                    onChange={(e) =>
+                      handleLinkRecruiter(message.id, e.target.value as string)
+                    }
+                    sx={{ minWidth: 160 }}
+                  >
+                    <MenuItem value="">
+                      <em>No recruiter</em>
+                    </MenuItem>
+                    {recruiters.map((r) => (
+                      <MenuItem key={r.id} value={r.id}>
+                        {r.name}
+                      </MenuItem>
+                    ))}
+                  </Select>
                 </Stack>
                 {replyingTo === message.id && (
                   <Stack spacing={2} sx={{ mt: 1 }}>

--- a/src/components/talentforge/Recruiters/List.tsx
+++ b/src/components/talentforge/Recruiters/List.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Stack,
+  Typography,
+  Chip,
+  TextField,
+  Button,
+} from "@mui/material";
+import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import type {
+  RecruiterEntry,
+  Message,
+} from "@/utils/talentforge/dataStore";
+
+export default function RecruiterList() {
+  const data = useTalentForgeData();
+  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  useEffect(() => {
+    setRecruiters(data.getRecruiters());
+    setMessages(data.getMessages());
+  }, [data]);
+
+  const handleSave = (recruiter: RecruiterEntry) => {
+    const updated = data.updateRecruiter(recruiter);
+    setRecruiters(updated);
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        Recruiters
+      </Typography>
+      {recruiters.map((r) => (
+        <Box key={r.id} sx={{ mb: 3 }}>
+          <Typography variant="subtitle1" fontWeight="bold">
+            {r.name}
+          </Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            {r.tags.map((tag) => (
+              <Chip key={tag} label={tag} sx={{ mb: 1 }} />
+            ))}
+          </Stack>
+          <TextField
+            label="Tags"
+            value={r.tags.join(", ")}
+            onChange={(e) =>
+              setRecruiters((rec) =>
+                rec.map((rr) =>
+                  rr.id === r.id
+                    ? {
+                        ...rr,
+                        tags: e.target.value
+                          .split(",")
+                          .map((t) => t.trim())
+                          .filter(Boolean),
+                      }
+                    : rr,
+                ),
+              )
+            }
+            sx={{ mt: 1 }}
+            fullWidth
+          />
+          <TextField
+            label="Notes"
+            multiline
+            rows={3}
+            value={r.notes}
+            onChange={(e) =>
+              setRecruiters((rec) =>
+                rec.map((rr) =>
+                  rr.id === r.id ? { ...rr, notes: e.target.value } : rr,
+                ),
+              )
+            }
+            sx={{ mt: 1 }}
+            fullWidth
+          />
+          <Button
+            variant="contained"
+            size="small"
+            sx={{ mt: 1 }}
+            onClick={() => handleSave(r)}
+          >
+            Save
+          </Button>
+          {r.threadIds.length > 0 && (
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="body2" color="text.secondary">
+                Threads:
+              </Typography>
+              {r.threadIds.map((id) => {
+                const msg = messages.find((m) => m.id === id);
+                return (
+                  <Typography key={id} variant="body2">
+                    {msg ? msg.body : id}
+                  </Typography>
+                );
+              })}
+            </Box>
+          )}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -73,6 +73,14 @@ export interface Recruiter {
   email?: string;
   /** Applications managed by this recruiter. */
   applications?: ApplicationRecord[];
+  /** Connector that surfaced this recruiter. */
+  connector?: string;
+  /** Tags describing the recruiter. */
+  tags?: string[];
+  /** Notes about the recruiter. */
+  notes?: string;
+  /** Message thread IDs linked to this recruiter. */
+  threadIds?: string[];
 }
 
 export interface Thread {
@@ -93,6 +101,8 @@ export interface Message {
   threadId: string;
   /** Identifier of the sender (user or recruiter). */
   senderId: string;
+  /** Recruiter associated with this thread, if any. */
+  recruiterId?: string;
   /** Timestamp in ISO format indicating when the message was sent. */
   sentAt: string;
   /** Body content of the message. */

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -15,6 +15,7 @@ import type {
   Offer as ModelOffer,
   ApplicationRecord,
   OfferComp,
+  Recruiter,
 } from "@/types";
 import { ParsedResume } from "@/types/talentforge/resume";
 
@@ -42,12 +43,20 @@ export type Offer = ModelOffer;
 
 export type JobApplication = ApplicationRecord;
 
+export type RecruiterEntry = Recruiter & {
+  connector: string;
+  tags: string[];
+  notes: string;
+  threadIds: string[];
+};
+
 interface StoreSchema {
   user: UserProfile | undefined;
   resumes: ResumeEntry[];
   messages: Message[];
   offers: Offer[];
   applications: JobApplication[];
+  recruiters: RecruiterEntry[];
   onboarding: number;
   openai: string | undefined;
   connectorTokens: Record<string, ConnectorToken>;
@@ -59,6 +68,7 @@ const KEYS: { [K in keyof StoreSchema]: string } = {
   messages: "messages",
   offers: "offers",
   applications: "jobApplications",
+  recruiters: "recruiters",
   onboarding: "onboardingStep",
   openai: "talentforge-openai-key",
   connectorTokens: "connectorTokens",
@@ -70,6 +80,7 @@ const VERSION: { [K in keyof StoreSchema]: number } = {
   messages: 2,
   offers: 2,
   applications: 1,
+  recruiters: 1,
   onboarding: 1,
   openai: 1,
   connectorTokens: 1,
@@ -269,6 +280,53 @@ export function deleteJobApplication(id: string): JobApplication[] {
   return updated;
 }
 
+// Recruiters
+export function getRecruiters(): RecruiterEntry[] {
+  return load("recruiters", []);
+}
+
+export function addRecruiter(recruiter: RecruiterEntry): RecruiterEntry[] {
+  const updated = [...getRecruiters(), recruiter];
+  save("recruiters", updated);
+  return updated;
+}
+
+export function updateRecruiter(recruiter: RecruiterEntry): RecruiterEntry[] {
+  const updated = getRecruiters().map((r) =>
+    r.id === recruiter.id ? recruiter : r,
+  );
+  save("recruiters", updated);
+  return updated;
+}
+
+export function deleteRecruiter(id: string): RecruiterEntry[] {
+  const updated = getRecruiters().filter((r) => r.id !== id);
+  save("recruiters", updated);
+  return updated;
+}
+
+export function linkThreadToRecruiter(
+  threadId: string,
+  recruiterId: string,
+): Message[] {
+  const messages = getMessages().map((m) =>
+    m.id === threadId ? { ...m, recruiterId } : m,
+  );
+  save("messages", messages);
+
+  const recruiters = getRecruiters();
+  for (const r of recruiters) {
+    const hasThread = r.threadIds.includes(threadId);
+    if (r.id === recruiterId && !hasThread) {
+      r.threadIds.push(threadId);
+    } else if (r.id !== recruiterId && hasThread) {
+      r.threadIds = r.threadIds.filter((t) => t !== threadId);
+    }
+  }
+  save("recruiters", recruiters);
+  return messages;
+}
+
 // Onboarding step
 export function getOnboardingStep(): number {
   return load("onboarding", 0);
@@ -378,6 +436,11 @@ const dataStore = {
   addJobApplication,
   updateJobApplicationStatus,
   deleteJobApplication,
+  getRecruiters,
+  addRecruiter,
+  updateRecruiter,
+  deleteRecruiter,
+  linkThreadToRecruiter,
   getOnboardingStep,
   setOnboardingStep,
   clearOnboardingStep,
@@ -391,7 +454,7 @@ const dataStore = {
   importFromJson,
 };
 
-export type { ResumeEntry, Message, Offer, JobApplication };
+export type { ResumeEntry, Message, Offer, JobApplication, RecruiterEntry };
 
 export default dataStore;
 


### PR DESCRIPTION
## Summary
- add recruiter slice with notes, tags, and thread links
- list recruiters and edit notes/tags
- associate inbox threads with recruiters

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c67177188c83308b7726d3582f9bc5