### PR TITLE
feat: add onboarding stepper reset and embed

### DIFF
--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -3,16 +3,25 @@
 import React from "react";
 import Dashboard from "@/components/talentforge/Dashboard";
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
+import OnboardingStepper, {
+  TOTAL_ONBOARDING_STEPS,
+} from "@/components/talentforge/OnboardingStepper";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import insertMockData from "@/utils/mockData";
+import { getOnboardingStep } from "@/utils/talentforge/dataStore";
 
 export default function TalentForgePage() {
   const { setDocumentTitle } = useDocumentTitle();
+  const [step, setStep] = React.useState(getOnboardingStep());
 
   React.useEffect(() => {
     insertMockData();
     setDocumentTitle("TalentForge");
   }, [setDocumentTitle]);
+
+  if (step < TOTAL_ONBOARDING_STEPS) {
+    return <OnboardingStepper onComplete={() => setStep(TOTAL_ONBOARDING_STEPS)} />;
+  }
 
   return (
     <ErrorBoundary>

--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -21,28 +21,41 @@ const steps = [
   { label: "Select Goals", Component: GoalSelectionStep },
 ];
 
-export default function OnboardingStepper() {
+export const TOTAL_ONBOARDING_STEPS = steps.length;
+
+export default function OnboardingStepper({
+  onComplete,
+}: {
+  onComplete?: () => void;
+}) {
   const [activeStep, setActiveStep] = useState(0);
 
   useEffect(() => {
-    setActiveStep(getOnboardingStep());
+    const step = getOnboardingStep();
+    setActiveStep(step);
+    setOnboardingStep(step);
   }, []);
 
-  useEffect(() => {
-    setOnboardingStep(activeStep);
-  }, [activeStep]);
-
   const handleNext = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+    setActiveStep((prevActiveStep) => {
+      const next = prevActiveStep + 1;
+      setOnboardingStep(next);
+      if (next === TOTAL_ONBOARDING_STEPS) onComplete?.();
+      return next;
+    });
   };
 
   const handleBack = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+    setActiveStep((prevActiveStep) => {
+      const next = prevActiveStep - 1;
+      setOnboardingStep(next);
+      return next;
+    });
   };
 
   const handleReset = () => {
-    setActiveStep(0);
     clearOnboardingStep();
+    setActiveStep(0);
   };
 
   const Current = steps[activeStep]?.Component;


### PR DESCRIPTION
## Summary
- call onboarding step persistence helpers on mount and step change
- add reset action and completion callback to onboarding stepper
- display onboarding stepper for new TalentForge users

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67cbec9608330bf5a8d0e72946eed