### PR TITLE
Auto-link threads to recruiters on reply

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -102,7 +102,16 @@ export default function Inbox() {
       sentAt: new Date().toISOString(),
       connector: message.connector,
     };
-    const updated = data.addThreadReply(message.id, reply);
+    let updated = data.addThreadReply(message.id, reply);
+
+    const matchedRecruiter = recruiters.find(
+      (r) => r.connector.toLowerCase() === message.connector.toLowerCase(),
+    );
+    if (matchedRecruiter) {
+      updated = data.linkThreadToRecruiter(message.id, matchedRecruiter.id);
+      setRecruiters(data.getRecruiters());
+    }
+
     setThreads(updated);
     setDrafts((d) => ({ ...d, [message.id]: "" }));
   };


### PR DESCRIPTION
## Summary
- automatically link message threads to recruiters when sending a reply if the message connector matches an existing recruiter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm ci` *(fails: 403 Forbidden for package '@dnd-kit/core')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c687524eb083309b4acd023cc242f7