### PR TITLE
fix: remove extraneous prop from BulletVariants

### DIFF
--- a/src/components/talentforge/ResumeVariants/Detail.tsx
+++ b/src/components/talentforge/ResumeVariants/Detail.tsx
@@ -54,7 +54,7 @@ export default function Detail({
               value={content}
               onChange={(e) => setContent(e.target.value)}
             />
-            <BulletVariants content={content} setContent={setContent} />
+            <BulletVariants setContent={setContent} />
             <TextField
               label="Tags"
               value={tagsText}


### PR DESCRIPTION
## Summary
- remove unused `content` prop when rendering `BulletVariants`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67260fa248330bc9675bdc5b94d24