### PR TITLE
feat: add threaded inbox with AI drafting

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from "react";
 import {
   Box,
   Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
   List,
   ListItem,
   ListItemText,
@@ -25,20 +28,25 @@ import {
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import { Message, RecruiterEntry } from "@/utils/talentforge/dataStore";
 import { v4 as uuidv4 } from "uuid";
+import PromptSelector from "./PromptSelector";
+import Tile from "./promptTiles/Tile";
+import { PROMPT_TILES } from "@/consts/promptTiles";
 
 export default function Inbox() {
   const data = useTalentForgeData();
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [threads, setThreads] = useState<Message[]>([]);
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
-  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [templates, setTemplates] = useState<Record<string, AutoReplyTemplate>>({});
   const [quickTones, setQuickTones] = useState<Record<string, AutoReplyTemplate>>({});
   const [search, setSearch] = useState("");
   const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
+  const [aiThread, setAiThread] = useState<string | null>(null);
+  const [promptKey, setPromptKey] = useState<string>("");
 
   useEffect(() => {
-    setMessages(data.getMessages());
+    setThreads(data.getThreads());
     setRecruiters(data.getRecruiters());
   }, [data]);
 
@@ -46,185 +54,224 @@ export default function Inbox() {
     setFilter(event.target.value as "all" | "unread" | "read");
   };
 
-  const filteredMessages = filterByText(messages, search, [
-    "body",
-    "connector",
-  ]).filter((message) => filter === "all" || message.status === filter);
+  const filteredThreads = filterByText(threads, search, ["body", "connector"]).filter(
+    (m) => filter === "all" || m.status === filter,
+  );
+
+  const selected = threads.find((m) => m.id === selectedId) || null;
+
+  const handleSelectThread = (message: Message) => {
+    setSelectedId(message.id);
+    if (!drafts[message.id]) void handleAutoReply(message);
+    if (message.status === "unread") {
+      const updated = data.updateThreadStatus(message.id, "read");
+      setThreads(updated);
+    }
+  };
 
   const handleAutoReply = async (message: Message) => {
     const template = templates[message.id] || "general";
-    const reply = await autoReply(
-      buildAutoReplyMessages(template, message.body),
-    );
+    const reply = await autoReply(buildAutoReplyMessages(template, message.body));
     setDrafts((d) => ({ ...d, [message.id]: reply }));
   };
 
   const handleQuickInsert = async (message: Message) => {
     const tone = quickTones[message.id] || "politeFollowUp";
-    const text = await autoReply(
-      buildAutoReplyMessages(tone, message.body),
-    );
-    const reply = { id: uuidv4(), body: text, sentAt: new Date().toISOString() };
-    const updated = data.addMessageReply(message.id, reply);
-    setMessages(updated);
+    const text = await autoReply(buildAutoReplyMessages(tone, message.body));
+    const reply = {
+      id: uuidv4(),
+      body: text,
+      sentAt: new Date().toISOString(),
+      connector: message.connector,
+    };
+    const updated = data.addThreadReply(message.id, reply);
+    setThreads(updated);
   };
 
   const handleSendReply = (message: Message) => {
     const text = drafts[message.id];
     if (!text) return;
-    const reply = { id: uuidv4(), body: text, sentAt: new Date().toISOString() };
-    const updated = data.addMessageReply(message.id, reply);
-    setMessages(updated);
+    const reply = {
+      id: uuidv4(),
+      body: text,
+      sentAt: new Date().toISOString(),
+      connector: message.connector,
+    };
+    const updated = data.addThreadReply(message.id, reply);
+    setThreads(updated);
     setDrafts((d) => ({ ...d, [message.id]: "" }));
   };
 
   const handleToggleStatus = (message: Message) => {
-    const updated = data.updateMessageStatus(
+    const updated = data.updateThreadStatus(
       message.id,
       message.status === "unread" ? "read" : "unread",
     );
-    setMessages(updated);
+    setThreads(updated);
   };
 
   const handleLinkRecruiter = (threadId: string, recruiterId: string) => {
     const updated = data.linkThreadToRecruiter(threadId, recruiterId);
-    setMessages(updated);
+    setThreads(updated);
     setRecruiters(data.getRecruiters());
   };
 
-  const handleOpenThread = (message: Message) => {
-    const isCurrent = replyingTo === message.id;
-    setReplyingTo((current) => (current === message.id ? null : message.id));
-    if (!isCurrent && !drafts[message.id]) {
-      void handleAutoReply(message);
+  const handleDraftWithAI = (threadId: string) => {
+    setAiThread(threadId);
+    setPromptKey("");
+  };
+
+  const handleInsertAIDraft = (text: string) => {
+    if (aiThread) {
+      setDrafts((d) => ({ ...d, [aiThread]: text }));
     }
-    if (message.status === "unread") {
-      const updated = data.updateMessageStatus(message.id, "read");
-      setMessages(updated);
-    }
+    setAiThread(null);
   };
 
   return (
     <Box>
-      <Stack spacing={2}>
-        <Typography variant="h5">Inbox</Typography>
-        <Select value={filter} onChange={handleFilterChange} sx={{ maxWidth: 200 }}>
-          <MenuItem value="all">All</MenuItem>
-          <MenuItem value="unread">Unread</MenuItem>
-          <MenuItem value="read">Read</MenuItem>
-        </Select>
-        <TextField
-          label="Search"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          sx={{ maxWidth: 300 }}
-        />
-        <List>
-          {filteredMessages.map((message) => (
-            <ListItem key={message.id} alignItems="flex-start">
-              <Stack spacing={1} sx={{ width: "100%" }}>
-                <ListItemText
-                  primary={
-                    <Typography variant="subtitle1" fontWeight="bold">
-                      {message.connector}
-                    </Typography>
-                  }
-                  secondary={message.body}
-                />
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <Button size="small" onClick={() => handleOpenThread(message)}>
-                    Reply
-                  </Button>
-                  <Button size="small" onClick={() => handleToggleStatus(message)}>
-                    {message.status === "unread" ? "Mark read" : "Mark unread"}
-                  </Button>
-                  <Select
-                    size="small"
-                    displayEmpty
-                    value={message.recruiterId || ""}
-                    onChange={(e) =>
-                      handleLinkRecruiter(message.id, e.target.value as string)
-                    }
-                    sx={{ minWidth: 160 }}
-                  >
-                    <MenuItem value="">
-                      <em>No recruiter</em>
-                    </MenuItem>
-                    {recruiters.map((r) => (
-                      <MenuItem key={r.id} value={r.id}>
-                        {r.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </Stack>
-                {replyingTo === message.id && (
-                  <Stack spacing={2} sx={{ mt: 1 }}>
-                    {message.replies.map((r) => (
-                      <Typography key={r.id} variant="body2">
-                        {r.body}
+      <Stack direction="row" spacing={2} sx={{ height: "100%" }}>
+        <Box sx={{ width: 300 }}>
+          <Stack spacing={2}>
+            <Typography variant="h5">Inbox</Typography>
+            <Select value={filter} onChange={handleFilterChange} sx={{ maxWidth: 200 }}>
+              <MenuItem value="all">All</MenuItem>
+              <MenuItem value="unread">Unread</MenuItem>
+              <MenuItem value="read">Read</MenuItem>
+            </Select>
+            <TextField
+              label="Search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              sx={{ maxWidth: 300 }}
+            />
+            <List>
+              {filteredThreads.map((message) => (
+                <ListItem
+                  key={message.id}
+                  button
+                  selected={selectedId === message.id}
+                  onClick={() => handleSelectThread(message)}
+                >
+                  <ListItemText
+                    primary={
+                      <Typography variant="subtitle1" fontWeight="bold">
+                        {message.connector}
                       </Typography>
-                    ))}
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      <Select
-                        size="small"
-                        value={quickTones[message.id] || "politeFollowUp"}
-                        onChange={(e) =>
-                          setQuickTones((t) => ({
-                            ...t,
-                            [message.id]: e.target.value as AutoReplyTemplate,
-                          }))
-                        }
-                        sx={{ maxWidth: 200 }}
-                      >
-                        <MenuItem value="politeFollowUp">Polite follow-up</MenuItem>
-                        <MenuItem value="politeDecline">Politely decline</MenuItem>
-                      </Select>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        onClick={() => void handleQuickInsert(message)}
-                      >
-                        Quick insert
-                      </Button>
-                    </Stack>
-                    <TextField
-                      label="Your reply"
-                      multiline
-                      rows={4}
-                      fullWidth
-                      value={drafts[message.id] || ""}
-                      onChange={(e) =>
-                        setDrafts((d) => ({ ...d, [message.id]: e.target.value }))
-                      }
-                    />
-                    <Select
-                      size="small"
-                      value={templates[message.id] || "general"}
-                      onChange={(e) =>
-                        setTemplates((t) => ({
-                          ...t,
-                          [message.id]: e.target.value as AutoReplyTemplate,
-                        }))
-                      }
-                      sx={{ maxWidth: 200 }}
-                    >
-                      <MenuItem value="general">General</MenuItem>
-                      <MenuItem value="politeDecline">Politely decline</MenuItem>
-                      <MenuItem value="requestMoreInfo">Request more info</MenuItem>
-                    </Select>
-                    <Button
-                      variant="contained"
-                      onClick={() => handleSendReply(message)}
-                    >
-                      Send
-                    </Button>
-                  </Stack>
-                )}
+                    }
+                    secondary={message.body}
+                  />
+                </ListItem>
+              ))}
+            </List>
+          </Stack>
+        </Box>
+        <Box sx={{ flexGrow: 1 }}>
+          {selected ? (
+            <Stack spacing={2}>
+              <Typography variant="h6">{selected.connector}</Typography>
+              <Typography>{selected.body}</Typography>
+              {selected.replies.map((r) => (
+                <Typography key={r.id} variant="body2">
+                  {r.body}
+                </Typography>
+              ))}
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Button size="small" onClick={() => handleToggleStatus(selected)}>
+                  {selected.status === "unread" ? "Mark read" : "Mark unread"}
+                </Button>
+                <Select
+                  size="small"
+                  displayEmpty
+                  value={selected.recruiterId || ""}
+                  onChange={(e) => handleLinkRecruiter(selected.id, e.target.value as string)}
+                  sx={{ minWidth: 160 }}
+                >
+                  <MenuItem value="">
+                    <em>No recruiter</em>
+                  </MenuItem>
+                  {recruiters.map((r) => (
+                    <MenuItem key={r.id} value={r.id}>
+                      {r.name}
+                    </MenuItem>
+                  ))}
+                </Select>
               </Stack>
-            </ListItem>
-          ))}
-        </List>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Select
+                  size="small"
+                  value={quickTones[selected.id] || "politeFollowUp"}
+                  onChange={(e) =>
+                    setQuickTones((t) => ({
+                      ...t,
+                      [selected.id]: e.target.value as AutoReplyTemplate,
+                    }))
+                  }
+                  sx={{ maxWidth: 200 }}
+                >
+                  <MenuItem value="politeFollowUp">Polite follow-up</MenuItem>
+                  <MenuItem value="politeDecline">Politely decline</MenuItem>
+                </Select>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() => void handleQuickInsert(selected)}
+                >
+                  Quick insert
+                </Button>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() => handleDraftWithAI(selected.id)}
+                >
+                  Draft with AI
+                </Button>
+              </Stack>
+              <TextField
+                label="Your reply"
+                multiline
+                rows={4}
+                fullWidth
+                value={drafts[selected.id] || ""}
+                onChange={(e) =>
+                  setDrafts((d) => ({ ...d, [selected.id]: e.target.value }))
+                }
+              />
+              <Select
+                size="small"
+                value={templates[selected.id] || "general"}
+                onChange={(e) =>
+                  setTemplates((t) => ({
+                    ...t,
+                    [selected.id]: e.target.value as AutoReplyTemplate,
+                  }))
+                }
+                sx={{ maxWidth: 200 }}
+              >
+                <MenuItem value="general">General</MenuItem>
+                <MenuItem value="politeDecline">Politely decline</MenuItem>
+                <MenuItem value="requestMoreInfo">Request more info</MenuItem>
+              </Select>
+              <Button variant="contained" onClick={() => handleSendReply(selected)}>
+                Send
+              </Button>
+            </Stack>
+          ) : (
+            <Typography>Select a thread to view messages</Typography>
+          )}
+        </Box>
       </Stack>
+      <Dialog open={aiThread !== null} onClose={() => setAiThread(null)} fullWidth maxWidth="sm">
+        <DialogTitle>Draft with AI</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2}>
+            <PromptSelector value={promptKey} onChange={setPromptKey} />
+            {promptKey && (
+              <Tile {...PROMPT_TILES[promptKey]} onInsert={handleInsertAIDraft} />
+            )}
+          </Stack>
+        </DialogContent>
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -21,15 +21,19 @@ import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { v4 as uuid } from "uuid";
 
 export interface PromptTileProps {
+  id: string;
   display: string;
   fullPrompt: string;
   inputs: string[];
+  onInsert?: (text: string) => void;
 }
 
 export default function Tile({
+  id,
   display,
   fullPrompt,
   inputs,
+  onInsert,
 }: PromptTileProps) {
   const [values, setValues] = useState<Record<string, string>>({});
   const [response, setResponse] = useState("");
@@ -72,7 +76,9 @@ export default function Tile({
         returnFirstResponse: true,
         chatHistory: [],
       });
-      setResponse(res?.message || "");
+      const text = res?.message || "";
+      setResponse(text);
+      onInsert?.(text);
     } finally {
       setLoading(false);
     }

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -31,6 +31,7 @@ export type MessageReply = {
   id: string;
   body: string;
   sentAt: string;
+  connector: string;
 };
 
 export interface Message extends ModelMessage {
@@ -128,6 +129,7 @@ interface LegacyMessageReply {
   id: string;
   content: string;
   sentAt: string;
+  connector?: string;
 }
 
 interface LegacyMessage {
@@ -161,7 +163,12 @@ function migrateLegacyMessages(data: unknown): Message[] {
     connector: m.connector,
     status: m.status,
     replies: Array.isArray(m.replies)
-      ? m.replies.map((r) => ({ id: r.id, body: r.content, sentAt: r.sentAt }))
+      ? m.replies.map((r) => ({
+          id: r.id,
+          body: r.content,
+          sentAt: r.sentAt,
+          connector: r.connector || m.connector,
+        }))
       : [],
   }));
 }
@@ -233,6 +240,26 @@ export function updateMessageStatus(
   );
   save("messages", updated);
   return updated;
+}
+
+// Thread aliases
+export function getThreads(): Message[] {
+  return getMessages();
+}
+export function addThread(thread: Message): Message[] {
+  return addMessage(thread);
+}
+export function deleteThread(id: string): Message[] {
+  return deleteMessage(id);
+}
+export function addThreadReply(id: string, reply: MessageReply): Message[] {
+  return addMessageReply(id, reply);
+}
+export function updateThreadStatus(
+  id: string,
+  status: "unread" | "read",
+): Message[] {
+  return updateMessageStatus(id, status);
 }
 
 // Offers
@@ -442,6 +469,11 @@ const dataStore = {
   deleteMessage,
   addMessageReply,
   updateMessageStatus,
+  getThreads,
+  addThread,
+  deleteThread,
+  addThreadReply,
+  updateThreadStatus,
   getOffers,
   addOffer,
   updateOffer,


### PR DESCRIPTION
## Summary
- Refactor inbox into split-view with thread list and message detail
- Add "Draft with AI" flow that uses prompt tiles to insert replies
- Persist message threads and connector-specific replies in DAL

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c6738acc5883308161e069f4e422f1