### PR TITLE
feat: add user-editable resume titles

### DIFF
--- a/src/components/talentforge/CoverLetter.tsx
+++ b/src/components/talentforge/CoverLetter.tsx
@@ -71,7 +71,7 @@ export default function CoverLetter() {
         >
           {resumes.map((r) => (
             <MenuItem key={r.id} value={r.id}>
-              {r.id}
+              {r.title}
             </MenuItem>
           ))}
         </TextField>

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -55,6 +55,7 @@ export default function ResumeManager() {
       id: uuid(),
       userId: "",
       label: "",
+      title: "",
       url: "",
       content: sanitized,
       parsed,

--- a/src/components/talentforge/ResumePaste.tsx
+++ b/src/components/talentforge/ResumePaste.tsx
@@ -51,6 +51,7 @@ export default function ResumePaste() {
       id: uuid(),
       userId: "",
       label: "",
+      title: "",
       url: "",
       content: text,
       parsed,

--- a/src/components/talentforge/ResumeVariants/Detail.tsx
+++ b/src/components/talentforge/ResumeVariants/Detail.tsx
@@ -55,7 +55,7 @@ export default function Detail({ resume, onClose, onSave }: Props) {
 
   return (
     <Dialog open onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>{resume.id}</DialogTitle>
+      <DialogTitle>{resume.title}</DialogTitle>
       <DialogContent dividers>
         <Stack spacing={2}>
           <Stack direction="row" spacing={1} flexWrap="wrap" alignItems="center">

--- a/src/components/talentforge/ResumeVariants/List.tsx
+++ b/src/components/talentforge/ResumeVariants/List.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import {
   Box,
   Stack,
-  Typography,
   Chip,
   IconButton,
   Dialog,
@@ -12,6 +11,7 @@ import {
   DialogContent,
   DialogActions,
   Button,
+  TextField,
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
@@ -85,6 +85,7 @@ export default function List({ resumes, setResumes }: Props) {
         id: uuid(),
         userId: "",
         label: "",
+        title: "",
         url: "",
         content,
         tags: tags || [],
@@ -122,9 +123,20 @@ export default function List({ resumes, setResumes }: Props) {
       {resumes.map((r) => (
         <Box key={r.id} sx={{ mb: 2 }}>
           <Stack direction="row" spacing={1} alignItems="center">
-            <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
-              {r.id}
-            </Typography>
+            <TextField
+              size="small"
+              value={r.title}
+              onChange={(e) =>
+                setResumes(
+                  resumes.map((res) =>
+                    res.id === r.id ? { ...res, title: e.target.value } : res,
+                  ),
+                )
+              }
+              onBlur={(e) => handleSave({ ...r, title: e.target.value })}
+              sx={{ flexGrow: 1 }}
+              inputProps={{ "aria-label": "Resume title" }}
+            />
             <IconButton size="small" onClick={() => setSelected(r)} aria-label="edit">
               <EditIcon fontSize="small" />
             </IconButton>
@@ -184,7 +196,7 @@ export default function List({ resumes, setResumes }: Props) {
       )}
       {diffTarget && (
         <Dialog open onClose={() => setDiffTarget(null)} fullWidth maxWidth="md">
-          <DialogTitle>Diff {diffTarget.id}</DialogTitle>
+          <DialogTitle>Diff {diffTarget.title}</DialogTitle>
           <DialogContent dividers>
             <Diff
               original={diffTarget.content}
@@ -200,7 +212,7 @@ export default function List({ resumes, setResumes }: Props) {
         <Dialog open onClose={() => setConfirmDelete(null)}>
           <DialogTitle>Delete Resume</DialogTitle>
           <DialogContent>
-            Are you sure you want to delete {confirmDelete.id}?
+            Are you sure you want to delete {confirmDelete.title}?
           </DialogContent>
           <DialogActions>
             <Button onClick={() => setConfirmDelete(null)}>Cancel</Button>

--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -33,6 +33,7 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
         id: uuid(),
         userId: "",
         label: "",
+        title: "",
         url: "",
         content: text,
         parsed,

--- a/src/components/talentforge/promptTiles/PromptTileGrid.tsx
+++ b/src/components/talentforge/promptTiles/PromptTileGrid.tsx
@@ -123,7 +123,7 @@ export default function PromptTileGrid({
                     >
                       {getResumes().map((r) => (
                         <MenuItem key={r.id} value={r.id}>
-                          {r.label}
+                          {r.title}
                         </MenuItem>
                       ))}
                     </TextField>

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -246,6 +246,7 @@ export default function Tile({
           id: uuid(),
           userId: "",
           label: "",
+          title: "",
           url: "",
           content: response,
           parsed,

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -22,6 +22,8 @@ export interface ResumeVariant {
   userId: string;
   /** Human readable label for the resume variant. */
   label: string;
+  /** User editable title for the resume variant. */
+  title: string;
   /** URL where the resume file is stored. */
   url: string;
   /** Additional notes about this resume variant. */

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -20,6 +20,7 @@ export const mockResumes: ResumeEntry[] = [
     id: "resume-1",
     userId: mockUserProfile.id,
     label: "Software Resume",
+    title: "Software Resume",
     url: "https://example.com/jane-doe-software.pdf",
     content: "",
     parsed: { ...emptyParsed },
@@ -29,6 +30,7 @@ export const mockResumes: ResumeEntry[] = [
     id: "resume-2",
     userId: mockUserProfile.id,
     label: "Product Resume",
+     title: "Product Resume",
     url: "https://example.com/jane-doe-product.pdf",
     content: "",
     parsed: { ...emptyParsed },
@@ -88,7 +90,9 @@ export const mockOffers: Offer[] = [
   },
 ];
 
-mockUserProfile.resumeVariants = mockResumes.map(({ content, parsed, tags, ...rv }) => rv);
+mockUserProfile.resumeVariants = mockResumes.map(
+  ({ content, parsed, tags, ...rv }) => rv,
+);
 mockUserProfile.applications = mockApplications;
 
 const DEMO_DATA_KEY = "tf_demo_data_inserted";

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -211,19 +211,51 @@ export function saveUserProfile(profile: UserProfile): void {
 }
 
 // Resumes
+function generateUniqueTitle(base: string, existing: ResumeEntry[]): string {
+  const titles = existing.map((r) => r.title.toLowerCase());
+  const candidate = base.trim() || "Resume";
+  let suffix = 1;
+  let title = candidate;
+  while (titles.includes(title.toLowerCase())) {
+    suffix += 1;
+    title = `${candidate} (${suffix})`;
+  }
+  return title;
+}
+
 export function getResumes(): ResumeEntry[] {
-  return load("resumes", []);
+  const loaded = load("resumes", []);
+  const existing: ResumeEntry[] = [];
+  let changed = false;
+  const updated = loaded.map((r) => {
+    const title = r.title
+      ? generateUniqueTitle(r.title, existing)
+      : generateUniqueTitle("Resume", existing);
+    if (title !== r.title) changed = true;
+    const updatedResume = { ...r, title };
+    existing.push(updatedResume);
+    return updatedResume;
+  });
+  if (changed) saveResumes(updated);
+  return updated;
 }
 export function saveResumes(resumes: ResumeEntry[]): void {
   save("resumes", resumes);
 }
 export function addResume(resume: ResumeEntry): ResumeEntry[] {
-  const updated = [...getResumes(), resume];
+  const current = getResumes();
+  const title = generateUniqueTitle(resume.title || "Resume", current);
+  const newResume = { ...resume, title };
+  const updated = [...current, newResume];
   saveResumes(updated);
   return updated;
 }
 export function updateResume(resume: ResumeEntry): ResumeEntry[] {
-  const updated = getResumes().map((r) => (r.id === resume.id ? resume : r));
+  const current = getResumes();
+  const others = current.filter((r) => r.id !== resume.id);
+  const title = generateUniqueTitle(resume.title || "Resume", others);
+  const updatedResume = { ...resume, title };
+  const updated = [...others, updatedResume];
   saveResumes(updated);
   return updated;
 }
@@ -233,8 +265,10 @@ export function deleteResume(id: string): ResumeEntry[] {
   return updated;
 }
 export function cloneResume(resume: ResumeEntry): ResumeEntry[] {
-  const clone = { ...resume, id: uuid() };
-  const updated = [...getResumes(), clone];
+  const current = getResumes();
+  const title = generateUniqueTitle(resume.title, current);
+  const clone = { ...resume, id: uuid(), title };
+  const updated = [...current, clone];
   saveResumes(updated);
   return updated;
 }

--- a/src/utils/talentforge/demoData.ts
+++ b/src/utils/talentforge/demoData.ts
@@ -22,6 +22,7 @@ export function getDemoData(): {
     id: "demo-resume-1",
     userId: user.id,
     label: "General Resume",
+    title: "General Resume",
     url: "https://example.com/resume.pdf",
     notes: "Demo resume for testing",
     content: "Jane Doe\nSoftware Engineer",


### PR DESCRIPTION
## Summary
- add title field to resume variants and ensure unique auto generation
- allow editing resume titles in list and use titles for selection

## Testing
- `npm test` (fails: jest-environment-jsdom missing, install 403)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6e5579eec833089cc4044494cfdf5