### PR TITLE
Handle server-side HTML sanitization for pasted content

### DIFF
--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -19,5 +19,8 @@ const localStorageMock = {
   },
 };
 
-(global as any).localStorage = localStorageMock;
-(global as any).window = { localStorage: localStorageMock };
+(globalThis as { localStorage?: typeof localStorageMock }).localStorage =
+  localStorageMock;
+(globalThis as { window?: { localStorage: typeof localStorageMock } }).window = {
+  localStorage: localStorageMock,
+};

--- a/src/tests/talentforge/dataStore.test.ts
+++ b/src/tests/talentforge/dataStore.test.ts
@@ -41,15 +41,15 @@ describe("dataStore migrations", () => {
 
     importFromJson(JSON.stringify(legacySnapshot));
 
-    const messages = loadItem<any>("messages", MESSAGES_VERSION);
+    const messages = loadItem<unknown>("messages", MESSAGES_VERSION);
     expect(messages).toHaveLength(1);
     expect(messages[0].replies[0].body).toBe("thanks");
 
-    const offers = loadItem<any>("offers", OFFERS_VERSION);
+    const offers = loadItem<unknown>("offers", OFFERS_VERSION);
     expect(offers).toHaveLength(1);
     expect(offers[0].compensation[0].notes).toBe("100k");
 
-    const apps = loadItem<any>("jobApplications", APPLICATIONS_VERSION);
+    const apps = loadItem<unknown>("jobApplications", APPLICATIONS_VERSION);
     expect(apps).toHaveLength(1);
     expect(apps[0].role.title).toBe("Engineer");
   });

--- a/src/tests/talentforge/pasteParser.test.ts
+++ b/src/tests/talentforge/pasteParser.test.ts
@@ -1,0 +1,16 @@
+describe("parsePastedHtml in SSR", () => {
+  it("strips HTML tags when window is undefined", async () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    // Simulate server-side environment
+    delete (globalThis as { window?: unknown }).window;
+
+    await jest.isolateModulesAsync(async () => {
+      const { parsePastedHtml } = await import("@/utils/talentforge/pasteParser");
+      const result = parsePastedHtml("<p>Hello <strong>world</strong></p>");
+      expect(result).toBe("Hello world");
+      expect(result).not.toMatch(/<[^>]+>/);
+    });
+
+    (globalThis as { window?: unknown }).window = originalWindow;
+  });
+});

--- a/src/utils/talentforge/pasteParser.ts
+++ b/src/utils/talentforge/pasteParser.ts
@@ -6,7 +6,10 @@ import DOMPurify from "dompurify";
  * Sanitize HTML pasted by the user and return plain text.
  */
 export function parsePastedHtml(html: string): string {
-  if (typeof window === "undefined") return html;
+  if (typeof window === "undefined") {
+    // Fallback for server-side environments: strip all HTML tags
+    return html.replace(/<[^>]*>/g, "");
+  }
   const clean = DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
   const temp = document.createElement("div");
   temp.innerHTML = clean;


### PR DESCRIPTION
## Summary
- Strip HTML tags when parsing pasted content in server environments
- Add SSR unit test for paste parser
- Tidy test utilities to avoid `any` lint errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6e90167488330a00f17c9e78e9a20