### PR TITLE
Ensure mock resumes use separate parsed data objects

### DIFF
--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -22,7 +22,7 @@ export const mockResumes: ResumeEntry[] = [
     label: "Software Resume",
     url: "https://example.com/jane-doe-software.pdf",
     content: "",
-    parsed: emptyParsed,
+    parsed: { ...emptyParsed },
     tags: ["software", "typescript"],
   },
   {
@@ -31,7 +31,7 @@ export const mockResumes: ResumeEntry[] = [
     label: "Product Resume",
     url: "https://example.com/jane-doe-product.pdf",
     content: "",
-    parsed: emptyParsed,
+    parsed: { ...emptyParsed },
     tags: ["product", "management"],
   },
 ];


### PR DESCRIPTION
## Summary
- Clone `emptyParsed` when populating `parsed` in `mockResumes` to avoid shared references

## Testing
- `node -e "const ts=require('typescript');const fs=require('fs');const code=fs.readFileSync('src/utils/mockData.ts','utf8');const transpiled=ts.transpileModule(code,{compilerOptions:{module:ts.ModuleKind.CommonJS}}).outputText;const Module=require('module');const m={exports:{}};const func=new Function('exports','require','module','__filename','__dirname',transpiled);func(m.exports,Module.createRequire(process.cwd()+'/'),m,'mockData.js',process.cwd());const {mockResumes}=m.exports;mockResumes[0].parsed.contact='Hello';console.log('resume1', mockResumes[0].parsed.contact);console.log('resume2', mockResumes[1].parsed.contact);console.log('same', mockResumes[0].parsed===mockResumes[1].parsed);"`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c6e35a6b2c8330bf3603b7a1a813ba