### PR TITLE
Parse uploaded resume in onboarding

### DIFF
--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -2,6 +2,11 @@
 
 import { useState } from "react";
 import { Button, Stack } from "@mui/material";
+import { v4 as uuid } from "uuid";
+
+import { pdfToMarkdown, parseResumeText } from "@/utils/talentforge/pdfParser";
+import { addResume } from "@/utils/talentforge/dataStore";
+import { tagResume } from "@/utils/talentforge/tagging";
 
 interface StepProps {
   onNext: () => void;
@@ -9,7 +14,35 @@ interface StepProps {
 }
 
 export default function ResumeImportStep({ onNext, onBack }: StepProps) {
-  const [hasFile, setHasFile] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0] || null;
+    setFile(selected);
+  };
+
+  const handleContinue = async () => {
+    if (!file) return;
+    setLoading(true);
+    try {
+      const text = await pdfToMarkdown(file);
+      const tags = await tagResume(text);
+      const parsed = parseResumeText(text);
+      addResume({
+        id: uuid(),
+        userId: "",
+        label: "",
+        url: "",
+        content: text,
+        parsed,
+        tags,
+      });
+      onNext();
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <Stack spacing={2} aria-label="Resume import">
@@ -18,7 +51,7 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
           <input
             type="file"
             hidden
-            onChange={(e) => setHasFile(!!e.target.files && e.target.files.length > 0)}
+            onChange={handleFileChange}
           />
         </Button>
         <Stack direction="row" spacing={1}>
@@ -29,8 +62,8 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
           )}
           <Button
             variant="contained"
-            onClick={onNext}
-            disabled={!hasFile}
+            onClick={handleContinue}
+            disabled={!file || loading}
             aria-label="Continue"
           >
             Continue


### PR DESCRIPTION
## Summary
- Parse uploaded resume files to text with `pdfToMarkdown`
- Tag and store resume via `addResume` then advance stepper

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c67cc4b520833094c3c44dde6c28c4