### PR TITLE
feat: add threaded inbox with ai drafting

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -4,8 +4,12 @@ import { useEffect, useState } from "react";
 import {
   Box,
   Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   List,
-  ListItem,
+  ListItemButton,
   ListItemText,
   MenuItem,
   Select,
@@ -25,16 +29,27 @@ import {
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import { Message } from "@/utils/talentforge/dataStore";
 import { v4 as uuidv4 } from "uuid";
+import PromptTileGrid from "./promptTiles/PromptTileGrid";
+
+const CONNECTORS = ["Email", "LinkedIn", "Indeed"];
 
 export default function Inbox() {
   const data = useTalentForgeData();
   const [messages, setMessages] = useState<Message[]>([]);
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
-  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
-  const [templates, setTemplates] = useState<Record<string, AutoReplyTemplate>>({});
-  const [quickTones, setQuickTones] = useState<Record<string, AutoReplyTemplate>>({});
+  const [templates, setTemplates] = useState<Record<string, AutoReplyTemplate>>(
+    {},
+  );
+  const [quickTones, setQuickTones] = useState<
+    Record<string, AutoReplyTemplate>
+  >({});
+  const [replyConnectors, setReplyConnectors] = useState<
+    Record<string, string>
+  >({});
   const [search, setSearch] = useState("");
+  const [openAi, setOpenAi] = useState(false);
 
   useEffect(() => {
     setMessages(data.getMessages());
@@ -47,7 +62,9 @@ export default function Inbox() {
   const filteredMessages = filterByText(messages, search, [
     "body",
     "connector",
-  ]).filter((message) => filter === "all" || message.status === filter);
+  ]).filter((m) => filter === "all" || m.status === filter);
+
+  const selected = messages.find((m) => m.id === selectedId) || null;
 
   const handleAutoReply = async (message: Message) => {
     const template = templates[message.id] || "general";
@@ -62,7 +79,13 @@ export default function Inbox() {
     const text = await autoReply(
       buildAutoReplyMessages(tone, message.body),
     );
-    const reply = { id: uuidv4(), body: text, sentAt: new Date().toISOString() };
+    const connector = replyConnectors[message.id] || message.connector;
+    const reply = {
+      id: uuidv4(),
+      body: text,
+      sentAt: new Date().toISOString(),
+      connector,
+    };
     const updated = data.addMessageReply(message.id, reply);
     setMessages(updated);
   };
@@ -70,7 +93,13 @@ export default function Inbox() {
   const handleSendReply = (message: Message) => {
     const text = drafts[message.id];
     if (!text) return;
-    const reply = { id: uuidv4(), body: text, sentAt: new Date().toISOString() };
+    const connector = replyConnectors[message.id] || message.connector;
+    const reply = {
+      id: uuidv4(),
+      body: text,
+      sentAt: new Date().toISOString(),
+      connector,
+    };
     const updated = data.addMessageReply(message.id, reply);
     setMessages(updated);
     setDrafts((d) => ({ ...d, [message.id]: "" }));
@@ -84,16 +113,21 @@ export default function Inbox() {
     setMessages(updated);
   };
 
-  const handleOpenThread = (message: Message) => {
-    const isCurrent = replyingTo === message.id;
-    setReplyingTo((current) => (current === message.id ? null : message.id));
-    if (!isCurrent && !drafts[message.id]) {
+  const handleSelect = (message: Message) => {
+    setSelectedId(message.id);
+    if (!drafts[message.id]) {
       void handleAutoReply(message);
     }
     if (message.status === "unread") {
       const updated = data.updateMessageStatus(message.id, "read");
       setMessages(updated);
     }
+  };
+
+  const insertFromAi = (text: string) => {
+    if (!selected) return;
+    setDrafts((d) => ({ ...d, [selected.id]: text }));
+    setOpenAi(false);
   };
 
   return (
@@ -111,10 +145,15 @@ export default function Inbox() {
           onChange={(e) => setSearch(e.target.value)}
           sx={{ maxWidth: 300 }}
         />
-        <List>
-          {filteredMessages.map((message) => (
-            <ListItem key={message.id} alignItems="flex-start">
-              <Stack spacing={1} sx={{ width: "100%" }}>
+        <Box sx={{ display: "flex", gap: 2 }}>
+          <List sx={{ width: 300, flexShrink: 0 }}>
+            {filteredMessages.map((message) => (
+              <ListItemButton
+                key={message.id}
+                selected={selectedId === message.id}
+                onClick={() => handleSelect(message)}
+                alignItems="flex-start"
+              >
                 <ListItemText
                   primary={
                     <Typography variant="subtitle1" fontWeight="bold">
@@ -123,82 +162,128 @@ export default function Inbox() {
                   }
                   secondary={message.body}
                 />
-                <Stack direction="row" spacing={1}>
-                  <Button size="small" onClick={() => handleOpenThread(message)}>
-                    Reply
-                  </Button>
-                  <Button size="small" onClick={() => handleToggleStatus(message)}>
-                    {message.status === "unread" ? "Mark read" : "Mark unread"}
+              </ListItemButton>
+            ))}
+          </List>
+          <Box sx={{ flexGrow: 1 }}>
+            {selected ? (
+              <Stack spacing={2}>
+                <Typography variant="h6">{selected.connector}</Typography>
+                <Typography>{selected.body}</Typography>
+                {selected.replies.map((r) => (
+                  <Typography key={r.id} variant="body2">
+                    [{r.connector}] {r.body}
+                  </Typography>
+                ))}
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Select
+                    size="small"
+                    value={quickTones[selected.id] || "politeFollowUp"}
+                    onChange={(e) =>
+                      setQuickTones((t) => ({
+                        ...t,
+                        [selected.id]: e.target.value as AutoReplyTemplate,
+                      }))
+                    }
+                    sx={{ maxWidth: 200 }}
+                  >
+                    <MenuItem value="politeFollowUp">Polite follow-up</MenuItem>
+                    <MenuItem value="politeDecline">Politely decline</MenuItem>
+                  </Select>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => void handleQuickInsert(selected)}
+                  >
+                    Quick insert
                   </Button>
                 </Stack>
-                {replyingTo === message.id && (
-                  <Stack spacing={2} sx={{ mt: 1 }}>
-                    {message.replies.map((r) => (
-                      <Typography key={r.id} variant="body2">
-                        {r.body}
-                      </Typography>
+                <TextField
+                  label="Your reply"
+                  multiline
+                  rows={4}
+                  fullWidth
+                  value={drafts[selected.id] || ""}
+                  onChange={(e) =>
+                    setDrafts((d) => ({ ...d, [selected.id]: e.target.value }))
+                  }
+                />
+                <Select
+                  size="small"
+                  value={templates[selected.id] || "general"}
+                  onChange={(e) =>
+                    setTemplates((t) => ({
+                      ...t,
+                      [selected.id]: e.target.value as AutoReplyTemplate,
+                    }))
+                  }
+                  sx={{ maxWidth: 200 }}
+                >
+                  <MenuItem value="general">General</MenuItem>
+                  <MenuItem value="politeDecline">Politely decline</MenuItem>
+                  <MenuItem value="requestMoreInfo">Request more info</MenuItem>
+                </Select>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Select
+                    size="small"
+                    value={replyConnectors[selected.id] || selected.connector}
+                    onChange={(e) =>
+                      setReplyConnectors((c) => ({
+                        ...c,
+                        [selected.id]: e.target.value,
+                      }))
+                    }
+                    sx={{ maxWidth: 200 }}
+                  >
+                    {CONNECTORS.map((c) => (
+                      <MenuItem key={c} value={c}>
+                        {c}
+                      </MenuItem>
                     ))}
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      <Select
-                        size="small"
-                        value={quickTones[message.id] || "politeFollowUp"}
-                        onChange={(e) =>
-                          setQuickTones((t) => ({
-                            ...t,
-                            [message.id]: e.target.value as AutoReplyTemplate,
-                          }))
-                        }
-                        sx={{ maxWidth: 200 }}
-                      >
-                        <MenuItem value="politeFollowUp">Polite follow-up</MenuItem>
-                        <MenuItem value="politeDecline">Politely decline</MenuItem>
-                      </Select>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        onClick={() => void handleQuickInsert(message)}
-                      >
-                        Quick insert
-                      </Button>
-                    </Stack>
-                    <TextField
-                      label="Your reply"
-                      multiline
-                      rows={4}
-                      fullWidth
-                      value={drafts[message.id] || ""}
-                      onChange={(e) =>
-                        setDrafts((d) => ({ ...d, [message.id]: e.target.value }))
-                      }
-                    />
-                    <Select
-                      size="small"
-                      value={templates[message.id] || "general"}
-                      onChange={(e) =>
-                        setTemplates((t) => ({
-                          ...t,
-                          [message.id]: e.target.value as AutoReplyTemplate,
-                        }))
-                      }
-                      sx={{ maxWidth: 200 }}
-                    >
-                      <MenuItem value="general">General</MenuItem>
-                      <MenuItem value="politeDecline">Politely decline</MenuItem>
-                      <MenuItem value="requestMoreInfo">Request more info</MenuItem>
-                    </Select>
-                    <Button
-                      variant="contained"
-                      onClick={() => handleSendReply(message)}
-                    >
-                      Send
-                    </Button>
-                  </Stack>
-                )}
+                  </Select>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => setOpenAi(true)}
+                  >
+                    Draft with AI
+                  </Button>
+                  <Button
+                    variant="contained"
+                    onClick={() => handleSendReply(selected)}
+                  >
+                    Send
+                  </Button>
+                  <Button
+                    size="small"
+                    onClick={() => handleToggleStatus(selected)}
+                  >
+                    {selected.status === "unread"
+                      ? "Mark read"
+                      : "Mark unread"}
+                  </Button>
+                </Stack>
               </Stack>
-            </ListItem>
-          ))}
-        </List>
+            ) : (
+              <Typography>Select a thread</Typography>
+            )}
+          </Box>
+        </Box>
       </Stack>
+      <Dialog
+        open={openAi}
+        onClose={() => setOpenAi(false)}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle>Draft with AI</DialogTitle>
+        <DialogContent>
+          <PromptTileGrid onInsert={insertFromAi} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenAi(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/talentforge/promptTiles/PromptTileGrid.tsx
+++ b/src/components/talentforge/promptTiles/PromptTileGrid.tsx
@@ -5,12 +5,16 @@ import { Grid } from "@mui/material";
 import Tile from "./Tile";
 import { PROMPT_TILES } from "@/consts/promptTiles";
 
-export default function PromptTileGrid() {
+interface PromptTileGridProps {
+  onInsert?: (text: string) => void;
+}
+
+export default function PromptTileGrid({ onInsert }: PromptTileGridProps) {
   return (
     <Grid container spacing={2}>
       {Object.values(PROMPT_TILES).map((tile) => (
         <Grid item xs={12} sm={6} md={4} key={tile.id}>
-          <Tile {...tile} />
+          <Tile {...tile} onInsert={onInsert} />
         </Grid>
       ))}
     </Grid>

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -21,15 +21,19 @@ import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { v4 as uuid } from "uuid";
 
 export interface PromptTileProps {
+  id: string;
   display: string;
   fullPrompt: string;
   inputs: string[];
+  onInsert?: (text: string) => void;
 }
 
 export default function Tile({
+  id,
   display,
   fullPrompt,
   inputs,
+  onInsert,
 }: PromptTileProps) {
   const [values, setValues] = useState<Record<string, string>>({});
   const [response, setResponse] = useState("");
@@ -133,7 +137,7 @@ export default function Tile({
               </Button>
             )}
             <Box>
-              <Box display="flex" justifyContent="flex-end">
+              <Box display="flex" justifyContent="flex-end" gap={1}>
                 {navigator.clipboard && (
                   <Tooltip title="copy to clipboard" arrow>
                     <IconButton
@@ -144,6 +148,11 @@ export default function Tile({
                       <ContentCopy fontSize="small" />
                     </IconButton>
                   </Tooltip>
+                )}
+                {onInsert && (
+                  <Button size="small" onClick={() => onInsert(response)}>
+                    Insert
+                  </Button>
                 )}
               </Box>
               <Markdown>{response}</Markdown>

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -30,6 +30,7 @@ export type MessageReply = {
   id: string;
   body: string;
   sentAt: string;
+  connector: string;
 };
 
 export interface Message extends ModelMessage {
@@ -67,7 +68,7 @@ const KEYS: { [K in keyof StoreSchema]: string } = {
 const VERSION: { [K in keyof StoreSchema]: number } = {
   user: 1,
   resumes: 1,
-  messages: 2,
+  messages: 3,
   offers: 2,
   applications: 1,
   onboarding: 1,
@@ -117,6 +118,7 @@ interface LegacyMessageReply {
   id: string;
   content: string;
   sentAt: string;
+  connector?: string;
 }
 
 interface LegacyMessage {
@@ -150,7 +152,12 @@ function migrateLegacyMessages(data: unknown): Message[] {
     connector: m.connector,
     status: m.status,
     replies: Array.isArray(m.replies)
-      ? m.replies.map((r) => ({ id: r.id, body: r.content, sentAt: r.sentAt }))
+      ? m.replies.map((r) => ({
+          id: r.id,
+          body: r.content,
+          sentAt: r.sentAt,
+          connector: r.connector || m.connector,
+        }))
       : [],
   }));
 }


### PR DESCRIPTION
## Summary
- Split inbox into thread list and message view with optional AI-generated drafts
- Allow inserting prompt tile responses directly into replies
- Store connector-specific message replies in the data layer

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c671807e58833092255060f1c193cf