### PR TITLE
feat: add chat workspace with output actions

### DIFF
--- a/src/components/talentforge/ChatWorkspace.tsx
+++ b/src/components/talentforge/ChatWorkspace.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, Stack, Typography } from "@mui/material";
+
+import PromptTileGrid from "./promptTiles/PromptTileGrid";
+
+interface ChatWorkspaceProps {
+  onInsertIntoInbox?: (text: string) => void;
+  onSaveResumeVariant?: (text: string) => void;
+}
+
+export default function ChatWorkspace({
+  onInsertIntoInbox,
+  onSaveResumeVariant,
+}: ChatWorkspaceProps) {
+  const [output, setOutput] = useState("");
+
+  const handleCopy = () => {
+    if (navigator.clipboard && output) {
+      navigator.clipboard.writeText(output);
+    }
+  };
+
+  const handleInsert = () => {
+    onInsertIntoInbox?.(output);
+  };
+
+  const handleSave = () => {
+    onSaveResumeVariant?.(output);
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "column", md: "row" },
+        gap: 2,
+      }}
+    >
+      <Box sx={{ flex: 1 }}>
+        <PromptTileGrid onResponse={setOutput} />
+      </Box>
+      <Box
+        sx={{
+          flexBasis: { md: "30%" },
+          border: 1,
+          borderColor: "divider",
+          p: 2,
+          borderRadius: 1,
+          minHeight: 200,
+        }}
+      >
+        <Typography variant="h6" gutterBottom>
+          Output
+        </Typography>
+        <Box sx={{ whiteSpace: "pre-wrap", mb: 2 }}>{output}</Box>
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" onClick={handleCopy} disabled={!output}>
+            Copy
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={handleInsert}
+            disabled={!onInsertIntoInbox || !output}
+          >
+            Insert into Inbox
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={!onSaveResumeVariant || !output}
+          >
+            Save Resume Variant
+          </Button>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+

--- a/src/components/talentforge/promptTiles/PromptTileGrid.tsx
+++ b/src/components/talentforge/promptTiles/PromptTileGrid.tsx
@@ -20,7 +20,13 @@ import { PROMPT_TILES, type PromptTileDefinition } from "@/consts/promptTiles";
 
 const registry: Record<string, PromptTileDefinition> = PROMPT_TILES;
 
-export default function PromptTileGrid() {
+interface PromptTileGridProps {
+  onResponse?: (response: string) => void;
+}
+
+export default function PromptTileGrid({
+  onResponse,
+}: PromptTileGridProps) {
   const [values, setValues] = useState<
     Record<string, Record<string, string>>
   >({});
@@ -71,7 +77,9 @@ export default function PromptTileGrid() {
         returnFirstResponse: true,
         chatHistory: [],
       });
-      setResponses((prev) => ({ ...prev, [id]: res?.message || "" }));
+      const message = res?.message || "";
+      setResponses((prev) => ({ ...prev, [id]: message }));
+      onResponse?.(message);
     } finally {
       setLoading((prev) => ({ ...prev, [id]: false }));
     }


### PR DESCRIPTION
## Summary
- add ChatWorkspace component combining prompt tile grid and output panel
- allow PromptTileGrid to report responses to parent component

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c6865f8b3c833089814efeea419cd0