### PR TITLE
refactor: avoid explicit any in tagging

### DIFF
--- a/src/utils/talentforge/tagging.ts
+++ b/src/utils/talentforge/tagging.ts
@@ -85,9 +85,9 @@ async function fetchAiTags(
         .split(/,|\n/)
         .map((t) => t.trim())
         .filter(Boolean);
-    } catch (err: any) {
-      const code = err?.code as string | undefined;
-      const msg = err?.message?.toLowerCase?.() ?? "";
+    } catch (err: unknown) {
+      const { code, message } = err as NodeJS.ErrnoException;
+      const msg = message?.toLowerCase?.() ?? "";
       const isNetworkError =
         (code && NETWORK_ERROR_CODES.includes(code)) || msg.includes("network");
       if (!isNetworkError || attempt === maxRetries) {


### PR DESCRIPTION
## Summary
- avoid explicit any in resume tagging utility

## Testing
- `npm run lint` *(fails: command not found: npm)*
- `npm test` *(fails: command not found: npm)*
- `npm run build` *(fails: command not found: npm)*


------
https://chatgpt.com/codex/tasks/task_e_68c67f359dd083309e610e7bd7047826