### PR TITLE
Add Job Description Risk tile with severity indicators

### DIFF
--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -20,6 +20,16 @@ import { tagResume } from "@/utils/talentforge/tagging";
 import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { v4 as uuid } from "uuid";
 
+interface Issue {
+  severity: "red" | "yellow";
+  message: string;
+}
+
+interface Analysis {
+  summary?: string;
+  issues: Issue[];
+}
+
 export interface PromptTileProps {
   id: string;
   display: string;
@@ -36,9 +46,10 @@ export default function Tile({
   inputs,
   onInsert,
   onResponse,
-}: PromptTileProps) {
-  const [values, setValues] = useState<Record<string, string>>({});
-  const [response, setResponse] = useState("");
+  }: PromptTileProps) {
+    const [values, setValues] = useState<Record<string, string>>({});
+    const [response, setResponse] = useState("");
+    const [analysis, setAnalysis] = useState<Analysis | null>(null);
   const [loading, setLoading] = useState(false);
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -53,39 +64,58 @@ export default function Tile({
       setOpenKeyModal(true);
       return;
     }
+    setResponse("");
+    setAnalysis(null);
     setLoading(true);
-    try {
-      let prompt = fullPrompt;
-      for (const key of inputs) {
-        prompt = prompt.replaceAll(`{{${key}}}`, values[key] || "");
-      }
-
-      if (id === "resumeRewrite") {
-        const resume = getResumes().find(
-          (r) => r.id === values["resumeVariantId"],
-        );
-        if (!resume) {
-          setResponse("Resume not found");
-          return;
+      try {
+        let prompt = fullPrompt;
+        for (const key of inputs) {
+          prompt = prompt.replaceAll(`{{${key}}}`, values[key] || "");
         }
-        prompt = `${prompt}\n\nJob Description:\n${values["jobDescription"]}\n\nResume:\n${resume.content}`;
-      }
 
-      const res = await askOpenAI({
-        context: "",
-        user: prompt,
-        system: "You are a helpful assistant.",
-        returnFirstResponse: true,
-        chatHistory: [],
-      });
-      const message = res?.message || "";
-      setResponse(message);
-      onResponse?.(message);
-      onInsert?.(message);
-    } finally {
-      setLoading(false);
-    }
-  };
+        if (id === "resumeRewrite") {
+          const resume = getResumes().find(
+            (r) => r.id === values["resumeVariantId"],
+          );
+          if (!resume) {
+            setResponse("Resume not found");
+            return;
+          }
+          prompt = `${prompt}\n\nJob Description:\n${values["jobDescription"]}\n\nResume:\n${resume.content}`;
+        }
+
+        const res = await askOpenAI({
+          context: "",
+          user: prompt,
+          system: "You are a helpful assistant.",
+          returnFirstResponse: true,
+          chatHistory: [],
+        });
+        const message = res?.message || "";
+        if (id === "jobDescriptionRisk") {
+          try {
+            const parsed = JSON.parse(message);
+            const issues: Issue[] = Array.isArray(parsed.issues)
+              ? (parsed.issues as Issue[]).sort(
+                  (a, b) =>
+                    (a.severity === "red" ? 0 : 1) -
+                    (b.severity === "red" ? 0 : 1),
+                )
+              : [];
+            setAnalysis({ summary: parsed.summary, issues });
+          } catch {
+            setAnalysis({ summary: message, issues: [] });
+          }
+          setResponse("");
+        } else {
+          setResponse(message);
+          onResponse?.(message);
+          onInsert?.(message);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
 
   const handleSaveVariant = async () => {
     if (id !== "resumeRewrite" || !response) return;
@@ -127,40 +157,66 @@ export default function Tile({
         <Button variant="contained" onClick={handleRun} disabled={loading}>
           {loading ? "Running..." : "Run"}
         </Button>
-        {response && (
-          <>
-            <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-              {response}
-            </Typography>
-            {id === "resumeRewrite" && (
-              <Button
-                variant="outlined"
-                onClick={handleSaveVariant}
-                disabled={saving}
-              >
-                {saving ? "Saving..." : "Save as new variant"}
-              </Button>
-            )}
-            <Box>
-              <Box display="flex" justifyContent="flex-end">
-                {navigator.clipboard && (
-                  <Tooltip title="copy to clipboard" arrow>
-                    <IconButton
-                      aria-label="copy response to clipboard"
-                      onClick={() => navigator.clipboard.writeText(response)}
-                      size="small"
+          {id === "jobDescriptionRisk"
+            ? analysis && (
+                <Box>
+                  {analysis.issues.map((issue, idx) => (
+                    <Stack
+                      key={idx}
+                      direction="row"
+                      spacing={1}
+                      alignItems="flex-start"
+                      sx={{ mb: 1 }}
                     >
-                      <ContentCopy fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
-                )}
-              </Box>
-              <Markdown>{response}</Markdown>
-            </Box>
-          </>
-        )}
-      </Stack>
-    </Box>
-  );
-}
+                      <Typography>
+                        {issue.severity === "red" ? "🚩" : "⚠️"}
+                      </Typography>
+                      <Typography variant="body2">
+                        {issue.message}
+                      </Typography>
+                    </Stack>
+                  ))}
+                  {analysis.summary && (
+                    <Typography variant="body2" sx={{ mt: 2 }}>
+                      {analysis.summary}
+                    </Typography>
+                  )}
+                </Box>
+              )
+            : response && (
+                <>
+                  <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                    {response}
+                  </Typography>
+                  {id === "resumeRewrite" && (
+                    <Button
+                      variant="outlined"
+                      onClick={handleSaveVariant}
+                      disabled={saving}
+                    >
+                      {saving ? "Saving..." : "Save as new variant"}
+                    </Button>
+                  )}
+                  <Box>
+                    <Box display="flex" justifyContent="flex-end">
+                      {navigator.clipboard && (
+                        <Tooltip title="copy to clipboard" arrow>
+                          <IconButton
+                            aria-label="copy response to clipboard"
+                            onClick={() => navigator.clipboard.writeText(response)}
+                            size="small"
+                          >
+                            <ContentCopy fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Box>
+                    <Markdown>{response}</Markdown>
+                  </Box>
+                </>
+              )}
+        </Stack>
+      </Box>
+    );
+  }
 

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -43,6 +43,12 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Rewrite this resume to emphasize how the candidate meets the role requirements.",
     inputs: ["resumeVariantId", "jobDescription"],
   },
+  jobDescriptionRisk: {
+    ...BASE_TILES.jobDescriptionRisk,
+    fullPrompt:
+      `${PROMPT_TEMPLATES.jobDescriptionRisk.fullText}\n\nJob Description:\n{{jobDescription}}`,
+    inputs: ["jobDescription"],
+  },
   jobRequirements: {
     ...BASE_TILES.jobRequirements,
     fullPrompt:


### PR DESCRIPTION
## Summary
- add Job Description Risk prompt tile requiring a job description
- parse job-description risk responses into severity-sorted issues with emoji indicators

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c67d1677b88330aa4154863bae54f4