### PR TITLE
feat: add talentforge workspace with output panel

### DIFF
--- a/src/components/talentforge/Workspace.tsx
+++ b/src/components/talentforge/Workspace.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, Stack, Typography } from "@mui/material";
+
+import { PROMPT_TILES } from "@/consts/promptTiles";
+import Tile from "./promptTiles/Tile";
+
+interface WorkspaceProps {
+  onInsertIntoThread?: (text: string) => void;
+  onSaveResumeVariant?: (text: string) => void;
+}
+
+export default function Workspace({
+  onInsertIntoThread,
+  onSaveResumeVariant,
+}: WorkspaceProps) {
+  const [output, setOutput] = useState("");
+
+  const handleCopy = () => {
+    if (navigator.clipboard && output) {
+      navigator.clipboard.writeText(output);
+    }
+  };
+
+  const handleInsert = () => {
+    onInsertIntoThread?.(output);
+  };
+
+  const handleSave = () => {
+    onSaveResumeVariant?.(output);
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "column", md: "row" },
+        gap: 2,
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          display: "grid",
+          gridTemplateColumns: {
+            xs: "1fr",
+            sm: "repeat(2, 1fr)",
+            md: "repeat(3, 1fr)",
+          },
+          gap: 2,
+        }}
+      >
+        {Object.values(PROMPT_TILES).map((tile) => (
+          <Tile key={tile.id} {...tile} onResponse={setOutput} />
+        ))}
+      </Box>
+      <Box
+        sx={{
+          flexBasis: { md: "30%" },
+          border: 1,
+          borderColor: "divider",
+          p: 2,
+          borderRadius: 1,
+          minHeight: 200,
+        }}
+      >
+        <Typography variant="h6" gutterBottom>
+          Output
+        </Typography>
+        <Box sx={{ whiteSpace: "pre-wrap", mb: 2 }}>{output}</Box>
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" onClick={handleCopy} disabled={!output}>
+            Copy
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={handleInsert}
+            disabled={!onInsertIntoThread || !output}
+          >
+            Insert into Thread
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={!onSaveResumeVariant || !output}
+          >
+            Save as Resume Variant
+          </Button>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -21,15 +21,19 @@ import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { v4 as uuid } from "uuid";
 
 export interface PromptTileProps {
+  id: string;
   display: string;
   fullPrompt: string;
   inputs: string[];
+  onResponse?: (response: string) => void;
 }
 
 export default function Tile({
+  id,
   display,
   fullPrompt,
   inputs,
+  onResponse,
 }: PromptTileProps) {
   const [values, setValues] = useState<Record<string, string>>({});
   const [response, setResponse] = useState("");
@@ -72,7 +76,9 @@ export default function Tile({
         returnFirstResponse: true,
         chatHistory: [],
       });
-      setResponse(res?.message || "");
+      const message = res?.message || "";
+      setResponse(message);
+      onResponse?.(message);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- add `Workspace` component arranging prompt tiles in a CSS grid with an output panel
- expose LLM results via actions: Copy, Insert into Thread, Save as Resume Variant
- update prompt tile to notify parent components of new responses

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c6739486f88330a5aae1fa01f0a6fc