### PR TITLE
test: cover single page in pdf text cleaner

### DIFF
--- a/src/tests/pdfParser.test.ts
+++ b/src/tests/pdfParser.test.ts
@@ -19,5 +19,12 @@ describe("cleanPdfText", () => {
       "Summary\nExperienced developer with focus on web\nSkills React Node",
     );
   });
+
+  test("handles single-page input", () => {
+    const pages = [["Only line"]];
+
+    const result = cleanPdfText(pages);
+    expect(result).toBe("Only line");
+  });
 });
 


### PR DESCRIPTION
## Summary
- add unit test ensuring `cleanPdfText` handles a single-page array

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c683c8c5f8833087849881fa4d0371