### PR TITLE
Refactor onboarding flow into modular steps with accessibility and empty states

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -22,6 +22,7 @@ import {
   updateJobApplicationStatus,
 } from "@/utils/talentforge/applicationStore";
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
+import EmptyState from "./EmptyState";
 
 const STATUSES: ApplicationStatus[] = [
   "applied",
@@ -119,21 +120,25 @@ export default function ApplicationBoard() {
 
   return (
     <DndContext onDragEnd={handleDragEnd}>
-      <Box sx={{ display: "flex", gap: 2 }}>
-        {STATUSES.map((status) => (
-          <Column
-            key={status}
-            id={status}
-            title={status.charAt(0).toUpperCase() + status.slice(1)}
-          >
-            {applications
-              .filter((app) => app.status === status)
-              .map((app) => (
-                <Card key={app.id} app={app} />
-              ))}
-          </Column>
-        ))}
-      </Box>
+      {applications.length === 0 ? (
+        <EmptyState text="No applications yet. Apply to jobs to track them here." />
+      ) : (
+        <Box sx={{ display: "flex", gap: 2 }} aria-label="application board">
+          {STATUSES.map((status) => (
+            <Column
+              key={status}
+              id={status}
+              title={status.charAt(0).toUpperCase() + status.slice(1)}
+            >
+              {applications
+                .filter((app) => app.status === status)
+                .map((app) => (
+                  <Card key={app.id} app={app} />
+                ))}
+            </Column>
+          ))}
+        </Box>
+      )}
     </DndContext>
   );
 }

--- a/src/components/talentforge/EmptyState.tsx
+++ b/src/components/talentforge/EmptyState.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Image from "next/image";
+import { Box, Typography } from "@mui/material";
+
+interface EmptyStateProps {
+  text: string;
+  illustration?: string;
+}
+
+export default function EmptyState({
+  text,
+  illustration = "/images/projects/bookworm.svg",
+}: EmptyStateProps) {
+  return (
+    <Box textAlign="center" sx={{ mt: 4 }} aria-live="polite">
+      <Image
+        src={illustration}
+        alt=""
+        width={120}
+        height={120}
+        aria-hidden
+      />
+      <Typography variant="body1" sx={{ mt: 2 }}>
+        {text}
+      </Typography>
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -25,6 +25,7 @@ import {
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import { Message, RecruiterEntry } from "@/utils/talentforge/dataStore";
 import { v4 as uuidv4 } from "uuid";
+import EmptyState from "./EmptyState";
 
 export default function Inbox() {
   const data = useTalentForgeData();
@@ -119,85 +120,100 @@ export default function Inbox() {
           onChange={(e) => setSearch(e.target.value)}
           sx={{ maxWidth: 300 }}
         />
-        <List>
-          {filteredMessages.map((message) => (
-            <ListItem key={message.id} alignItems="flex-start">
-              <Stack spacing={1} sx={{ width: "100%" }}>
-                <ListItemText
-                  primary={
-                    <Typography variant="subtitle1" fontWeight="bold">
-                      {message.connector}
-                    </Typography>
-                  }
-                  secondary={message.body}
-                />
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <Button size="small" onClick={() => handleOpenThread(message)}>
-                    Reply
-                  </Button>
-                  <Button size="small" onClick={() => handleToggleStatus(message)}>
-                    {message.status === "unread" ? "Mark read" : "Mark unread"}
-                  </Button>
-                  <Select
-                    size="small"
-                    displayEmpty
-                    value={message.recruiterId || ""}
-                    onChange={(e) =>
-                      handleLinkRecruiter(message.id, e.target.value as string)
-                    }
-                    sx={{ minWidth: 160 }}
-                  >
-                    <MenuItem value="">
-                      <em>No recruiter</em>
-                    </MenuItem>
-                    {recruiters.map((r) => (
-                      <MenuItem key={r.id} value={r.id}>
-                        {r.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </Stack>
-                {replyingTo === message.id && (
-                  <Stack spacing={2} sx={{ mt: 1 }}>
-                    {message.replies.map((r) => (
-                      <Typography key={r.id} variant="body2">
-                        {r.body}
+        {filteredMessages.length === 0 ? (
+          <EmptyState text="No messages yet. Connect accounts to receive messages." />
+        ) : (
+          <List aria-label="messages">
+            {filteredMessages.map((message) => (
+              <ListItem key={message.id} alignItems="flex-start">
+                <Stack spacing={1} sx={{ width: "100%" }}>
+                  <ListItemText
+                    primary={
+                      <Typography variant="subtitle1" fontWeight="bold">
+                        {message.connector}
                       </Typography>
-                    ))}
-                    <Stack direction="row" spacing={1} alignItems="center">
-                      <Select
-                        size="small"
-                        value={quickTones[message.id] || "politeFollowUp"}
-                        onChange={(e) =>
-                          setQuickTones((t) => ({
-                            ...t,
-                            [message.id]: e.target.value as AutoReplyTemplate,
-                          }))
-                        }
-                        sx={{ maxWidth: 200 }}
-                      >
-                        <MenuItem value="politeFollowUp">Polite follow-up</MenuItem>
-                        <MenuItem value="politeDecline">Politely decline</MenuItem>
-                      </Select>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        onClick={() => void handleQuickInsert(message)}
-                      >
-                        Quick insert
-                      </Button>
-                    </Stack>
-                    <TextField
-                      label="Your reply"
-                      multiline
-                      rows={4}
-                      fullWidth
-                      value={drafts[message.id] || ""}
-                      onChange={(e) =>
-                        setDrafts((d) => ({ ...d, [message.id]: e.target.value }))
-                      }
-                    />
+                    }
+                    secondary={message.body}
+                  />
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Button
+                      size="small"
+                      onClick={() => handleOpenThread(message)}
+                      aria-label="reply to message"
+                    >
+                      Reply
+                    </Button>
+                    <Button
+                      size="small"
+                      onClick={() => handleToggleStatus(message)}
+                      aria-label="toggle read status"
+                    >
+                      {message.status === "unread" ? "Mark read" : "Mark unread"}
+                    </Button>
                     <Select
+                      size="small"
+                      displayEmpty
+                      value={message.recruiterId || ""}
+                      onChange={(e) =>
+                        handleLinkRecruiter(message.id, e.target.value as string)
+                      }
+                      sx={{ minWidth: 160 }}
+                      aria-label="link recruiter"
+                    >
+                      <MenuItem value="">
+                        <em>No recruiter</em>
+                      </MenuItem>
+                      {recruiters.map((r) => (
+                        <MenuItem key={r.id} value={r.id}>
+                          {r.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </Stack>
+                  {replyingTo === message.id && (
+                    <Stack spacing={2} sx={{ mt: 1 }}>
+                      {message.replies.map((r) => (
+                        <Typography key={r.id} variant="body2">
+                          {r.body}
+                        </Typography>
+                      ))}
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Select
+                          size="small"
+                          value={quickTones[message.id] || "politeFollowUp"}
+                          onChange={(e) =>
+                            setQuickTones((t) => ({
+                              ...t,
+                              [message.id]: e.target.value as AutoReplyTemplate,
+                            }))
+                          }
+                          sx={{ maxWidth: 200 }}
+                          aria-label="auto reply tone"
+                        >
+                          <MenuItem value="politeFollowUp">Polite follow-up</MenuItem>
+                          <MenuItem value="politeDecline">Politely decline</MenuItem>
+                        </Select>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          onClick={() => void handleQuickInsert(message)}
+                          aria-label="quick insert"
+                        >
+                          Quick insert
+                        </Button>
+                      </Stack>
+                      <TextField
+                        label="Your reply"
+                        multiline
+                        rows={4}
+                        fullWidth
+                        value={drafts[message.id] || ""}
+                        onChange={(e) =>
+                          setDrafts((d) => ({ ...d, [message.id]: e.target.value }))
+                        }
+                        aria-label="reply text"
+                      />
+                      <Select
                       size="small"
                       value={templates[message.id] || "general"}
                       onChange={(e) =>

--- a/src/components/talentforge/Offers/OfferList.tsx
+++ b/src/components/talentforge/Offers/OfferList.tsx
@@ -19,6 +19,7 @@ import {
 } from "@mui/material";
 import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
 import { exportElementToPdf } from "@/utils/pdfExport";
+import EmptyState from "../EmptyState";
 
 interface OfferListProps {
   refreshKey?: number;
@@ -71,28 +72,32 @@ export default function OfferList({ refreshKey }: OfferListProps) {
 
   return (
     <Box>
-      <List>
-        {offers.map((offer, index) => (
-          <ListItem
-            key={offer.id}
-            button
-            onClick={() => toggleSelect(offer.id)}
-          >
-            <ListItemIcon>
-              <Checkbox edge="start" checked={selected.has(offer.id)} />
-            </ListItemIcon>
-            <ListItemText
-              primary={`Offer ${index + 1}`}
-              secondary={
-                offer.summary ||
-                offer.compensation
-                  .map((c) => `${c.type}: ${c.amount}`)
-                  .join(", ")
-              }
-            />
-          </ListItem>
-        ))}
-      </List>
+      {offers.length === 0 ? (
+        <EmptyState text="No offers yet. Track offers to compare compensation." />
+      ) : (
+        <List aria-label="offers">
+          {offers.map((offer, index) => (
+            <ListItem
+              key={offer.id}
+              button
+              onClick={() => toggleSelect(offer.id)}
+            >
+              <ListItemIcon>
+                <Checkbox edge="start" checked={selected.has(offer.id)} />
+              </ListItemIcon>
+              <ListItemText
+                primary={`Offer ${index + 1}`}
+                secondary={
+                  offer.summary ||
+                  offer.compensation
+                    .map((c) => `${c.type}: ${c.amount}`)
+                    .join(", ")
+                }
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
       {selectedOffers.length > 0 && (
         <Box sx={{ mt: 2 }}>
           <TableContainer component={Paper} sx={{ mb: 2 }}>

--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -9,7 +9,17 @@ import {
   clearOnboardingStep,
 } from "@/utils/talentforge/dataStore";
 
-const steps = ["Profile Info", "Upload Resume", "Connect Accounts", "Finish"];
+import KeyEntryStep from "./onboarding/KeyEntryStep";
+import ResumeImportStep from "./onboarding/ResumeImportStep";
+import ConnectorMockStep from "./onboarding/ConnectorMockStep";
+import GoalSelectionStep from "./onboarding/GoalSelectionStep";
+
+const steps = [
+  "Enter Key",
+  "Import Resume",
+  "Connect Accounts",
+  "Select Goal",
+];
 
 export default function OnboardingStepper() {
   const [activeStep, setActiveStep] = useState(0);
@@ -35,9 +45,24 @@ export default function OnboardingStepper() {
     clearOnboardingStep();
   };
 
+  const renderStep = () => {
+    switch (activeStep) {
+      case 0:
+        return <KeyEntryStep onNext={handleNext} />;
+      case 1:
+        return <ResumeImportStep onNext={handleNext} />;
+      case 2:
+        return <ConnectorMockStep onNext={handleNext} />;
+      case 3:
+        return <GoalSelectionStep onFinish={handleNext} />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <Box>
-      <Stepper activeStep={activeStep} alternativeLabel>
+      <Stepper activeStep={activeStep} alternativeLabel aria-label="onboarding steps">
         {steps.map((label) => (
           <Step key={label}>
             <StepLabel>{label}</StepLabel>
@@ -46,22 +71,19 @@ export default function OnboardingStepper() {
       </Stepper>
       {activeStep === steps.length ? (
         <Box sx={{ mt: 2 }}>
-          <Typography>All steps completed - you&apos;re finished</Typography>
-          <Button sx={{ mt: 1 }} onClick={handleReset}>
+          <Typography>All steps completed - you're finished</Typography>
+          <Button sx={{ mt: 1 }} onClick={handleReset} aria-label="reset onboarding">
             Reset
           </Button>
         </Box>
       ) : (
         <Box sx={{ mt: 2 }}>
-          <Typography sx={{ mb: 1 }}>{steps[activeStep]}</Typography>
-          <Box>
-            <Button disabled={activeStep === 0} onClick={handleBack} sx={{ mr: 1 }}>
+          {renderStep()}
+          {activeStep > 0 && (
+            <Button onClick={handleBack} sx={{ mt: 2 }} aria-label="back">
               Back
             </Button>
-            <Button variant="contained" onClick={handleNext}>
-              {activeStep === steps.length - 1 ? "Finish" : "Next"}
-            </Button>
-          </Box>
+          )}
         </Box>
       )}
     </Box>

--- a/src/components/talentforge/onboarding/ConnectorMockStep.tsx
+++ b/src/components/talentforge/onboarding/ConnectorMockStep.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Typography,
+} from "@mui/material";
+import FocusTrap from "@mui/base/FocusTrap";
+
+interface ConnectorMockStepProps {
+  onNext: () => void;
+}
+
+export default function ConnectorMockStep({ onNext }: ConnectorMockStepProps) {
+  const [connected, setConnected] = useState(false);
+
+  return (
+    <FocusTrap open>
+      <Box aria-label="connect accounts step">
+        <Typography>Mock connecting your job board accounts.</Typography>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={connected}
+              onChange={(e) => setConnected(e.target.checked)}
+              inputProps={{ "aria-label": "connect mock accounts" }}
+            />
+          }
+          label="Connect mock accounts"
+          sx={{ mt: 2 }}
+        />
+        <Button
+          variant="contained"
+          onClick={onNext}
+          disabled={!connected}
+          sx={{ mt: 2 }}
+          aria-label="continue after connecting accounts"
+        >
+          Continue
+        </Button>
+      </Box>
+    </FocusTrap>
+  );
+}
+

--- a/src/components/talentforge/onboarding/GoalSelectionStep.tsx
+++ b/src/components/talentforge/onboarding/GoalSelectionStep.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from "@mui/material";
+import FocusTrap from "@mui/base/FocusTrap";
+
+interface GoalSelectionStepProps {
+  onFinish: () => void;
+}
+
+export default function GoalSelectionStep({ onFinish }: GoalSelectionStepProps) {
+  const [goal, setGoal] = useState("");
+
+  return (
+    <FocusTrap open>
+      <Box aria-label="goal selection step">
+        <Typography>Select a goal to customize your experience.</Typography>
+        <FormControl sx={{ mt: 2 }}>
+          <FormLabel id="goal-label">Goal</FormLabel>
+          <RadioGroup
+            aria-labelledby="goal-label"
+            value={goal}
+            onChange={(e) => setGoal(e.target.value)}
+          >
+            <FormControlLabel
+              value="findJob"
+              control={<Radio />}
+              label="Find a job"
+            />
+            <FormControlLabel
+              value="improveResume"
+              control={<Radio />}
+              label="Improve my resume"
+            />
+            <FormControlLabel
+              value="practiceInterview"
+              control={<Radio />}
+              label="Practice interviews"
+            />
+          </RadioGroup>
+        </FormControl>
+        <Button
+          variant="contained"
+          onClick={onFinish}
+          disabled={!goal}
+          sx={{ mt: 2 }}
+          aria-label="finish onboarding"
+        >
+          Finish
+        </Button>
+      </Box>
+    </FocusTrap>
+  );
+}
+

--- a/src/components/talentforge/onboarding/KeyEntryStep.tsx
+++ b/src/components/talentforge/onboarding/KeyEntryStep.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Box, Button, TextField, Typography } from "@mui/material";
+import FocusTrap from "@mui/base/FocusTrap";
+
+import { setOpenAIKey } from "@/utils/talentforge/utils";
+
+interface KeyEntryStepProps {
+  onNext: () => void;
+}
+
+export default function KeyEntryStep({ onNext }: KeyEntryStepProps) {
+  const [key, setKey] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSave = () => {
+    const trimmed = key.trim();
+    if (!trimmed) return;
+    setOpenAIKey(trimmed);
+    onNext();
+  };
+
+  return (
+    <FocusTrap open>
+      <Box role="form" aria-label="enter openai api key">
+        <Typography>Enter your OpenAI API key to continue.</Typography>
+        <TextField
+          inputRef={inputRef}
+          aria-label="OpenAI API key"
+          type="password"
+          fullWidth
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          sx={{ mt: 2 }}
+        />
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!key.trim()}
+          sx={{ mt: 2 }}
+          aria-label="save key and continue"
+        >
+          Save and continue
+        </Button>
+      </Box>
+    </FocusTrap>
+  );
+}
+

--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, Typography } from "@mui/material";
+import FocusTrap from "@mui/base/FocusTrap";
+
+import FileUploader from "../FileUploader";
+
+interface ResumeImportStepProps {
+  onNext: () => void;
+}
+
+export default function ResumeImportStep({ onNext }: ResumeImportStepProps) {
+  const [uploaded, setUploaded] = useState(false);
+
+  return (
+    <FocusTrap open>
+      <Box aria-label="resume import step">
+        <Typography>Upload your resume to personalize suggestions.</Typography>
+        <FileUploader
+          accept=".pdf,.txt,.md"
+          label="Upload resume"
+          onChange={() => setUploaded(true)}
+          sx={{ mt: 2 }}
+        />
+        <Button
+          variant="contained"
+          onClick={onNext}
+          disabled={!uploaded}
+          sx={{ mt: 2 }}
+          aria-label="continue after resume upload"
+        >
+          Continue
+        </Button>
+      </Box>
+    </FocusTrap>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace onboarding stepper with dedicated steps for key entry, resume import, connector mock, and goal selection
- add focus traps and aria labels for better keyboard navigation
- introduce reusable EmptyState component and apply to Inbox, applications board, and offers list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6739c81f483309e13062e24fe9b50