### PR TITLE
Handle OpenAI response errors in TalentForge utils

### DIFF
--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -63,6 +63,11 @@ const requestCompletion = async (systemMessage: string) => {
     }),
   });
 
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Request failed with status ${response.status}: ${errorText}`);
+  }
+
   const data = await response.json();
   const content = data?.choices?.[0]?.message?.content;
 


### PR DESCRIPTION
## Summary
- Throw descriptive error when OpenAI chat completion API responds with non-OK status

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden retrieving package)*

------
https://chatgpt.com/codex/tasks/task_e_68c6878668fc8330a4029c715f128e3e