### PR TITLE
feat: add negotiate offer prompt tile

### DIFF
--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -9,6 +9,8 @@ import {
   Typography,
   IconButton,
   Tooltip,
+  Tabs,
+  Tab,
 } from "@mui/material";
 import { ContentCopy } from "@mui/icons-material";
 import Markdown from "react-markdown";
@@ -42,6 +44,11 @@ export default function Tile({
   const [loading, setLoading] = useState(false);
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [drafts, setDrafts] = useState<
+    | { email: string; linkedin: string; indeed: string }
+    | null
+  >(null);
+  const [activeTab, setActiveTab] = useState(0);
 
   const handleChange = (key: string, value: string) => {
     setValues((prev) => ({ ...prev, [key]: value }));
@@ -69,6 +76,38 @@ export default function Tile({
           return;
         }
         prompt = `${prompt}\n\nJob Description:\n${values["jobDescription"]}\n\nResume:\n${resume.content}`;
+      }
+
+      if (id === "negotiateOffer") {
+        setDrafts(null);
+        setActiveTab(0);
+        const context = `Offer Letter:\n${values["offerLetter"] || ""}\n\nCurrent Compensation:\n${values["currentComp"] || ""}`;
+        const res = await askOpenAI({
+          context,
+          user: prompt,
+          system:
+            "You analyze offers and produce structured negotiation drafts.",
+          returnFirstResponse: true,
+          chatHistory: [],
+        });
+        const message = res?.message || "";
+        try {
+          const parsed = JSON.parse(message) as {
+            email?: string;
+            linkedin?: string;
+            indeed?: string;
+          };
+          setDrafts({
+            email: parsed.email || "",
+            linkedin: parsed.linkedin || "",
+            indeed: parsed.indeed || "",
+          });
+        } catch {
+          setDrafts({ email: message, linkedin: "", indeed: "" });
+        }
+        onResponse?.(message);
+        onInsert?.(message);
+        return;
       }
 
       const res = await askOpenAI({
@@ -125,9 +164,44 @@ export default function Tile({
           />
         ))}
         <Button variant="contained" onClick={handleRun} disabled={loading}>
-          {loading ? "Running..." : "Run"}
+        {loading ? "Running..." : "Run"}
         </Button>
-        {response && (
+        {id === "negotiateOffer" && drafts && (
+          <Box>
+            <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)}>
+              <Tab label="Email" />
+              <Tab label="LinkedIn" />
+              <Tab label="Indeed" />
+            </Tabs>
+            <Box sx={{ mt: 2 }}>
+              <Box display="flex" justifyContent="flex-end">
+                {navigator.clipboard && (
+                  <Tooltip title="copy to clipboard" arrow>
+                    <IconButton
+                      aria-label="copy response to clipboard"
+                      onClick={() =>
+                        navigator.clipboard.writeText(
+                          activeTab === 0
+                            ? drafts.email
+                            : activeTab === 1
+                              ? drafts.linkedin
+                              : drafts.indeed,
+                        )
+                      }
+                      size="small"
+                    >
+                      <ContentCopy fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </Box>
+              {activeTab === 0 && <Markdown>{drafts.email}</Markdown>}
+              {activeTab === 1 && <Markdown>{drafts.linkedin}</Markdown>}
+              {activeTab === 2 && <Markdown>{drafts.indeed}</Markdown>}
+            </Box>
+          </Box>
+        )}
+        {id !== "negotiateOffer" && response && (
           <>
             <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
               {response}

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -49,5 +49,11 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "From the following job description, list the key job requirements as bullet points:\n\n{{jobDescription}}",
     inputs: ["jobDescription"],
   },
+  negotiateOffer: {
+    ...BASE_TILES.negotiateOffer,
+    fullPrompt:
+      "Compare the offer letter to the current compensation and summarize key differences. Then draft professional replies for email, LinkedIn, and Indeed. Respond in JSON with keys email, linkedin, indeed.",
+    inputs: ["offerLetter", "currentComp"],
+  },
 };
 


### PR DESCRIPTION
## Summary
- add negotiate offer tile with offer letter and current compensation inputs
- support offer analysis to produce email, LinkedIn, and Indeed drafts in tabs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c67d0dc58883309333d34722949110