### PR TITLE
Rename pdfToMarkdown to pdfToText in TalentForge PDF parser

### DIFF
--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/utils/talentforge/dataStore";
 
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
-import { pdfToMarkdown, parseResumeText } from "@/utils/talentforge/pdfParser";
+import { pdfToText, parseResumeText } from "@/utils/talentforge/pdfParser";
 import { parsePastedHtml } from "@/utils/talentforge/pasteParser";
 import { tagResume } from "@/utils/talentforge/tagging";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
@@ -111,7 +111,7 @@ export default function ResumeManager() {
           const file = files[0];
           const content =
             file.type === "application/pdf"
-              ? await pdfToMarkdown(file)
+              ? await pdfToText(file)
               : await file.text();
           setText(content);
         }}

--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button, Stack } from "@mui/material";
 import { v4 as uuid } from "uuid";
 
-import { pdfToMarkdown, parseResumeText } from "@/utils/talentforge/pdfParser";
+import { pdfToText, parseResumeText } from "@/utils/talentforge/pdfParser";
 import { addResume } from "@/utils/talentforge/dataStore";
 import { tagResume } from "@/utils/talentforge/tagging";
 
@@ -26,7 +26,7 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
     if (!file) return;
     setLoading(true);
     try {
-      const text = await pdfToMarkdown(file);
+      const text = await pdfToText(file);
       const tags = await tagResume(text);
       const parsed = parseResumeText(text);
       addResume({

--- a/src/hooks/useResumeParser.ts
+++ b/src/hooks/useResumeParser.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 
-import { pdfToMarkdown } from "@/utils/talentforge/pdfParser";
+import { pdfToText } from "@/utils/talentforge/pdfParser";
 
 export default function useResumeParser() {
   const [resume, setResume] = useState("");
@@ -10,7 +10,7 @@ export default function useResumeParser() {
       setResume(input);
       return input;
     }
-    const text = await pdfToMarkdown(input);
+    const text = await pdfToText(input);
     setResume(text);
     return text;
   }, []);

--- a/src/utils/talentforge/pdfParser.ts
+++ b/src/utils/talentforge/pdfParser.ts
@@ -61,7 +61,10 @@ export function cleanPdfText(pageLines: string[][]): string {
   return cleanedPages.join("\n\n");
 }
 
-export async function pdfToMarkdown(file: File): Promise<string> {
+/**
+ * Extract plain text from a PDF file.
+ */
+export async function pdfToText(file: File): Promise<string> {
   const reader = new FileReader();
   const workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`;
 
@@ -156,12 +159,12 @@ export function parseResumeText(text: string): ParsedResume {
 }
 
 /**
- * Convenience helper to convert a PDF file and parse its sections.
+ * Convenience helper to convert a PDF file to plain text and parse its sections.
  */
 export async function parsePdf(
   file: File,
 ): Promise<{ text: string; parsed: ParsedResume }> {
-  const text = await pdfToMarkdown(file);
+  const text = await pdfToText(file);
   return { text, parsed: parseResumeText(text) };
 }
 


### PR DESCRIPTION
## Summary
- Rename `pdfToMarkdown` to `pdfToText` in TalentForge PDF parser
- Update TalentForge components and hook to use the new PDF text extractor
- Clarify docs around parsing PDF files to plain text

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e906d3d48330ad49733913a10e0f