### PR TITLE
Add JD Requirements prompt tile with job description textarea

### DIFF
--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -115,15 +115,27 @@ export default function Tile({
       <OpenAiKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
       <Stack spacing={1}>
         <Typography variant="subtitle1">{display}</Typography>
-        {inputs.map((name) => (
-          <TextField
-            key={name}
-            label={name}
-            value={values[name] || ""}
-            onChange={(e) => handleChange(name, e.target.value)}
-            size="small"
-          />
-        ))}
+        {inputs.map((name) =>
+          name === "jobDescription" ? (
+            <TextField
+              key={name}
+              label={name}
+              value={values[name] || ""}
+              onChange={(e) => handleChange(name, e.target.value)}
+              multiline
+              minRows={4}
+              fullWidth
+            />
+          ) : (
+            <TextField
+              key={name}
+              label={name}
+              value={values[name] || ""}
+              onChange={(e) => handleChange(name, e.target.value)}
+              size="small"
+            />
+          ),
+        )}
         <Button variant="contained" onClick={handleRun} disabled={loading}>
           {loading ? "Running..." : "Run"}
         </Button>

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -43,6 +43,13 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Rewrite this resume to emphasize how the candidate meets the role requirements.",
     inputs: ["resumeVariantId", "jobDescription"],
   },
+  jdRequirements: {
+    id: "jdRequirements",
+    display: "JD Requirements",
+    fullPrompt:
+      "From the following job description, list the key job requirements as bullet points:\n\n{{jobDescription}}",
+    inputs: ["jobDescription"],
+  },
   jobRequirements: {
     ...BASE_TILES.jobRequirements,
     fullPrompt:


### PR DESCRIPTION
## Summary
- add JD Requirements tile to prompt tiles using `jobDescription` as input
- support multiline job description input in prompt tile component

## Testing
- `npm install` *(fails: 403 Forbidden fetching @dnd-kit/core)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67d06968883308f5ac8c259f8819c