### PR TITLE
fix: replace deprecated ListItem button usage

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
   List,
   ListItem,
+  ListItemButton,
   ListItemText,
   MenuItem,
   Select,
@@ -147,20 +148,20 @@ export default function Inbox() {
             />
             <List>
               {filteredThreads.map((message) => (
-                <ListItem
-                  key={message.id}
-                  button
-                  selected={selectedId === message.id}
-                  onClick={() => handleSelectThread(message)}
-                >
-                  <ListItemText
-                    primary={
-                      <Typography variant="subtitle1" fontWeight="bold">
-                        {message.connector}
-                      </Typography>
-                    }
-                    secondary={message.body}
-                  />
+                <ListItem key={message.id} disablePadding>
+                  <ListItemButton
+                    selected={selectedId === message.id}
+                    onClick={() => handleSelectThread(message)}
+                  >
+                    <ListItemText
+                      primary={
+                        <Typography variant="subtitle1" fontWeight="bold">
+                          {message.connector}
+                        </Typography>
+                      }
+                      secondary={message.body}
+                    />
+                  </ListItemButton>
                 </ListItem>
               ))}
             </List>


### PR DESCRIPTION
## Summary
- replace `ListItem` button prop with `ListItemButton` for MUI v6 compatibility

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c676c9ffd88330981010036059bfb0