### PR TITLE
feat: add ErrorBoundary for talentforge pages

### DIFF
--- a/src/app/talentforge/layout.tsx
+++ b/src/app/talentforge/layout.tsx
@@ -5,6 +5,7 @@ import { CssBaseline, PaletteMode, ThemeProvider, useMediaQuery } from "@mui/mat
 import LayoutShell from "@/components/talentforge/LayoutShell";
 import getTalentforgeTheme from "@/themes/talentforgeTheme";
 import { TalentForgeDataProvider } from "@/contexts/TalentForgeDataContext";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 export default function TalentForgeLayout({
   children,
@@ -37,13 +38,15 @@ export default function TalentForgeLayout({
     <TalentForgeDataProvider>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <LayoutShell
-          navItems={navItems}
-          mode={mode}
-          toggleColorMode={toggleColorMode}
-        >
-          {children}
-        </LayoutShell>
+        <ErrorBoundary>
+          <LayoutShell
+            navItems={navItems}
+            mode={mode}
+            toggleColorMode={toggleColorMode}
+          >
+            {children}
+          </LayoutShell>
+        </ErrorBoundary>
       </ThemeProvider>
     </TalentForgeDataProvider>
   );

--- a/src/components/talentforge/ErrorBoundary.tsx
+++ b/src/components/talentforge/ErrorBoundary.tsx
@@ -28,12 +28,18 @@ class InnerErrorBoundary extends Component<BoundaryProps, BoundaryState> {
   render() {
     if (this.state.hasError) {
       return (
-        <Box role="alert" sx={{ p: 2 }}>
+        <Box role="alert" sx={{ p: 3, textAlign: 'center' }}>
           <Typography variant="h6" gutterBottom>
-            Something went wrong.
+            Oops! Something went wrong.
           </Typography>
-          <Button variant="contained" onClick={this.reset}>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            Please try again. If the problem persists, reload the page.
+          </Typography>
+          <Button variant="contained" onClick={this.reset} sx={{ mr: 1 }}>
             Try again
+          </Button>
+          <Button variant="outlined" onClick={() => window.location.reload()}>
+            Reload
           </Button>
         </Box>
       );


### PR DESCRIPTION
## Summary
- improve TalentForge error boundary with friendly messaging and reset/reload actions
- wrap all /talentforge routes with the new error boundary

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c6821874a483309e54e7b288841aff