### PR TITLE
Refactor onboarding and add TalentForge empty states

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -22,6 +22,7 @@ import {
   updateJobApplicationStatus,
 } from "@/utils/talentforge/applicationStore";
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
+import EmptyState from "./EmptyState";
 
 const STATUSES: ApplicationStatus[] = [
   "applied",
@@ -119,21 +120,28 @@ export default function ApplicationBoard() {
 
   return (
     <DndContext onDragEnd={handleDragEnd}>
-      <Box sx={{ display: "flex", gap: 2 }}>
-        {STATUSES.map((status) => (
-          <Column
-            key={status}
-            id={status}
-            title={status.charAt(0).toUpperCase() + status.slice(1)}
-          >
-            {applications
-              .filter((app) => app.status === status)
-              .map((app) => (
-                <Card key={app.id} app={app} />
-              ))}
-          </Column>
-        ))}
-      </Box>
+      {applications.length === 0 ? (
+        <EmptyState
+          message="No applications yet"
+          helperText="Start tracking your job applications here."
+        />
+      ) : (
+        <Box sx={{ display: "flex", gap: 2 }}>
+          {STATUSES.map((status) => (
+            <Column
+              key={status}
+              id={status}
+              title={status.charAt(0).toUpperCase() + status.slice(1)}
+            >
+              {applications
+                .filter((app) => app.status === status)
+                .map((app) => (
+                  <Card key={app.id} app={app} />
+                ))}
+            </Column>
+          ))}
+        </Box>
+      )}
     </DndContext>
   );
 }

--- a/src/components/talentforge/CoverLetter.tsx
+++ b/src/components/talentforge/CoverLetter.tsx
@@ -14,6 +14,7 @@ import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { getResumes } from "@/utils/talentforge/dataStore";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAiKeyModal from "./OpenAiKeyModal";
+import EmptyState from "./EmptyState";
 
 export default function CoverLetter() {
   const [resumeVariantId, setResumeVariantId] = useState("");
@@ -49,6 +50,15 @@ export default function CoverLetter() {
     setLoading(false);
   };
 
+  if (resumes.length === 0) {
+    return (
+      <EmptyState
+        message="No resumes available"
+        helperText="Add a resume before generating a cover letter."
+      />
+    );
+  }
+
   return (
     <Box>
       <OpenAiKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
@@ -77,6 +87,7 @@ export default function CoverLetter() {
             variant="contained"
             onClick={handleGenerate}
             disabled={!resumeVariantId || !jobDescription || loading}
+            aria-label="Generate cover letter"
           >
             Generate
           </Button>
@@ -87,6 +98,7 @@ export default function CoverLetter() {
               coverRef.current &&
               exportElementToPdf(coverRef.current, "cover-letter.pdf")
             }
+            aria-label="Export cover letter"
           >
             Export
           </Button>

--- a/src/components/talentforge/EmptyState.tsx
+++ b/src/components/talentforge/EmptyState.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import InboxIcon from "@mui/icons-material/Inbox";
+import { Box, Typography } from "@mui/material";
+
+interface EmptyStateProps {
+  message: string;
+  helperText?: string;
+  icon?: React.ReactNode;
+}
+
+export default function EmptyState({
+  message,
+  helperText,
+  icon = <InboxIcon sx={{ fontSize: 64 }} aria-hidden="true" />,
+}: EmptyStateProps) {
+  return (
+    <Box textAlign="center" sx={{ py: 6 }} role="status" aria-live="polite">
+      <Box>{icon}</Box>
+      <Typography variant="h6" sx={{ mt: 2 }}>
+        {message}
+      </Typography>
+      {helperText && (
+        <Typography variant="body2" color="text.secondary">
+          {helperText}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -31,6 +31,7 @@ import { v4 as uuidv4 } from "uuid";
 import PromptSelector from "./PromptSelector";
 import Tile from "./promptTiles/Tile";
 import { PROMPT_TILES } from "@/consts/promptTiles";
+import EmptyState from "./EmptyState";
 
 export default function Inbox() {
   const data = useTalentForgeData();
@@ -128,13 +129,27 @@ export default function Inbox() {
     setAiThread(null);
   };
 
+  if (threads.length === 0) {
+    return (
+      <EmptyState
+        message="No messages"
+        helperText="Your recruiter conversations will appear here."
+      />
+    );
+  }
+
   return (
     <Box>
       <Stack direction="row" spacing={2} sx={{ height: "100%" }}>
         <Box sx={{ width: 300 }}>
           <Stack spacing={2}>
             <Typography variant="h5">Inbox</Typography>
-            <Select value={filter} onChange={handleFilterChange} sx={{ maxWidth: 200 }}>
+            <Select
+              value={filter}
+              onChange={handleFilterChange}
+              sx={{ maxWidth: 200 }}
+              aria-label="Filter threads"
+            >
               <MenuItem value="all">All</MenuItem>
               <MenuItem value="unread">Unread</MenuItem>
               <MenuItem value="read">Read</MenuItem>
@@ -145,7 +160,7 @@ export default function Inbox() {
               onChange={(e) => setSearch(e.target.value)}
               sx={{ maxWidth: 300 }}
             />
-            <List>
+            <List aria-label="Thread list">
               {filteredThreads.map((message) => (
                 <ListItem
                   key={message.id}
@@ -177,15 +192,22 @@ export default function Inbox() {
                 </Typography>
               ))}
               <Stack direction="row" spacing={1} alignItems="center">
-                <Button size="small" onClick={() => handleToggleStatus(selected)}>
+                <Button
+                  size="small"
+                  onClick={() => handleToggleStatus(selected)}
+                  aria-label="Toggle read status"
+                >
                   {selected.status === "unread" ? "Mark read" : "Mark unread"}
                 </Button>
                 <Select
                   size="small"
                   displayEmpty
                   value={selected.recruiterId || ""}
-                  onChange={(e) => handleLinkRecruiter(selected.id, e.target.value as string)}
+                  onChange={(e) =>
+                    handleLinkRecruiter(selected.id, e.target.value as string)
+                  }
                   sx={{ minWidth: 160 }}
+                  aria-label="Linked recruiter"
                 >
                   <MenuItem value="">
                     <em>No recruiter</em>
@@ -208,6 +230,7 @@ export default function Inbox() {
                     }))
                   }
                   sx={{ maxWidth: 200 }}
+                  aria-label="Quick tone"
                 >
                   <MenuItem value="politeFollowUp">Polite follow-up</MenuItem>
                   <MenuItem value="politeDecline">Politely decline</MenuItem>
@@ -216,6 +239,7 @@ export default function Inbox() {
                   size="small"
                   variant="outlined"
                   onClick={() => void handleQuickInsert(selected)}
+                  aria-label="Quick insert"
                 >
                   Quick insert
                 </Button>
@@ -223,6 +247,7 @@ export default function Inbox() {
                   size="small"
                   variant="outlined"
                   onClick={() => handleDraftWithAI(selected.id)}
+                  aria-label="Draft with AI"
                 >
                   Draft with AI
                 </Button>
@@ -247,12 +272,17 @@ export default function Inbox() {
                   }))
                 }
                 sx={{ maxWidth: 200 }}
+                aria-label="Template"
               >
                 <MenuItem value="general">General</MenuItem>
                 <MenuItem value="politeDecline">Politely decline</MenuItem>
                 <MenuItem value="requestMoreInfo">Request more info</MenuItem>
               </Select>
-              <Button variant="contained" onClick={() => handleSendReply(selected)}>
+              <Button
+                variant="contained"
+                onClick={() => handleSendReply(selected)}
+                aria-label="Send reply"
+              >
                 Send
               </Button>
             </Stack>

--- a/src/components/talentforge/JobDescriptionRisk.tsx
+++ b/src/components/talentforge/JobDescriptionRisk.tsx
@@ -12,6 +12,7 @@ import {
 import OpenAiKeyModal from "./OpenAiKeyModal";
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
+import EmptyState from "./EmptyState";
 
 interface Issue {
   severity: "red" | "yellow";
@@ -83,7 +84,7 @@ export default function JobDescriptionRisk() {
           <CircularProgress />
         </Box>
       )}
-      {analysis && (
+      {analysis ? (
         <Box sx={{ mt: 2 }}>
           {analysis.issues.map((issue, idx) => (
             <Stack
@@ -103,6 +104,13 @@ export default function JobDescriptionRisk() {
             </Typography>
           )}
         </Box>
+      ) : (
+        !loading && (
+          <EmptyState
+            message="No analysis yet"
+            helperText="Paste a job description and click Analyze."
+          />
+        )
       )}
     </Box>
   );

--- a/src/components/talentforge/Offers/OfferList.tsx
+++ b/src/components/talentforge/Offers/OfferList.tsx
@@ -20,6 +20,7 @@ import {
 } from "@mui/material";
 import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
 import { exportElementToPdf } from "@/utils/pdfExport";
+import EmptyState from "../EmptyState";
 
 interface OfferListProps {
   refreshKey?: number;
@@ -70,9 +71,18 @@ export default function OfferList({ refreshKey }: OfferListProps) {
     }
   };
 
+  if (offers.length === 0) {
+    return (
+      <EmptyState
+        message="No offers"
+        helperText="Save offer details to compare compensation."
+      />
+    );
+  }
+
   return (
     <Box>
-      <List>
+      <List aria-label="Offer list">
         {offers.map((offer, index) => (
           <ListItem disablePadding key={offer.id}>
             <ListItemButton onClick={() => toggleSelect(offer.id)}>

--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -9,7 +9,17 @@ import {
   clearOnboardingStep,
 } from "@/utils/talentforge/dataStore";
 
-const steps = ["Profile Info", "Upload Resume", "Connect Accounts", "Finish"];
+import KeyEntryStep from "./onboarding/KeyEntryStep";
+import ResumeImportStep from "./onboarding/ResumeImportStep";
+import ConnectorMockStep from "./onboarding/ConnectorMockStep";
+import GoalSelectionStep from "./onboarding/GoalSelectionStep";
+
+const steps = [
+  { label: "Enter API Key", Component: KeyEntryStep },
+  { label: "Import Resume", Component: ResumeImportStep },
+  { label: "Connect Accounts", Component: ConnectorMockStep },
+  { label: "Select Goals", Component: GoalSelectionStep },
+];
 
 export default function OnboardingStepper() {
   const [activeStep, setActiveStep] = useState(0);
@@ -35,33 +45,29 @@ export default function OnboardingStepper() {
     clearOnboardingStep();
   };
 
+  const Current = steps[activeStep]?.Component;
+
   return (
     <Box>
-      <Stepper activeStep={activeStep} alternativeLabel>
-        {steps.map((label) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
+      <Stepper activeStep={activeStep} alternativeLabel aria-label="Onboarding steps">
+        {steps.map((step) => (
+          <Step key={step.label}>
+            <StepLabel aria-label={step.label}>{step.label}</StepLabel>
           </Step>
         ))}
       </Stepper>
       {activeStep === steps.length ? (
         <Box sx={{ mt: 2 }}>
-          <Typography>All steps completed - you&apos;re finished</Typography>
-          <Button sx={{ mt: 1 }} onClick={handleReset}>
+          <Typography tabIndex={0}>
+            All steps completed - you&apos;re finished
+          </Typography>
+          <Button sx={{ mt: 1 }} onClick={handleReset} aria-label="Reset">
             Reset
           </Button>
         </Box>
       ) : (
         <Box sx={{ mt: 2 }}>
-          <Typography sx={{ mb: 1 }}>{steps[activeStep]}</Typography>
-          <Box>
-            <Button disabled={activeStep === 0} onClick={handleBack} sx={{ mr: 1 }}>
-              Back
-            </Button>
-            <Button variant="contained" onClick={handleNext}>
-              {activeStep === steps.length - 1 ? "Finish" : "Next"}
-            </Button>
-          </Box>
+          {Current && <Current onNext={handleNext} onBack={handleBack} />}
         </Box>
       )}
     </Box>

--- a/src/components/talentforge/ResumeVariants/List.tsx
+++ b/src/components/talentforge/ResumeVariants/List.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/utils/talentforge/dataStore";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import Detail from "./Detail";
+import EmptyState from "../EmptyState";
 
 interface Props {
   resumes: ResumeEntry[];
@@ -50,8 +51,17 @@ export default function List({ resumes, setResumes }: Props) {
     setResumes(updated);
   };
 
+  if (resumes.length === 0) {
+    return (
+      <EmptyState
+        message="No resumes"
+        helperText="Add a resume above to begin."
+      />
+    );
+  }
+
   return (
-    <Box>
+    <Box aria-label="Resume list">
       {resumes.map((r) => (
         <Box key={r.id} sx={{ mb: 2 }}>
           <Stack direction="row" spacing={1} alignItems="center">

--- a/src/components/talentforge/onboarding/ConnectorMockStep.tsx
+++ b/src/components/talentforge/onboarding/ConnectorMockStep.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Checkbox, FormControlLabel, Stack } from "@mui/material";
+import FocusTrap from "@mui/base/FocusTrap";
+
+interface StepProps {
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+export default function ConnectorMockStep({ onNext, onBack }: StepProps) {
+  const [connected, setConnected] = useState(false);
+
+  return (
+    <FocusTrap open>
+      <Stack spacing={2} aria-label="Connect accounts">
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={connected}
+              onChange={(e) => setConnected(e.target.checked)}
+              inputProps={{ "aria-label": "Mock connector" }}
+            />
+          }
+          label="Mock Connector"
+        />
+        <Stack direction="row" spacing={1}>
+          {onBack && (
+            <Button onClick={onBack} aria-label="Back">
+              Back
+            </Button>
+          )}
+          <Button
+            variant="contained"
+            onClick={onNext}
+            disabled={!connected}
+            aria-label="Continue"
+          >
+            Continue
+          </Button>
+        </Stack>
+      </Stack>
+    </FocusTrap>
+  );
+}
+

--- a/src/components/talentforge/onboarding/GoalSelectionStep.tsx
+++ b/src/components/talentforge/onboarding/GoalSelectionStep.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Checkbox, FormControlLabel, Stack } from "@mui/material";
+import FocusTrap from "@mui/base/FocusTrap";
+
+interface StepProps {
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+export default function GoalSelectionStep({ onNext, onBack }: StepProps) {
+  const [goals, setGoals] = useState({
+    resume: false,
+    networking: false,
+    search: false,
+  });
+
+  const handleChange = (key: "resume" | "networking" | "search") => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setGoals((g) => ({ ...g, [key]: event.target.checked }));
+  };
+
+  const hasGoal = Object.values(goals).some(Boolean);
+
+  return (
+    <FocusTrap open>
+      <Stack spacing={2} aria-label="Select goals">
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={goals.resume}
+              onChange={handleChange("resume")}
+              inputProps={{ "aria-label": "Improve resume" }}
+            />
+          }
+          label="Improve resume"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={goals.networking}
+              onChange={handleChange("networking")}
+              inputProps={{ "aria-label": "Enhance networking" }}
+            />
+          }
+          label="Enhance networking"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={goals.search}
+              onChange={handleChange("search")}
+              inputProps={{ "aria-label": "Streamline job search" }}
+            />
+          }
+          label="Streamline job search"
+        />
+        <Stack direction="row" spacing={1}>
+          {onBack && (
+            <Button onClick={onBack} aria-label="Back">
+              Back
+            </Button>
+          )}
+          <Button
+            variant="contained"
+            onClick={onNext}
+            disabled={!hasGoal}
+            aria-label="Finish"
+          >
+            Finish
+          </Button>
+        </Stack>
+      </Stack>
+    </FocusTrap>
+  );
+}
+

--- a/src/components/talentforge/onboarding/KeyEntryStep.tsx
+++ b/src/components/talentforge/onboarding/KeyEntryStep.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Stack, TextField } from "@mui/material";
+import FocusTrap from "@mui/base/FocusTrap";
+
+interface StepProps {
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+export default function KeyEntryStep({ onNext }: StepProps) {
+  const [key, setKey] = useState("");
+
+  return (
+    <FocusTrap open>
+      <Stack spacing={2} aria-label="API key entry">
+        <TextField
+          label="OpenAI API Key"
+          aria-label="OpenAI API Key"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          autoFocus
+        />
+        <Button
+          variant="contained"
+          onClick={onNext}
+          disabled={!key}
+          aria-label="Continue"
+        >
+          Continue
+        </Button>
+      </Stack>
+    </FocusTrap>
+  );
+}
+

--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Stack } from "@mui/material";
+import FocusTrap from "@mui/base/FocusTrap";
+
+interface StepProps {
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+export default function ResumeImportStep({ onNext, onBack }: StepProps) {
+  const [hasFile, setHasFile] = useState(false);
+
+  return (
+    <FocusTrap open>
+      <Stack spacing={2} aria-label="Resume import">
+        <Button component="label" variant="outlined" aria-label="Upload resume">
+          Upload Resume
+          <input
+            type="file"
+            hidden
+            onChange={(e) => setHasFile(!!e.target.files && e.target.files.length > 0)}
+          />
+        </Button>
+        <Stack direction="row" spacing={1}>
+          {onBack && (
+            <Button onClick={onBack} aria-label="Back">
+              Back
+            </Button>
+          )}
+          <Button
+            variant="contained"
+            onClick={onNext}
+            disabled={!hasFile}
+            aria-label="Continue"
+          >
+            Continue
+          </Button>
+        </Stack>
+      </Stack>
+    </FocusTrap>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace OnboardingStepper with dedicated steps for API key, resume import, mock connector and goal selection
- add EmptyState component and helper text across TalentForge pages
- improve keyboard navigation with aria labels and focus traps

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c676a4322c8330b39be8041911b433