### PR TITLE
fix: correct Thinking test path comment

### DIFF
--- a/src/components/showcase/Thinking/Thinking.test.tsx
+++ b/src/components/showcase/Thinking/Thinking.test.tsx
@@ -1,4 +1,4 @@
-// __tests__/Thinking.test.tsx
+// src/components/showcase/Thinking/Thinking.test.tsx
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { Thinking, ThinkingProps } from "@components/Thinking";


### PR DESCRIPTION
## Summary
- fix test file path comment in Thinking test

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden for @dnd-kit/core)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c683b29be48330b5262c140e6ef047