### PR TITLE
feat: guard clipboard API

### DIFF
--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,12 +1,16 @@
 /**
- * Copies the provided text to the clipboard, if it is available.
+ * Copies the provided text to the clipboard when supported and logs when the Clipboard API is unavailable.
  *
  * @param copyMe the string to copy
  */
 const copyToClipboard = async (copyMe: string) => {
   try {
     if (typeof window !== "undefined") {
-      await navigator.clipboard.writeText(copyMe);
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(copyMe);
+      } else {
+        console.log("Clipboard API not supported");
+      }
     }
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
## Summary
- check for clipboard API availability before copying
- note fallback logging in comment

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c680eabce883308d8ac6ca62a88fe3