### PR TITLE
fix: guard base path duplication in withBasePath

### DIFF
--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -22,6 +22,7 @@ export function withBasePath(path: string): string {
   }
 
   const base = BASE_PATH.endsWith("/") ? BASE_PATH.slice(0, -1) : BASE_PATH;
+  if (BASE_PATH && path.startsWith(BASE_PATH)) return path;
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   return `${base}${normalizedPath}`;
 }


### PR DESCRIPTION
## Summary
- avoid prefixing paths already containing the base path

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c683bbde748330bf9bd1c3c99016f2