### PR TITLE
feat(talentforge): sync OpenAI key modal

### DIFF
--- a/src/components/talentforge/ChatAssistant.tsx
+++ b/src/components/talentforge/ChatAssistant.tsx
@@ -9,7 +9,7 @@ import {
   hasValidOpenAIKey,
 } from "@/utils/talentforge/utils";
 import { exportElementToPdf } from "@/utils/pdfExport";
-import OpenAiKeyModal from "./OpenAiKeyModal";
+import OpenAIKeyModal from "./OpenAiKeyModal";
 import RequireAIKey from "./RequireAIKey";
 import { ChatMessage } from "@/types/talentforge/types";
 import PromptSelector from "./PromptSelector";
@@ -60,7 +60,7 @@ export default function ChatAssistant() {
   return (
     <RequireAIKey>
       <Box>
-        <OpenAiKeyModal
+        <OpenAIKeyModal
           open={openKeyModal}
           onClose={() => setOpenKeyModal(false)}
         />

--- a/src/components/talentforge/CoverLetter.tsx
+++ b/src/components/talentforge/CoverLetter.tsx
@@ -13,7 +13,7 @@ import {
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { getResumes } from "@/utils/talentforge/dataStore";
 import { exportElementToPdf } from "@/utils/pdfExport";
-import OpenAiKeyModal from "./OpenAiKeyModal";
+import OpenAIKeyModal from "./OpenAiKeyModal";
 import EmptyState from "./EmptyState";
 
 export default function CoverLetter() {
@@ -61,7 +61,7 @@ export default function CoverLetter() {
 
   return (
     <Box>
-      <OpenAiKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
       <Stack spacing={2}>
         <TextField
           select

--- a/src/components/talentforge/Hero.tsx
+++ b/src/components/talentforge/Hero.tsx
@@ -28,7 +28,7 @@ import {
   pdfToMarkdown,
   hasOpenAIKey,
 } from "@/utils/talentforge/utils";
-import OpenAiKeyModal from "./OpenAiKeyModal";
+import OpenAIKeyModal from "./OpenAiKeyModal";
 
 import CircularProgressWithLabel from "./CircularProgressWithLabel";
 import FileUploader from "./FileUploader";
@@ -135,7 +135,7 @@ export default function Hero() {
       })}
     >
       <TermsDialog open={openTerms} onClose={() => setOpenTerms(false)} />
-      <OpenAiKeyModal
+      <OpenAIKeyModal
         open={openKeyModal}
         onClose={() => setOpenKeyModal(false)}
       />

--- a/src/components/talentforge/JobDescriptionRisk.tsx
+++ b/src/components/talentforge/JobDescriptionRisk.tsx
@@ -9,7 +9,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import OpenAiKeyModal from "./OpenAiKeyModal";
+import OpenAIKeyModal from "./OpenAiKeyModal";
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import EmptyState from "./EmptyState";
@@ -62,7 +62,7 @@ export default function JobDescriptionRisk() {
 
   return (
     <Box>
-      <OpenAiKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
       <TextField
         label="Paste job description"
         multiline

--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -19,7 +19,7 @@ import {
   pdfToMarkdown,
   hasOpenAIKey,
 } from "@/utils/talentforge/utils";
-import OpenAiKeyModal from "./OpenAiKeyModal";
+import OpenAIKeyModal from "./OpenAiKeyModal";
 import {
   addOffer,
   type Offer,
@@ -136,7 +136,7 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
 
   return (
     <Box>
-      <OpenAiKeyModal
+      <OpenAIKeyModal
         open={openKeyModal}
         onClose={() => setOpenKeyModal(false)}
       />

--- a/src/components/talentforge/OpenAiKeyModal.tsx
+++ b/src/components/talentforge/OpenAiKeyModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import {
   Dialog,
@@ -10,7 +12,9 @@ import {
   DialogProps,
   FormControlLabel,
   Switch,
+  IconButton,
 } from "@mui/material";
+import { Close } from "@mui/icons-material";
 
 import { setOpenAIKey } from "@/utils/talentforge/utils";
 import {
@@ -18,16 +22,17 @@ import {
   deleteOpenAIKey,
 } from "@/utils/talentforge/dataStore";
 
-export interface OpenAiKeyModalProps
+export interface OpenAIKeyModalProps
   extends Omit<DialogProps, "open" | "onClose"> {
   open?: boolean;
   onClose?: () => void;
 }
 
-export default function OpenAiKeyModal({
+export default function OpenAIKeyModal({
   open = false,
   onClose,
-}: OpenAiKeyModalProps) {
+  ...props
+}: OpenAIKeyModalProps) {
   const [key, setKey] = React.useState("");
   const [persist, setPersist] = React.useState(true);
 
@@ -119,8 +124,22 @@ export default function OpenAiKeyModal({
   };
 
   return (
-    <Dialog open={open} onClose={handleClose}>
-      <DialogTitle>Enter OpenAI API Key</DialogTitle>
+    <Dialog open={open} onClose={handleClose} {...props}>
+      <DialogTitle>
+        Enter OpenAI API Key
+        <IconButton
+          aria-label="close"
+          onClick={handleClose}
+          sx={{
+            position: "absolute",
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500],
+          }}
+        >
+          <Close />
+        </IconButton>
+      </DialogTitle>
       <DialogContent>
         <DialogContentText sx={{ mb: 2 }}>
           Your key is stored locally under <code>talentforge-openai-key</code> and

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -23,7 +23,7 @@ import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { pdfToMarkdown, parseResumeText } from "@/utils/talentforge/pdfParser";
 import { tagResume } from "@/utils/talentforge/tagging";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
-import OpenAiKeyModal from "./OpenAiKeyModal";
+import OpenAIKeyModal from "./OpenAiKeyModal";
 import FileUploader from "./FileUploader";
 import ResumeVariantList from "./ResumeVariants/List";
 
@@ -90,7 +90,7 @@ export default function ResumeManager() {
 
   return (
     <Box>
-      <OpenAiKeyModal
+      <OpenAIKeyModal
         open={openKeyModal}
         onClose={() => setOpenKeyModal(false)}
       />

--- a/src/components/talentforge/Settings.tsx
+++ b/src/components/talentforge/Settings.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
 } from "@mui/material";
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
-import OpenAiKeyModal from "@/components/talentforge/OpenAiKeyModal";
+import OpenAIKeyModal from "@/components/talentforge/OpenAiKeyModal";
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
 import { exportSnapshot, importSnapshot } from "@/utils/talentforge/snapshot";
 import { loadDemoData, clearDemoData } from "@/utils/talentforge/demoData";
@@ -145,7 +145,7 @@ export default function Settings() {
           </CardActions>
         </Card>
 
-        <OpenAiKeyModal open={openKeyModal} onClose={handleCloseModal} />
+        <OpenAIKeyModal open={openKeyModal} onClose={handleCloseModal} />
       </Stack>
     </ErrorBoundary>
   );

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -13,7 +13,7 @@ import {
 import { ContentCopy } from "@mui/icons-material";
 import Markdown from "react-markdown";
 
-import OpenAiKeyModal from "../OpenAiKeyModal";
+import OpenAIKeyModal from "../OpenAiKeyModal";
 import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
 import { getResumes, addResume, type ResumeEntry } from "@/utils/talentforge/dataStore";
 import { tagResume } from "@/utils/talentforge/tagging";
@@ -112,7 +112,7 @@ export default function Tile({
 
   return (
     <Box>
-      <OpenAiKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
       <Stack spacing={1}>
         <Typography variant="subtitle1">{display}</Typography>
         {inputs.map((name) => (


### PR DESCRIPTION
## Summary
- copy Bookworm's OpenAI API key modal into TalentForge
- support persisting key in local or session storage
- rename and update imports to new modal component

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68c67cb8251883308fe56977912d22fa