### PR TITLE
Clarify clean start behavior for blackjack

### DIFF
--- a/go/blackjack/flags/flags.go
+++ b/go/blackjack/flags/flags.go
@@ -12,7 +12,7 @@ var HouseStart = flag.Int("house", 0, "override the house's initial starting win
 var PlayerStartStack = flag.Int("stack", 0, "set the starting stack for ALL players")
 var TrifectaStax = flag.Bool("trifectaStax", true, "turn on/off Trifecta Stax payouts")
 var Autoplay = flag.Bool("autoplay", false, "turn on/off (will play 500 rounds, will not play trifecta)")
-var Clean = flag.Bool("clean", true, "whether or not to read initial state from State.out file")
+var Clean = flag.Bool("clean", true, "when true, start without reading state.out")
 var ColorTerminal = flag.Bool("colorTerminal", true, "whether or not to try to use color codes for coloring the terminal")
 
 // Config holds runtime configuration for the application. Fields mirror the

--- a/go/blackjack/game/game.go
+++ b/go/blackjack/game/game.go
@@ -65,7 +65,8 @@ var GameMode Game = Spanish21
 
 func LoadBlackjackStateYaml(clean bool) error {
 	if clean {
-		return errors.New("clean state is required")
+		// skip loading state.out when starting clean
+		return errors.New("clean start requested")
 	}
 
 	if runtime.GOOS == "js" {


### PR DESCRIPTION
## Summary
- Clarify `clean` flag description to state that it skips reading `state.out`
- Document clean start behavior in `LoadBlackjackStateYaml`

## Testing
- `go fmt go/blackjack/flags/flags.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c6e36498388330b2932904ffaa12ed