### PR TITLE
fix: ensure interval cleanup in useDimensions

### DIFF
--- a/src/hooks/useDimensions.ts
+++ b/src/hooks/useDimensions.ts
@@ -68,6 +68,8 @@ export function useDimensions(
       setDimensions(getDimensions());
     }, 100);
 
+    let interval: ReturnType<typeof setInterval> | null = null;
+
     // set the initial dimensions if ref is defined
     if (ref && ref.current) {
       const dimensions = getDimensions();
@@ -77,9 +79,16 @@ export function useDimensions(
         // if the element is not visible, or has not rendered content yet,
         // we need to wait for the element to become visible or render content
         // before we can get the dimensions
-        const interval = setInterval(() => {
-          if (ref.current && ref.current.offsetHeight > 0) {
-            clearInterval(interval);
+        interval = setInterval(() => {
+          if (
+            ref.current &&
+            ref.current.offsetHeight > 0 &&
+            ref.current.offsetWidth > 0
+          ) {
+            if (interval) {
+              clearInterval(interval);
+              interval = null;
+            }
             handleResize();
           }
         }, 15);
@@ -96,6 +105,9 @@ export function useDimensions(
     return () => {
       // remove the event listener during cleanup
       window.removeEventListener("resize", handleResize);
+      if (interval) {
+        clearInterval(interval);
+      }
     };
   }, [ref, theme?.breakpoints?.values]);
 


### PR DESCRIPTION
## Summary
- manage interval outside conditional in `useDimensions` and clear it when dimensions resolve
- clear the interval on cleanup to avoid leaks when unmounted

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68c68c06b8d08330a9ec22399d60a2e0