### PR TITLE
feat: add recruiter nudge prompt

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -311,7 +311,17 @@ export default function Inbox() {
           <Stack spacing={2}>
             <PromptSelector value={promptKey} onChange={setPromptKey} />
             {promptKey && (
-              <Tile {...PROMPT_TILES[promptKey]} onInsert={handleInsertAIDraft} />
+              <Tile
+                {...PROMPT_TILES[promptKey]}
+                onInsert={handleInsertAIDraft}
+                initialValues=
+                  {promptKey === "recruiterNudge" && aiThread
+                    ? {
+                        messageContext:
+                          threads.find((m) => m.id === aiThread)?.body || "",
+                      }
+                    : undefined}
+              />
             )}
           </Stack>
         </DialogContent>

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   Button,
@@ -29,6 +29,7 @@ export interface PromptTileProps {
   inputs: string[];
   onInsert?: (text: string) => void;
   onResponse?: (response: string) => void;
+  initialValues?: Record<string, string>;
 }
 
 export default function Tile({
@@ -38,17 +39,31 @@ export default function Tile({
   inputs,
   onInsert,
   onResponse,
+  initialValues = {},
 }: PromptTileProps) {
-  const [values, setValues] = useState<Record<string, string>>({});
+  const [values, setValues] = useState<Record<string, string>>(initialValues);
   const [response, setResponse] = useState("");
   const [loading, setLoading] = useState(false);
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [drafts, setDrafts] = useState<
-    | { email: string; linkedin: string; indeed: string }
+  const [offerDrafts, setOfferDrafts] = useState<
+    { email: string; linkedin: string; indeed: string } | null
+  >(null);
+  const [nudgeDrafts, setNudgeDrafts] = useState<
+    | {
+        followUp: { email: string; linkedin: string; indeed: string };
+        decline: { email: string; linkedin: string; indeed: string };
+      }
     | null
   >(null);
   const [activeTab, setActiveTab] = useState(0);
+  const [nudgeMode, setNudgeMode] = useState<"followUp" | "decline">(
+    "followUp",
+  );
+
+  useEffect(() => {
+    setValues(initialValues);
+  }, [initialValues]);
 
   const handleChange = (key: string, value: string) => {
     setValues((prev) => ({ ...prev, [key]: value }));
@@ -65,6 +80,9 @@ export default function Tile({
     }
     setLoading(true);
     try {
+      setResponse("");
+      setOfferDrafts(null);
+      setNudgeDrafts(null);
       let prompt = fullPrompt;
       for (const key of inputs) {
         prompt = prompt.replaceAll(`{{${key}}}`, values[key] || "");
@@ -81,7 +99,8 @@ export default function Tile({
       }
 
       if (id === "negotiateOffer") {
-        setDrafts(null);
+        setOfferDrafts(null);
+        setNudgeDrafts(null);
         setActiveTab(0);
         const context = `Offer Letter:\n${values["offerLetter"] || ""}\n\nCurrent Compensation:\n${values["currentComp"] || ""}`;
         const res = await askOpenAI({
@@ -99,13 +118,52 @@ export default function Tile({
             linkedin?: string;
             indeed?: string;
           };
-          setDrafts({
+          setOfferDrafts({
             email: parsed.email || "",
             linkedin: parsed.linkedin || "",
             indeed: parsed.indeed || "",
           });
         } catch {
-          setDrafts({ email: message, linkedin: "", indeed: "" });
+          setOfferDrafts({ email: message, linkedin: "", indeed: "" });
+        }
+        onResponse?.(message);
+        onInsert?.(message);
+        return;
+      }
+
+      if (id === "recruiterNudge") {
+        setOfferDrafts(null);
+        setNudgeDrafts(null);
+        setActiveTab(0);
+        setNudgeMode("followUp");
+        const res = await askOpenAI({
+          context: "",
+          user: prompt,
+          system:
+            "You craft professional recruiter follow-up and decline messages.",
+          returnFirstResponse: true,
+          chatHistory: [],
+        });
+        const message = res?.message || "";
+        try {
+          const parsed = JSON.parse(message) as {
+            followUp?: { email?: string; linkedin?: string; indeed?: string };
+            decline?: { email?: string; linkedin?: string; indeed?: string };
+          };
+          setNudgeDrafts({
+            followUp: {
+              email: parsed.followUp?.email || "",
+              linkedin: parsed.followUp?.linkedin || "",
+              indeed: parsed.followUp?.indeed || "",
+            },
+            decline: {
+              email: parsed.decline?.email || "",
+              linkedin: parsed.decline?.linkedin || "",
+              indeed: parsed.decline?.indeed || "",
+            },
+          });
+        } catch {
+          setResponse(message);
         }
         onResponse?.(message);
         onInsert?.(message);
@@ -197,9 +255,9 @@ export default function Tile({
           ),
         )}
         <Button variant="contained" onClick={handleRun} disabled={loading}>
-        {loading ? "Running..." : "Run"}
+          {loading ? "Running..." : "Run"}
         </Button>
-        {id === "negotiateOffer" && drafts && (
+        {id === "negotiateOffer" && offerDrafts && (
           <Box>
             <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)}>
               <Tab label="Email" />
@@ -215,10 +273,10 @@ export default function Tile({
                       onClick={() =>
                         navigator.clipboard.writeText(
                           activeTab === 0
-                            ? drafts.email
+                            ? offerDrafts.email
                             : activeTab === 1
-                              ? drafts.linkedin
-                              : drafts.indeed,
+                              ? offerDrafts.linkedin
+                              : offerDrafts.indeed,
                         )
                       }
                       size="small"
@@ -228,13 +286,63 @@ export default function Tile({
                   </Tooltip>
                 )}
               </Box>
-              {activeTab === 0 && <Markdown>{drafts.email}</Markdown>}
-              {activeTab === 1 && <Markdown>{drafts.linkedin}</Markdown>}
-              {activeTab === 2 && <Markdown>{drafts.indeed}</Markdown>}
+              {activeTab === 0 && <Markdown>{offerDrafts.email}</Markdown>}
+              {activeTab === 1 && <Markdown>{offerDrafts.linkedin}</Markdown>}
+              {activeTab === 2 && <Markdown>{offerDrafts.indeed}</Markdown>}
             </Box>
           </Box>
         )}
-        {id !== "negotiateOffer" && response && (
+        {id === "recruiterNudge" && nudgeDrafts && (
+          <Box>
+            <Tabs
+              value={nudgeMode === "followUp" ? 0 : 1}
+              onChange={(_, v) =>
+                setNudgeMode(v === 0 ? "followUp" : "decline")
+              }
+            >
+              <Tab label="Follow Up" />
+              <Tab label="Decline" />
+            </Tabs>
+            <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)}>
+              <Tab label="Email" />
+              <Tab label="LinkedIn" />
+              <Tab label="Indeed" />
+            </Tabs>
+            <Box sx={{ mt: 2 }}>
+              <Box display="flex" justifyContent="flex-end">
+                {navigator.clipboard && (
+                  <Tooltip title="copy to clipboard" arrow>
+                    <IconButton
+                      aria-label="copy response to clipboard"
+                      onClick={() =>
+                        navigator.clipboard.writeText(
+                          activeTab === 0
+                            ? nudgeDrafts[nudgeMode].email
+                            : activeTab === 1
+                              ? nudgeDrafts[nudgeMode].linkedin
+                              : nudgeDrafts[nudgeMode].indeed,
+                        )
+                      }
+                      size="small"
+                    >
+                      <ContentCopy fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </Box>
+              {activeTab === 0 && (
+                <Markdown>{nudgeDrafts[nudgeMode].email}</Markdown>
+              )}
+              {activeTab === 1 && (
+                <Markdown>{nudgeDrafts[nudgeMode].linkedin}</Markdown>
+              )}
+              {activeTab === 2 && (
+                <Markdown>{nudgeDrafts[nudgeMode].indeed}</Markdown>
+              )}
+            </Box>
+          </Box>
+        )}
+        {id !== "negotiateOffer" && id !== "recruiterNudge" && response && (
           <>
             <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
               {response}

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -62,5 +62,11 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Compare the offer letter to the current compensation and summarize key differences. Then draft professional replies for email, LinkedIn, and Indeed. Respond in JSON with keys email, linkedin, indeed.",
     inputs: ["offerLetter", "currentComp"],
   },
+  recruiterNudge: {
+    ...BASE_TILES.recruiterNudge,
+    fullPrompt:
+      "Given the message context, draft a polite follow-up and a polite decline for a recruiter. Provide versions for email, LinkedIn, and Indeed in JSON with keys followUp and decline, each containing email, linkedin, and indeed.\n\nMessage context:\n{{messageContext}}",
+    inputs: ["messageContext"],
+  },
 };
 

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -59,6 +59,11 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Draft a message to connect with professionals in this industry or company for networking purposes.",
   },
+  recruiterNudge: {
+    displayText: "Recruiter Nudge",
+    fullText:
+      "Generate polite follow-up and decline messages for a recruiter. Provide versions for email, LinkedIn, and Indeed.",
+  },
   portfolioReview: {
     displayText: "Portfolio Review",
     fullText:
@@ -89,7 +94,11 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
 export const PROMPT_GROUPS: Record<string, string[]> = {
   Resumes: ["resumeSummary", "coverLetter", "portfolioReview", "projectSummary"],
   Offers: ["negotiateOffer", "salaryResearch"],
-  "Recruiter Replies": ["interviewPreparation", "networkingOutreach"],
+  "Recruiter Replies": [
+    "interviewPreparation",
+    "networkingOutreach",
+    "recruiterNudge",
+  ],
   "Career Growth": [
     "skillGapAnalysis",
     "jobDescriptionRewrite",


### PR DESCRIPTION
## Summary
- add recruiter nudge prompt tile for drafting follow-up or decline replies
- support recruiter nudge drafts in tile component and prefill message context in inbox dialog

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c684f478848330b441ca301224b018