### PR TITLE
test: verify prompt template mappings

### DIFF
--- a/src/tests/talentforge/promptMapper.test.ts
+++ b/src/tests/talentforge/promptMapper.test.ts
@@ -7,6 +7,12 @@ describe("promptMapper", () => {
     expect(getPromptFullText(label)).toBe(PROMPT_TEMPLATES[label].fullText);
   });
 
+  test("maps all labels to their full text", () => {
+    Object.entries(PROMPT_TEMPLATES).forEach(([label, { fullText }]) => {
+      expect(getPromptFullText(label)).toBe(fullText);
+    });
+  });
+
   test("returns undefined for unknown label", () => {
     expect(getPromptFullText("unknown")).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- add comprehensive test ensuring each prompt template label maps to correct full text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e90c09c88330b08d0deb493b9521