### PR TITLE
docs: clarify rewindAndPlayAudio parameters

### DIFF
--- a/src/utils/lightgun-web/audio.ts
+++ b/src/utils/lightgun-web/audio.ts
@@ -14,7 +14,10 @@ export const pauseAudio = (audioRef?: RefObject<HTMLAudioElement | null>) => {
  * Reset an audio element to the beginning and play it.
  *
  * @param audioRef React ref to the audio element.
- * @param options Optional loop/volume settings applied before playing.
+ * @param srcOrOptions Either the path to a new audio file that replaces the current
+ * audio source or an object with playback options (`loop` to repeat, `volume` 0-1).
+ * @param maybeOptions Playback options (`loop`, `volume`) applied when a source path is
+ * provided as the second argument.
  */
 export const rewindAndPlayAudio = (
   audioRef?: RefObject<HTMLAudioElement | null>,


### PR DESCRIPTION
## Summary
- clarify that rewindAndPlayAudio accepts a new file path or playback options
- document option usage for loop and volume

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c68c0bd3a88330a520a989834ae115