### PR TITLE
feat: add job description and application analysis

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/utils/talentforge/dataStore";
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
 import EmptyState from "./EmptyState";
+import PromptTileGrid from "./promptTiles/PromptTileGrid";
 
 const STATUSES: ApplicationStatus[] = [
   "applied",
@@ -70,6 +71,20 @@ function Card({ app }: { app: JobApplication }) {
     cursor: "grab",
   } as const;
 
+  const [tile, setTile] = useState<string | null>(null);
+  const [initialValues, setInitialValues] = useState<
+    Record<string, Record<string, string>>
+  >({});
+
+  const openTile = (id: string) => {
+    const init: Record<string, Record<string, string>> = {};
+    if (app.role.description) {
+      init[id] = { jobDescription: app.role.description };
+    }
+    setInitialValues(init);
+    setTile(id);
+  };
+
   return (
     <Box
       ref={setNodeRef}
@@ -88,6 +103,33 @@ function Card({ app }: { app: JobApplication }) {
       <Typography variant="body2" color="text.secondary">
         {app.role.company} – {app.role.location}
       </Typography>
+      {app.role.description && (
+        <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+          <Button size="small" onClick={() => openTile("screenRole")}>
+            Analyze Risks
+          </Button>
+          <Button size="small" onClick={() => openTile("resumeRewrite")}>
+            Compare to Resume
+          </Button>
+        </Stack>
+      )}
+      <Dialog open={!!tile} onClose={() => setTile(null)} fullWidth maxWidth="sm">
+        <DialogTitle>
+          {tile === "screenRole" ? "Analyze Risks" : "Compare to Resume"}
+        </DialogTitle>
+        <DialogContent>
+          {tile && (
+            <PromptTileGrid
+              key={tile}
+              tileIds={[tile]}
+              initialValues={initialValues}
+            />
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setTile(null)}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }
@@ -98,6 +140,7 @@ export default function ApplicationBoard() {
   const [title, setTitle] = useState("");
   const [company, setCompany] = useState("");
   const [location, setLocation] = useState("");
+  const [description, setDescription] = useState("");
 
   useEffect(() => {
     const existing = getJobApplications();
@@ -134,7 +177,7 @@ export default function ApplicationBoard() {
     const newApp: JobApplication = {
       id: uuid(),
       applicant: { id: "", name: "", email: "" },
-      role: { id: uuid(), title, company, location },
+      role: { id: uuid(), title, company, location, description },
       status: "applied",
       history: [{ status: "applied", changedAt: new Date().toISOString() }],
     };
@@ -144,6 +187,7 @@ export default function ApplicationBoard() {
     setTitle("");
     setCompany("");
     setLocation("");
+    setDescription("");
   };
 
   return (
@@ -200,6 +244,14 @@ export default function ApplicationBoard() {
               value={location}
               onChange={(e) => setLocation(e.target.value)}
               fullWidth
+            />
+            <TextField
+              label="Job Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              fullWidth
+              multiline
+              minRows={4}
             />
           </Stack>
         </DialogContent>

--- a/src/components/talentforge/promptTiles/PromptTileGrid.tsx
+++ b/src/components/talentforge/promptTiles/PromptTileGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Box,
   Button,
@@ -8,6 +8,7 @@ import {
   Stack,
   TextField,
   Typography,
+  MenuItem,
 } from "@mui/material";
 
 import OpenAiKeyModal from "../OpenAiKeyModal";
@@ -22,14 +23,21 @@ const registry: Record<string, PromptTileDefinition> = PROMPT_TILES;
 
 interface PromptTileGridProps {
   onResponse?: (response: string) => void;
+  tileIds?: string[];
+  initialValues?: Record<string, Record<string, string>>;
 }
 
 export default function PromptTileGrid({
   onResponse,
+  tileIds,
+  initialValues = {},
 }: PromptTileGridProps) {
   const [values, setValues] = useState<
     Record<string, Record<string, string>>
-  >({});
+  >(initialValues);
+  useEffect(() => {
+    setValues(initialValues);
+  }, [initialValues]);
   const [responses, setResponses] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState<Record<string, boolean>>({});
   const [openKeyModal, setOpenKeyModal] = useState(false);
@@ -85,6 +93,10 @@ export default function PromptTileGrid({
     }
   };
 
+  const tiles = tileIds
+    ? tileIds.map((id) => registry[id]).filter(Boolean)
+    : Object.values(registry);
+
   return (
     <>
       <OpenAiKeyModal
@@ -92,21 +104,40 @@ export default function PromptTileGrid({
         onClose={() => setOpenKeyModal(false)}
       />
       <Grid container spacing={2}>
-        {Object.values(registry).map((tile) => (
+        {tiles.map((tile) => (
           <Grid item xs={12} sm={6} md={4} key={tile.id}>
             <Box>
               <Stack spacing={1}>
                 <Typography variant="subtitle1">{tile.display}</Typography>
                 {tile.inputs.map((name) => (
-                  <TextField
-                    key={name}
-                    label={name}
-                    size="small"
-                    value={values[tile.id]?.[name] || ""}
-                    onChange={(e) =>
-                      handleChange(tile.id, name, e.target.value)
-                    }
-                  />
+                  name === "resumeVariantId" ? (
+                    <TextField
+                      key={name}
+                      label="Resume"
+                      select
+                      size="small"
+                      value={values[tile.id]?.[name] || ""}
+                      onChange={(e) =>
+                        handleChange(tile.id, name, e.target.value)
+                      }
+                    >
+                      {getResumes().map((r) => (
+                        <MenuItem key={r.id} value={r.id}>
+                          {r.label}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  ) : (
+                    <TextField
+                      key={name}
+                      label={name}
+                      size="small"
+                      value={values[tile.id]?.[name] || ""}
+                      onChange={(e) =>
+                        handleChange(tile.id, name, e.target.value)
+                      }
+                    />
+                  )
                 ))}
                 <Button
                   variant="contained"

--- a/src/types/talentforge/job.ts
+++ b/src/types/talentforge/job.ts
@@ -5,6 +5,8 @@ export interface JobListing {
   company: string;
   /** Location where the job is based */
   location: string;
+  /** Full job description text */
+  description?: string;
   /** Direct link to the job posting */
   url: string;
   /** Source of the job listing, e.g. "indeed" or "linkedin" */

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -37,6 +37,8 @@ export interface RolePosting {
   company: string;
   /** Location of the job, if specified. */
   location?: string;
+  /** Full job description text. */
+  description?: string;
   /** Direct link to the job posting. */
   url?: string;
   /** Source of the listing such as "indeed" or "linkedin". */


### PR DESCRIPTION
## Summary
- allow entering job descriptions for new applications
- enable Analyze Risks and Compare to Resume actions on application cards
- extend prompt tile grid with filtering, initial values, and resume selection

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: cannot find @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e326f37883309814edb9b580f523