### PR TITLE
docs: correct CircularTimer test path comment

### DIFF
--- a/src/components/showcase/CircularTimer/CircularTimer.test.tsx
+++ b/src/components/showcase/CircularTimer/CircularTimer.test.tsx
@@ -1,4 +1,4 @@
-// src/components/CircularTimer.test.tsx
+// src/components/showcase/CircularTimer/CircularTimer.test.tsx
 import React from "react";
 import { render, screen, act, cleanup } from "@testing-library/react";
 import CircularTimer from "../CircularTimer";


### PR DESCRIPTION
## Summary
- fix CircularTimer test comment to reflect actual path

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - registry access)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c683c160ac8330aa28319248fe452c