### PR TITLE
Remove FocusTrap wrappers from onboarding steps

### DIFF
--- a/src/components/talentforge/onboarding/ConnectorMockStep.tsx
+++ b/src/components/talentforge/onboarding/ConnectorMockStep.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Button, Checkbox, FormControlLabel, Stack } from "@mui/material";
-import FocusTrap from "@mui/base/FocusTrap";
 
 interface StepProps {
   onNext: () => void;
@@ -13,8 +12,7 @@ export default function ConnectorMockStep({ onNext, onBack }: StepProps) {
   const [connected, setConnected] = useState(false);
 
   return (
-    <FocusTrap open>
-      <Stack spacing={2} aria-label="Connect accounts">
+    <Stack spacing={2} aria-label="Connect accounts">
         <FormControlLabel
           control={
             <Checkbox
@@ -41,7 +39,6 @@ export default function ConnectorMockStep({ onNext, onBack }: StepProps) {
           </Button>
         </Stack>
       </Stack>
-    </FocusTrap>
   );
 }
 

--- a/src/components/talentforge/onboarding/GoalSelectionStep.tsx
+++ b/src/components/talentforge/onboarding/GoalSelectionStep.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Button, Checkbox, FormControlLabel, Stack } from "@mui/material";
-import FocusTrap from "@mui/base/FocusTrap";
 
 interface StepProps {
   onNext: () => void;
@@ -25,8 +24,7 @@ export default function GoalSelectionStep({ onNext, onBack }: StepProps) {
   const hasGoal = Object.values(goals).some(Boolean);
 
   return (
-    <FocusTrap open>
-      <Stack spacing={2} aria-label="Select goals">
+    <Stack spacing={2} aria-label="Select goals">
         <FormControlLabel
           control={
             <Checkbox
@@ -73,7 +71,6 @@ export default function GoalSelectionStep({ onNext, onBack }: StepProps) {
           </Button>
         </Stack>
       </Stack>
-    </FocusTrap>
   );
 }
 

--- a/src/components/talentforge/onboarding/KeyEntryStep.tsx
+++ b/src/components/talentforge/onboarding/KeyEntryStep.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Button, Stack, TextField } from "@mui/material";
-import FocusTrap from "@mui/base/FocusTrap";
 
 interface StepProps {
   onNext: () => void;
@@ -13,8 +12,7 @@ export default function KeyEntryStep({ onNext }: StepProps) {
   const [key, setKey] = useState("");
 
   return (
-    <FocusTrap open>
-      <Stack spacing={2} aria-label="API key entry">
+    <Stack spacing={2} aria-label="API key entry">
         <TextField
           label="OpenAI API Key"
           aria-label="OpenAI API Key"
@@ -31,7 +29,6 @@ export default function KeyEntryStep({ onNext }: StepProps) {
           Continue
         </Button>
       </Stack>
-    </FocusTrap>
   );
 }
 

--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Button, Stack } from "@mui/material";
-import FocusTrap from "@mui/base/FocusTrap";
 
 interface StepProps {
   onNext: () => void;
@@ -13,8 +12,7 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
   const [hasFile, setHasFile] = useState(false);
 
   return (
-    <FocusTrap open>
-      <Stack spacing={2} aria-label="Resume import">
+    <Stack spacing={2} aria-label="Resume import">
         <Button component="label" variant="outlined" aria-label="Upload resume">
           Upload Resume
           <input
@@ -39,7 +37,6 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
           </Button>
         </Stack>
       </Stack>
-    </FocusTrap>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace `FocusTrap` wrappers with standard `Stack` containers in talentforge onboarding steps

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c679db2dec8330b7ee742f1367b958