### PR TITLE
feat: add resume rewriting tile with context handling

### DIFF
--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -47,6 +47,9 @@ export default function Tile({
     setValues((prev) => ({ ...prev, [key]: value }));
   };
 
+  const loadSelectedResume = () =>
+    getResumes().find((r) => r.id === values["resumeVariantId"]);
+
   const handleRun = async () => {
     const valid = await hasValidOpenAIKey();
     if (!valid) {
@@ -60,21 +63,20 @@ export default function Tile({
         prompt = prompt.replaceAll(`{{${key}}}`, values[key] || "");
       }
 
+      let context = "";
       if (id === "resumeRewrite") {
-        const resume = getResumes().find(
-          (r) => r.id === values["resumeVariantId"],
-        );
+        const resume = loadSelectedResume();
         if (!resume) {
           setResponse("Resume not found");
           return;
         }
-        prompt = `${prompt}\n\nJob Description:\n${values["jobDescription"]}\n\nResume:\n${resume.content}`;
+        context = `Job Description:\n${values["jobDescription"]}\n\nResume:\n${resume.content}`;
       }
 
       const res = await askOpenAI({
-        context: "",
+        context,
         user: prompt,
-        system: "You are a helpful assistant.",
+        system: "You are a helpful assistant. Use the following context:\n{{context}}",
         returnFirstResponse: true,
         chatHistory: [],
       });
@@ -89,9 +91,7 @@ export default function Tile({
 
   const handleSaveVariant = async () => {
     if (id !== "resumeRewrite" || !response) return;
-    const resume = getResumes().find(
-      (r) => r.id === values["resumeVariantId"],
-    );
+    const resume = loadSelectedResume();
     if (!resume) return;
     setSaving(true);
     try {

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -40,7 +40,7 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
     id: "resumeRewrite",
     display: "Resume Rewrite",
     fullPrompt:
-      "Rewrite this resume to emphasize how the candidate meets the role requirements.",
+      "Using the provided job description and resume, rewrite the resume to emphasize how the candidate meets the role requirements.",
     inputs: ["resumeVariantId", "jobDescription"],
   },
   jobRequirements: {


### PR DESCRIPTION
## Summary
- add `resumeRewrite` prompt tile accepting resume variant and job description
- load selected resume and send resume/job description context to `askOpenAI`

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c67d026944833088e49ce7f514e16c