### PR TITLE
feat: revamp talentforge onboarding with a11y improvements

### DIFF
--- a/public/images/empty-state.svg
+++ b/public/images/empty-state.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Empty illustration">
+  <rect width="120" height="100" fill="#f0f0f0"/>
+  <circle cx="60" cy="50" r="20" fill="#dddddd"/>
+</svg>

--- a/src/components/talentforge/EmptyState.tsx
+++ b/src/components/talentforge/EmptyState.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Image from "next/image";
+import { Box, Typography } from "@mui/material";
+
+interface EmptyStateProps {
+  imgSrc: string;
+  alt: string;
+  message: string;
+  helperText?: string;
+}
+
+export default function EmptyState({ imgSrc, alt, message, helperText }: EmptyStateProps) {
+  return (
+    <Box textAlign="center" sx={{ mt: 4 }} aria-label="empty state">
+      <Image src={imgSrc} alt={alt} width={200} height={160} />
+      <Typography variant="h6" sx={{ mt: 2 }}>
+        {message}
+      </Typography>
+      {helperText && (
+        <Typography variant="body2" color="text.secondary">
+          {helperText}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -31,6 +31,7 @@ import { v4 as uuidv4 } from "uuid";
 import PromptSelector from "./PromptSelector";
 import Tile from "./promptTiles/Tile";
 import { PROMPT_TILES } from "@/consts/promptTiles";
+import EmptyState from "./EmptyState";
 
 export default function Inbox() {
   const data = useTalentForgeData();
@@ -134,7 +135,12 @@ export default function Inbox() {
         <Box sx={{ width: 300 }}>
           <Stack spacing={2}>
             <Typography variant="h5">Inbox</Typography>
-            <Select value={filter} onChange={handleFilterChange} sx={{ maxWidth: 200 }}>
+            <Select
+              value={filter}
+              onChange={handleFilterChange}
+              sx={{ maxWidth: 200 }}
+              aria-label="filter threads"
+            >
               <MenuItem value="all">All</MenuItem>
               <MenuItem value="unread">Unread</MenuItem>
               <MenuItem value="read">Read</MenuItem>
@@ -145,25 +151,35 @@ export default function Inbox() {
               onChange={(e) => setSearch(e.target.value)}
               sx={{ maxWidth: 300 }}
             />
-            <List>
-              {filteredThreads.map((message) => (
-                <ListItem
-                  key={message.id}
-                  button
-                  selected={selectedId === message.id}
-                  onClick={() => handleSelectThread(message)}
-                >
-                  <ListItemText
-                    primary={
-                      <Typography variant="subtitle1" fontWeight="bold">
-                        {message.connector}
-                      </Typography>
-                    }
-                    secondary={message.body}
-                  />
-                </ListItem>
-              ))}
-            </List>
+            {filteredThreads.length === 0 ? (
+              <EmptyState
+                imgSrc="/images/empty-state.svg"
+                alt="No messages illustration"
+                message="No messages"
+                helperText="Recruiter messages will appear here."
+              />
+            ) : (
+              <List aria-label="message threads">
+                {filteredThreads.map((message) => (
+                  <ListItem
+                    key={message.id}
+                    button
+                    selected={selectedId === message.id}
+                    onClick={() => handleSelectThread(message)}
+                    aria-label={`message from ${message.connector}`}
+                  >
+                    <ListItemText
+                      primary={
+                        <Typography variant="subtitle1" fontWeight="bold">
+                          {message.connector}
+                        </Typography>
+                      }
+                      secondary={message.body}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            )}
           </Stack>
         </Box>
         <Box sx={{ flexGrow: 1 }}>

--- a/src/components/talentforge/JobDescriptionRisk.tsx
+++ b/src/components/talentforge/JobDescriptionRisk.tsx
@@ -12,6 +12,7 @@ import {
 import OpenAiKeyModal from "./OpenAiKeyModal";
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
+import EmptyState from "./EmptyState";
 
 interface Issue {
   severity: "red" | "yellow";
@@ -82,6 +83,14 @@ export default function JobDescriptionRisk() {
         <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
           <CircularProgress />
         </Box>
+      )}
+      {!analysis && !loading && (
+        <EmptyState
+          imgSrc="/images/empty-state.svg"
+          alt="No analysis illustration"
+          message="No analysis yet"
+          helperText="Paste a job description and click analyze."
+        />
       )}
       {analysis && (
         <Box sx={{ mt: 2 }}>

--- a/src/components/talentforge/Offers/OfferList.tsx
+++ b/src/components/talentforge/Offers/OfferList.tsx
@@ -19,6 +19,7 @@ import {
 } from "@mui/material";
 import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
 import { exportElementToPdf } from "@/utils/pdfExport";
+import EmptyState from "../EmptyState";
 
 interface OfferListProps {
   refreshKey?: number;
@@ -71,28 +72,41 @@ export default function OfferList({ refreshKey }: OfferListProps) {
 
   return (
     <Box>
-      <List>
-        {offers.map((offer, index) => (
-          <ListItem
-            key={offer.id}
-            button
-            onClick={() => toggleSelect(offer.id)}
-          >
-            <ListItemIcon>
-              <Checkbox edge="start" checked={selected.has(offer.id)} />
-            </ListItemIcon>
-            <ListItemText
-              primary={`Offer ${index + 1}`}
-              secondary={
-                offer.summary ||
-                offer.compensation
-                  .map((c) => `${c.type}: ${c.amount}`)
-                  .join(", ")
-              }
-            />
-          </ListItem>
-        ))}
-      </List>
+      {offers.length === 0 ? (
+        <EmptyState
+          imgSrc="/images/empty-state.svg"
+          alt="No offers illustration"
+          message="No offers"
+          helperText="Add job offers to compare compensation."
+        />
+      ) : (
+        <List aria-label="offers list">
+          {offers.map((offer, index) => (
+            <ListItem
+              key={offer.id}
+              button
+              onClick={() => toggleSelect(offer.id)}
+            >
+              <ListItemIcon>
+                <Checkbox
+                  edge="start"
+                  checked={selected.has(offer.id)}
+                  inputProps={{ "aria-label": `select offer ${index + 1}` }}
+                />
+              </ListItemIcon>
+              <ListItemText
+                primary={`Offer ${index + 1}`}
+                secondary={
+                  offer.summary ||
+                  offer.compensation
+                    .map((c) => `${c.type}: ${c.amount}`)
+                    .join(", ")
+                }
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
       {selectedOffers.length > 0 && (
         <Box sx={{ mt: 2 }}>
           <TableContainer component={Paper} sx={{ mb: 2 }}>

--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -1,15 +1,25 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Button, Step, StepLabel, Stepper, Typography } from "@mui/material";
+import { Box, Step, StepLabel, Stepper, Typography } from "@mui/material";
+import TrapFocus from "@mui/material/Unstable_TrapFocus";
 
 import {
   getOnboardingStep,
   setOnboardingStep,
   clearOnboardingStep,
 } from "@/utils/talentforge/dataStore";
+import KeyEntryStep from "./onboarding/KeyEntryStep";
+import ResumeImportStep from "./onboarding/ResumeImportStep";
+import ConnectorMockStep from "./onboarding/ConnectorMockStep";
+import GoalSelectionStep from "./onboarding/GoalSelectionStep";
 
-const steps = ["Profile Info", "Upload Resume", "Connect Accounts", "Finish"];
+const stepConfigs = [
+  { label: "Enter Key", Component: KeyEntryStep },
+  { label: "Import Resume", Component: ResumeImportStep },
+  { label: "Connect Accounts", Component: ConnectorMockStep },
+  { label: "Set Goals", Component: GoalSelectionStep },
+];
 
 export default function OnboardingStepper() {
   const [activeStep, setActiveStep] = useState(0);
@@ -35,35 +45,42 @@ export default function OnboardingStepper() {
     clearOnboardingStep();
   };
 
+  if (activeStep >= stepConfigs.length) {
+    return (
+      <Box sx={{ mt: 2 }}>
+        <Typography>All steps completed - you&apos;re finished</Typography>
+        <Box sx={{ mt: 1 }}>
+          <Typography
+            role="button"
+            tabIndex={0}
+            onClick={handleReset}
+            onKeyDown={(e) => e.key === "Enter" && handleReset()}
+            sx={{ cursor: "pointer", color: "primary.main" }}
+            aria-label="reset onboarding"
+          >
+            Reset
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
+
+  const { Component } = stepConfigs[activeStep];
+
   return (
     <Box>
-      <Stepper activeStep={activeStep} alternativeLabel>
-        {steps.map((label) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
+      <Stepper activeStep={activeStep} alternativeLabel aria-label="onboarding steps">
+        {stepConfigs.map((s) => (
+          <Step key={s.label} aria-label={s.label}>
+            <StepLabel>{s.label}</StepLabel>
           </Step>
         ))}
       </Stepper>
-      {activeStep === steps.length ? (
-        <Box sx={{ mt: 2 }}>
-          <Typography>All steps completed - you&apos;re finished</Typography>
-          <Button sx={{ mt: 1 }} onClick={handleReset}>
-            Reset
-          </Button>
+      <TrapFocus open>
+        <Box sx={{ mt: 2 }} aria-label="onboarding step">
+          <Component onNext={handleNext} onBack={handleBack} />
         </Box>
-      ) : (
-        <Box sx={{ mt: 2 }}>
-          <Typography sx={{ mb: 1 }}>{steps[activeStep]}</Typography>
-          <Box>
-            <Button disabled={activeStep === 0} onClick={handleBack} sx={{ mr: 1 }}>
-              Back
-            </Button>
-            <Button variant="contained" onClick={handleNext}>
-              {activeStep === steps.length - 1 ? "Finish" : "Next"}
-            </Button>
-          </Box>
-        </Box>
-      )}
+      </TrapFocus>
     </Box>
   );
 }

--- a/src/components/talentforge/onboarding/ConnectorMockStep.tsx
+++ b/src/components/talentforge/onboarding/ConnectorMockStep.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Box, Button, FormControlLabel, Checkbox, Stack } from "@mui/material";
+
+interface ConnectorMockStepProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export default function ConnectorMockStep({ onNext, onBack }: ConnectorMockStepProps) {
+  const [linkedIn, setLinkedIn] = useState(false);
+  const [indeed, setIndeed] = useState(false);
+  const firstRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    firstRef.current?.focus();
+  }, []);
+
+  return (
+    <Box aria-label="connector selection">
+      <Stack spacing={1}>
+        <FormControlLabel
+          control={<Checkbox inputRef={firstRef} checked={linkedIn} onChange={(e) => setLinkedIn(e.target.checked)} />}
+          label="LinkedIn"
+        />
+        <FormControlLabel
+          control={<Checkbox checked={indeed} onChange={(e) => setIndeed(e.target.checked)} />}
+          label="Indeed"
+        />
+      </Stack>
+      <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+        <Button variant="outlined" onClick={onBack} aria-label="back">
+          Back
+        </Button>
+        <Button variant="contained" onClick={onNext} aria-label="save connectors">
+          Save Connections
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/onboarding/GoalSelectionStep.tsx
+++ b/src/components/talentforge/onboarding/GoalSelectionStep.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Box, Button, Checkbox, FormControlLabel, Stack } from "@mui/material";
+
+interface GoalSelectionStepProps {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export default function GoalSelectionStep({ onNext, onBack }: GoalSelectionStepProps) {
+  const [goals, setGoals] = useState({ job: false, resume: false, networking: false });
+  const firstRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    firstRef.current?.focus();
+  }, []);
+
+  const handleChange = (key: keyof typeof goals) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setGoals((g) => ({ ...g, [key]: e.target.checked }));
+  };
+
+  return (
+    <Box aria-label="goal selection">
+      <Stack spacing={1}>
+        <FormControlLabel
+          control={<Checkbox inputRef={firstRef} checked={goals.job} onChange={handleChange("job")} />}
+          label="Find a new job"
+        />
+        <FormControlLabel
+          control={<Checkbox checked={goals.resume} onChange={handleChange("resume")} />}
+          label="Improve my resume"
+        />
+        <FormControlLabel
+          control={<Checkbox checked={goals.networking} onChange={handleChange("networking")} />}
+          label="Expand my network"
+        />
+      </Stack>
+      <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+        <Button variant="outlined" onClick={onBack} aria-label="back">
+          Back
+        </Button>
+        <Button variant="contained" onClick={onNext} aria-label="finish onboarding" disabled={!Object.values(goals).some(Boolean)}>
+          Finish
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/onboarding/KeyEntryStep.tsx
+++ b/src/components/talentforge/onboarding/KeyEntryStep.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Box, Button, TextField } from "@mui/material";
+import { setOpenAIKey } from "@/utils/talentforge/utils";
+
+interface KeyEntryStepProps {
+  onNext: () => void;
+}
+
+export default function KeyEntryStep({ onNext }: KeyEntryStepProps) {
+  const [key, setKey] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSave = () => {
+    const trimmed = key.trim();
+    if (!trimmed) return;
+    setOpenAIKey(trimmed);
+    onNext();
+  };
+
+  return (
+    <Box aria-label="openai key entry">
+      <TextField
+        inputRef={inputRef}
+        label="OpenAI API Key"
+        type="password"
+        fullWidth
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+      />
+      <Button
+        variant="contained"
+        sx={{ mt: 2 }}
+        onClick={handleSave}
+        disabled={!key.trim()}
+        aria-label="save api key"
+      >
+        Save Key
+      </Button>
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Box, Button, TextField } from "@mui/material";
+
+interface ResumeImportStepProps {
+  onNext: () => void;
+}
+
+export default function ResumeImportStep({ onNext }: ResumeImportStepProps) {
+  const [resume, setResume] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleImport = () => {
+    if (!resume.trim()) return;
+    // Placeholder for resume processing logic
+    onNext();
+  };
+
+  return (
+    <Box aria-label="resume import">
+      <TextField
+        inputRef={inputRef}
+        label="Paste resume text"
+        multiline
+        minRows={4}
+        fullWidth
+        value={resume}
+        onChange={(e) => setResume(e.target.value)}
+      />
+      <Button
+        variant="contained"
+        sx={{ mt: 2 }}
+        onClick={handleImport}
+        disabled={!resume.trim()}
+        aria-label="import resume"
+      >
+        Import Resume
+      </Button>
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace onboarding stepper with dedicated steps for key entry, resume import, connector setup, and goal selection
- add keyboard navigation aids via aria labels and focus traps
- introduce reusable empty-state component across TalentForge pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6757f3ed48330a4ff87e5b2dc3f9f