### PR TITLE
Store OpenAI key in onboarding

### DIFF
--- a/src/components/talentforge/onboarding/KeyEntryStep.tsx
+++ b/src/components/talentforge/onboarding/KeyEntryStep.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Button, Stack, TextField } from "@mui/material";
+import { setOpenAIKey } from "@/utils/talentforge/utils";
 
 interface StepProps {
   onNext: () => void;
@@ -10,6 +11,27 @@ interface StepProps {
 
 export default function KeyEntryStep({ onNext }: StepProps) {
   const [key, setKey] = useState("");
+
+  const handleContinue = async () => {
+    const trimmed = key.trim();
+    if (!trimmed) return;
+    try {
+      const res = await fetch("/api/test-openai-key", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: trimmed }),
+      });
+      if (res.ok) {
+        setOpenAIKey(trimmed);
+        alert("Key is valid!");
+        onNext();
+      } else {
+        alert("Key test failed.");
+      }
+    } catch {
+      alert("Key test failed.");
+    }
+  };
 
   return (
     <Stack spacing={2} aria-label="API key entry">
@@ -22,7 +44,7 @@ export default function KeyEntryStep({ onNext }: StepProps) {
         />
         <Button
           variant="contained"
-          onClick={onNext}
+          onClick={handleContinue}
           disabled={!key}
           aria-label="Continue"
         >


### PR DESCRIPTION
## Summary
- Save OpenAI API key during onboarding and test it before continuing.

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c67ca9f1cc8330acbf36c29f799d21