### PR TITLE
Add skeleton loading states with ARIA attributes

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -14,6 +14,7 @@ import {
   MenuItem,
   Select,
   SelectChangeEvent,
+  Skeleton,
   Stack,
   TextField,
   Typography,
@@ -46,10 +47,12 @@ export default function Inbox() {
   const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
   const [aiThread, setAiThread] = useState<string | null>(null);
   const [promptKey, setPromptKey] = useState<string>("");
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setThreads(data.getThreads());
     setRecruiters(data.getRecruiters());
+    setLoading(false);
   }, [data]);
 
   const handleFilterChange = (event: SelectChangeEvent) => {
@@ -129,6 +132,16 @@ export default function Inbox() {
     }
     setAiThread(null);
   };
+
+  if (loading) {
+    return (
+      <Stack spacing={2} aria-label="Loading inbox" aria-busy="true">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <Skeleton key={idx} variant="rectangular" height={60} />
+        ))}
+      </Stack>
+    );
+  }
 
   if (threads.length === 0) {
     return (

--- a/src/components/talentforge/Offers/OfferList.tsx
+++ b/src/components/talentforge/Offers/OfferList.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   Checkbox,
+  Skeleton,
   List,
   ListItem,
   ListItemButton,
@@ -30,9 +31,11 @@ export default function OfferList({ refreshKey }: OfferListProps) {
   const [offers, setOffers] = useState<Offer[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const markdownRef = useRef<HTMLPreElement>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setOffers(getOffers());
+    setLoading(false);
   }, [refreshKey]);
 
   const toggleSelect = (id: string) => {
@@ -71,6 +74,20 @@ export default function OfferList({ refreshKey }: OfferListProps) {
     }
   };
 
+  if (loading) {
+    return (
+      <List aria-label="Loading offers" aria-busy="true">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <ListItem key={idx}>
+            <ListItemText>
+              <Skeleton variant="rectangular" height={40} />
+            </ListItemText>
+          </ListItem>
+        ))}
+      </List>
+    );
+  }
+
   if (offers.length === 0) {
     return (
       <EmptyState
@@ -81,7 +98,7 @@ export default function OfferList({ refreshKey }: OfferListProps) {
   }
 
   return (
-    <Box>
+    <Box aria-busy={loading}>
       <List aria-label="Offer list">
         {offers.map((offer, index) => (
           <ListItem disablePadding key={offer.id}>

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -169,7 +169,12 @@ export default function ResumeManager() {
           </Typography>
         </Box>
       )}
-      <Stack spacing={2} sx={{ mt: 4 }}>
+      <Stack
+        spacing={2}
+        sx={{ mt: 4 }}
+        aria-busy={loadingResumes}
+        aria-label={loadingResumes ? "Loading resumes" : undefined}
+      >
         <TextField
           label="Filter by text"
           value={searchText}


### PR DESCRIPTION
## Summary
- Show skeleton placeholders while inbox threads load
- Indicate resume loading state with ARIA attributes
- Display skeletons and aria-busy state for offer list

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c6820f3e3c833082de8e5e7fd8ce4e