### PR TITLE
feat: add bullet rewrite prompt tile

### DIFF
--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -35,6 +35,12 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Craft a short elevator pitch for a professional with experience in {{experience}} looking for {{goal}}.",
     inputs: ["experience", "goal"],
   },
+  bulletRewrite: {
+    ...BASE_TILES.bulletRewrite,
+    fullPrompt:
+      "Rewrite the following resume bullet into three STAR-formatted variants, each including clear metrics:\n\n{{bullet}}",
+    inputs: ["bullet"],
+  },
   resumeRewrite: {
     ...BASE_TILES.resumeSummary,
     id: "resumeRewrite",

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -14,6 +14,11 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Write a professional cover letter with exactly three paragraphs tailored to the job description.",
   },
+  bulletRewrite: {
+    displayText: "Bullet Rewrite",
+    fullText:
+      "Rewrite the following resume bullet into three STAR-formatted variants with clear metrics.",
+  },
   negotiateOffer: {
     displayText: "Negotiate Offer",
     fullText:
@@ -87,7 +92,13 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
 };
 
 export const PROMPT_GROUPS: Record<string, string[]> = {
-  Resumes: ["resumeSummary", "coverLetter", "portfolioReview", "projectSummary"],
+  Resumes: [
+    "resumeSummary",
+    "coverLetter",
+    "bulletRewrite",
+    "portfolioReview",
+    "projectSummary",
+  ],
   Offers: ["negotiateOffer", "salaryResearch"],
   "Recruiter Replies": ["interviewPreparation", "networkingOutreach"],
   "Career Growth": [


### PR DESCRIPTION
## Summary
- add bullet rewrite template and tile for STAR-formatted variants with metrics
- list bullet rewrite option in prompt selector groups

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c684ed94f88330a6359573bd6f258b