### PR TITLE
feat: add offer comparison prompt tile

### DIFF
--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -17,10 +17,17 @@ import Markdown from "react-markdown";
 
 import OpenAIKeyModal from "../OpenAiKeyModal";
 import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
-import { getResumes, addResume, type ResumeEntry } from "@/utils/talentforge/dataStore";
+import {
+  getResumes,
+  addResume,
+  addOffer,
+  type ResumeEntry,
+  type Offer,
+} from "@/utils/talentforge/dataStore";
 import { tagResume } from "@/utils/talentforge/tagging";
 import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { v4 as uuid } from "uuid";
+import type { ApplicationRecord } from "@/types";
 
 export interface PromptTileProps {
   id: string;
@@ -78,6 +85,29 @@ export default function Tile({
           return;
         }
         context = `Job Description:\n${values["jobDescription"]}\n\nResume:\n${resume.content}`;
+      }
+
+      if (id === "compareOffers") {
+        const context = `Offer A:\n${values["offerA"] || ""}\n\nOffer B:\n${values["offerB"] || ""}`;
+        const res = await askOpenAI({
+          context,
+          user: prompt,
+          system: "You compare job offers and highlight key differences.",
+          returnFirstResponse: true,
+          chatHistory: [],
+        });
+        const message = res?.message || "";
+        setResponse(message);
+        const offer: Offer = {
+          id: uuid(),
+          application: {} as ApplicationRecord,
+          compensation: [],
+          summary: message,
+        };
+        addOffer(offer);
+        onResponse?.(message);
+        onInsert?.(message);
+        return;
       }
 
       if (id === "negotiateOffer") {

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -56,6 +56,13 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "From the following job description, list the key job requirements as bullet points:\n\n{{jobDescription}}",
     inputs: ["jobDescription"],
   },
+  compareOffers: {
+    id: "compareOffers",
+    display: "Compare Offers",
+    fullPrompt:
+      "Compare the following two job offers in a markdown table highlighting differences in compensation, benefits, and other terms. Then provide a brief summary of which offer is more advantageous.\n\nOffer A:\n{{offerA}}\n\nOffer B:\n{{offerB}}",
+    inputs: ["offerA", "offerB"],
+  },
   negotiateOffer: {
     ...BASE_TILES.negotiateOffer,
     fullPrompt:


### PR DESCRIPTION
## Summary
- add "Compare Offers" prompt tile with inputs for two offers and markdown comparison summary
- save comparison results as offers for later review

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c684ea88c8833099d52d39338d1e19