### PR TITLE
feat: add prompt tile registry and runner

### DIFF
--- a/src/components/talentforge/promptTiles/PromptTileGrid.tsx
+++ b/src/components/talentforge/promptTiles/PromptTileGrid.tsx
@@ -1,19 +1,126 @@
 "use client";
 
-import { Grid } from "@mui/material";
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Grid,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 
-import Tile from "./Tile";
-import { PROMPT_TILES } from "@/consts/promptTiles";
+import OpenAiKeyModal from "../OpenAiKeyModal";
+import {
+  askOpenAI,
+  hasValidOpenAIKey,
+} from "@/utils/talentforge/utils";
+import { getResumes } from "@/utils/talentforge/dataStore";
+import { PROMPT_TILES, type PromptTileDefinition } from "@/consts/promptTiles";
+
+const registry: Record<string, PromptTileDefinition> = PROMPT_TILES;
 
 export default function PromptTileGrid() {
+  const [values, setValues] = useState<
+    Record<string, Record<string, string>>
+  >({});
+  const [responses, setResponses] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState<Record<string, boolean>>({});
+  const [openKeyModal, setOpenKeyModal] = useState(false);
+
+  const handleChange = (id: string, key: string, value: string) => {
+    setValues((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], [key]: value },
+    }));
+  };
+
+  const runTile = async (id: string) => {
+    const tile = registry[id];
+    if (!tile) return;
+
+    const valid = await hasValidOpenAIKey();
+    if (!valid) {
+      setOpenKeyModal(true);
+      return;
+    }
+
+    setLoading((prev) => ({ ...prev, [id]: true }));
+    try {
+      const tileValues = values[id] || {};
+      let prompt = tile.fullPrompt;
+      for (const key of tile.inputs) {
+        prompt = prompt.replaceAll(`{{${key}}}`, tileValues[key] || "");
+      }
+
+      if (tile.id === "resumeRewrite") {
+        const resume = getResumes().find(
+          (r) => r.id === tileValues["resumeVariantId"],
+        );
+        if (!resume) {
+          setResponses((prev) => ({ ...prev, [id]: "Resume not found" }));
+          return;
+        }
+        prompt = `${prompt}\n\nJob Description:\n${tileValues["jobDescription"]}\n\nResume:\n${resume.content}`;
+      }
+
+      const res = await askOpenAI({
+        context: "",
+        user: prompt,
+        system: "You are a helpful assistant.",
+        returnFirstResponse: true,
+        chatHistory: [],
+      });
+      setResponses((prev) => ({ ...prev, [id]: res?.message || "" }));
+    } finally {
+      setLoading((prev) => ({ ...prev, [id]: false }));
+    }
+  };
+
   return (
-    <Grid container spacing={2}>
-      {Object.values(PROMPT_TILES).map((tile) => (
-        <Grid item xs={12} sm={6} md={4} key={tile.id}>
-          <Tile {...tile} />
-        </Grid>
-      ))}
-    </Grid>
+    <>
+      <OpenAiKeyModal
+        open={openKeyModal}
+        onClose={() => setOpenKeyModal(false)}
+      />
+      <Grid container spacing={2}>
+        {Object.values(registry).map((tile) => (
+          <Grid item xs={12} sm={6} md={4} key={tile.id}>
+            <Box>
+              <Stack spacing={1}>
+                <Typography variant="subtitle1">{tile.display}</Typography>
+                {tile.inputs.map((name) => (
+                  <TextField
+                    key={name}
+                    label={name}
+                    size="small"
+                    value={values[tile.id]?.[name] || ""}
+                    onChange={(e) =>
+                      handleChange(tile.id, name, e.target.value)
+                    }
+                  />
+                ))}
+                <Button
+                  variant="contained"
+                  onClick={() => runTile(tile.id)}
+                  disabled={loading[tile.id]}
+                >
+                  {loading[tile.id] ? "Running..." : "Run"}
+                </Button>
+                {responses[tile.id] && (
+                  <Typography
+                    variant="body2"
+                    sx={{ whiteSpace: "pre-wrap" }}
+                  >
+                    {responses[tile.id]}
+                  </Typography>
+                )}
+              </Stack>
+            </Box>
+          </Grid>
+        ))}
+      </Grid>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- build prompt tile registry loading from `PROMPT_TILES`
- render tile inputs and display OpenAI responses
- add helper to assemble prompts and call `askOpenAI`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c67cf6934c8330821ce7169f0e70c3