### PR TITLE
feat: manage resume tags with persistence

### DIFF
--- a/src/components/talentforge/ResumeVariants/Detail.tsx
+++ b/src/components/talentforge/ResumeVariants/Detail.tsx
@@ -13,6 +13,7 @@ import {
   Typography,
 } from "@mui/material";
 import type { ResumeEntry } from "@/utils/talentforge/dataStore";
+import { updateResume } from "@/utils/talentforge/dataStore";
 
 interface Props {
   resume: ResumeEntry;
@@ -26,8 +27,10 @@ export default function Detail({ resume, onClose, onSave }: Props) {
   const [newTag, setNewTag] = useState("");
 
   const updateTags = (updated: string[]) => {
+    const updatedResume = { ...resume, tags: updated };
     setTags(updated);
-    onSave({ ...resume, tags: updated });
+    updateResume(updatedResume);
+    onSave(updatedResume);
   };
 
   const handleDelete = (tag: string) => {


### PR DESCRIPTION
## Summary
- allow editing resume tags with chips and add-tag input
- persist tag changes through dataStore.updateResume

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c683e977188330ad89de770753dee9