### PR TITLE
feat: validate OpenAI key during onboarding

### DIFF
--- a/src/components/talentforge/onboarding/KeyEntryStep.tsx
+++ b/src/components/talentforge/onboarding/KeyEntryStep.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import { Button, Stack, TextField } from "@mui/material";
-import { setOpenAIKey } from "@/utils/talentforge/utils";
+import { useEffect, useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  InputAdornment,
+  Stack,
+  TextField,
+} from "@mui/material";
+import CheckCircleOutline from "@mui/icons-material/CheckCircleOutline";
+import ErrorOutline from "@mui/icons-material/ErrorOutline";
+import { askOpenAI, setOpenAIKey } from "@/utils/talentforge/utils";
 
 interface StepProps {
   onNext: () => void;
@@ -11,46 +19,85 @@ interface StepProps {
 
 export default function KeyEntryStep({ onNext }: StepProps) {
   const [key, setKey] = useState("");
+  const [status, setStatus] = useState<
+    "idle" | "checking" | "success" | "error"
+  >("idle");
 
-  const handleContinue = async () => {
-    const trimmed = key.trim();
-    if (!trimmed) return;
+  const validateKey = async (keyToCheck: string) => {
+    setStatus("checking");
+    setOpenAIKey(keyToCheck);
     try {
-      const res = await fetch("/api/test-openai-key", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key: trimmed }),
+      await askOpenAI({
+        context: "",
+        user: "ping",
+        system: "{{context}}",
+        logMessagesToChatHistory: false,
+        returnFirstResponse: true,
+        chatHistory: [],
       });
-      if (res.ok) {
-        setOpenAIKey(trimmed);
-        alert("Key is valid!");
-        onNext();
-      } else {
-        alert("Key test failed.");
+      if (keyToCheck === key.trim()) {
+        setStatus("success");
       }
     } catch {
-      alert("Key test failed.");
+      if (keyToCheck === key.trim()) {
+        setStatus("error");
+        setOpenAIKey("");
+      }
     }
   };
 
+  useEffect(() => {
+    const trimmed = key.trim();
+    if (!trimmed) {
+      setStatus("idle");
+      setOpenAIKey("");
+      return;
+    }
+    const handle = setTimeout(() => validateKey(trimmed), 500);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const adornment =
+    status === "checking"
+      ? (
+          <CircularProgress size={20} />
+        )
+      : status === "success"
+      ? (
+          <CheckCircleOutline color="success" />
+        )
+      : status === "error"
+      ? (
+          <ErrorOutline color="error" />
+        )
+      : null;
+
   return (
     <Stack spacing={2} aria-label="API key entry">
-        <TextField
-          label="OpenAI API Key"
-          aria-label="OpenAI API Key"
-          value={key}
-          onChange={(e) => setKey(e.target.value)}
-          autoFocus
-        />
-        <Button
-          variant="contained"
-          onClick={handleContinue}
-          disabled={!key}
-          aria-label="Continue"
-        >
-          Continue
-        </Button>
-      </Stack>
+      <TextField
+        label="OpenAI API Key"
+        aria-label="OpenAI API Key"
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        autoFocus
+        error={status === "error"}
+        helperText={status === "error" ? "OpenAI Key is Invalid" : ""}
+        InputProps={{
+          endAdornment: adornment ? (
+            <InputAdornment position="end">{adornment}</InputAdornment>
+          ) : undefined,
+        }}
+      />
+      <Button
+        variant="contained"
+        onClick={onNext}
+        disabled={status !== "success"}
+        aria-label="Continue"
+      >
+        Continue
+      </Button>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
## Summary
- validate OpenAI key by pinging askOpenAI
- show success or error icon and helper text based on key validity
- enable Continue only when key test passes

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c68b36d8248330a24931af39ce5ebc