### PR TITLE
Add screen role analyzer

### DIFF
--- a/src/app/talentforge/screen-role/page.tsx
+++ b/src/app/talentforge/screen-role/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import ScreenRole from "@/components/talentforge/ScreenRole";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
+
+export default function ScreenRolePage() {
+  return (
+    <ErrorBoundary>
+      <ScreenRole />
+    </ErrorBoundary>
+  );
+}
+

--- a/src/components/talentforge/ScreenRole.tsx
+++ b/src/components/talentforge/ScreenRole.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import OpenAIKeyModal from "./OpenAiKeyModal";
+import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { PROMPT_TEMPLATES } from "@/consts/prompts";
+import EmptyState from "./EmptyState";
+
+interface Issue {
+  severity: "red" | "yellow";
+  message: string;
+}
+
+interface Analysis {
+  summary?: string;
+  issues: Issue[];
+}
+
+export default function ScreenRole() {
+  const [jobDescription, setJobDescription] = useState("");
+  const [analysis, setAnalysis] = useState<Analysis | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [openKeyModal, setOpenKeyModal] = useState(false);
+
+  const analyze = async () => {
+    if (!hasOpenAIKey()) {
+      setOpenKeyModal(true);
+      return;
+    }
+    if (!jobDescription.trim()) return;
+    const context = `Job Description:\n${jobDescription}`;
+    const prompt = PROMPT_TEMPLATES.screenRole?.fullText || "";
+    setLoading(true);
+    const response = await askOpenAI({
+      context,
+      user: prompt,
+      system:
+        "You are an assistant that screens job descriptions and notes potential issues. Respond in JSON with a 'summary' and an array 'issues' with objects containing 'severity' (\"red\" or \"yellow\") and 'message'.",
+      chatHistory: [],
+      returnFirstResponse: true,
+    });
+    const message = response?.message || "";
+    try {
+      const parsed = JSON.parse(message);
+      setAnalysis({
+        summary: parsed.summary,
+        issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+      });
+    } catch {
+      setAnalysis({ summary: message, issues: [] });
+    }
+    setLoading(false);
+  };
+
+  return (
+    <Box>
+      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+      <TextField
+        label="Paste job description"
+        multiline
+        minRows={6}
+        fullWidth
+        value={jobDescription}
+        onChange={(e) => setJobDescription(e.target.value)}
+      />
+      <Button
+        variant="contained"
+        sx={{ mt: 2 }}
+        onClick={analyze}
+        disabled={!jobDescription || loading}
+      >
+        Analyze
+      </Button>
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+          <CircularProgress />
+        </Box>
+      )}
+      {analysis ? (
+        <Box sx={{ mt: 2 }}>
+          {analysis.issues.map((issue, idx) => (
+            <Stack
+              key={idx}
+              direction="row"
+              spacing={1}
+              alignItems="flex-start"
+              sx={{ mb: 1 }}
+            >
+              <Typography>{issue.severity === "red" ? "🚩" : "⚠️"}</Typography>
+              <Typography variant="body2">{issue.message}</Typography>
+            </Stack>
+          ))}
+          {analysis.summary && (
+            <Typography variant="body2" sx={{ mt: 2 }}>
+              {analysis.summary}
+            </Typography>
+          )}
+        </Box>
+      ) : (
+        !loading && (
+          <EmptyState
+            message="No analysis yet"
+            helperText="Paste a job description and click Analyze."
+          />
+        )
+      )}
+    </Box>
+  );
+}
+

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -56,6 +56,12 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "From the following job description, list the key job requirements as bullet points:\n\n{{jobDescription}}",
     inputs: ["jobDescription"],
   },
+  screenRole: {
+    ...BASE_TILES.screenRole,
+    fullPrompt:
+      "Review the following job description, provide a brief summary, and list potential issues candidates should note. Return JSON with a 'summary' and an 'issues' array of objects with 'severity' ('red' or 'yellow') and 'message'.\n\n{{jobDescription}}",
+    inputs: ["jobDescription"],
+  },
   negotiateOffer: {
     ...BASE_TILES.negotiateOffer,
     fullPrompt:

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -49,6 +49,11 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Identify potential issues in this job description like unpaid overtime, vague responsibilities, or compliance red flags. Return JSON with a 'summary' and an 'issues' array of objects with 'severity' ('red' or 'yellow') and 'message'.",
   },
+  screenRole: {
+    displayText: "Screen Role",
+    fullText:
+      "Review the following job description, provide a brief summary, and list potential issues candidates should note. Return JSON with a 'summary' and an 'issues' array of objects with 'severity' ('red' or 'yellow') and 'message'.",
+  },
   jobRequirements: {
     displayText: "Job Requirements",
     fullText:


### PR DESCRIPTION
## Summary
- add `screenRole` prompt tile tied to job descriptions
- implement ScreenRole component to summarize and flag issues returned as JSON
- expose ScreenRole page under TalentForge

## Testing
- `npm test` (fails: jest: not found)
- `npm install` (fails: 403 Forbidden)
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')

------
https://chatgpt.com/codex/tasks/task_e_68c684f05bf4833084fb841c4788db44