### PR TITLE
fix: remove redundant type export

### DIFF
--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -500,7 +500,5 @@ const dataStore = {
   importFromJson,
 };
 
-export type { ResumeEntry, Message, Offer, JobApplication, RecruiterEntry };
-
 export default dataStore;
 


### PR DESCRIPTION
## Summary
- remove duplicate type re-export in dataStore to avoid TypeScript conflicts

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: next: not found)*
- `npx tsc --noEmit` *(fails: Cannot find module 'uuid' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c67928f8648330aa227b34882fd271