### PR TITLE
fix: use ListItemButton for offer selection

### DIFF
--- a/src/components/talentforge/Offers/OfferList.tsx
+++ b/src/components/talentforge/Offers/OfferList.tsx
@@ -7,6 +7,7 @@ import {
   Checkbox,
   List,
   ListItem,
+  ListItemButton,
   ListItemIcon,
   ListItemText,
   Table,
@@ -73,23 +74,21 @@ export default function OfferList({ refreshKey }: OfferListProps) {
     <Box>
       <List>
         {offers.map((offer, index) => (
-          <ListItem
-            key={offer.id}
-            button
-            onClick={() => toggleSelect(offer.id)}
-          >
-            <ListItemIcon>
-              <Checkbox edge="start" checked={selected.has(offer.id)} />
-            </ListItemIcon>
-            <ListItemText
-              primary={`Offer ${index + 1}`}
-              secondary={
-                offer.summary ||
-                offer.compensation
-                  .map((c) => `${c.type}: ${c.amount}`)
-                  .join(", ")
-              }
-            />
+          <ListItem disablePadding key={offer.id}>
+            <ListItemButton onClick={() => toggleSelect(offer.id)}>
+              <ListItemIcon>
+                <Checkbox edge="start" checked={selected.has(offer.id)} />
+              </ListItemIcon>
+              <ListItemText
+                primary={`Offer ${index + 1}`}
+                secondary={
+                  offer.summary ||
+                  offer.compensation
+                    .map((c) => `${c.type}: ${c.amount}`)
+                    .join(", ")
+                }
+              />
+            </ListItemButton>
           </ListItem>
         ))}
       </List>


### PR DESCRIPTION
## Summary
- replace deprecated ListItem `button` usage with ListItemButton

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c675bd43148330a5a488737d81f520