### PR TITLE
fix: resolve lint errors in tests and mock data

### DIFF
--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,3 +1,5 @@
+export {};
+
 const storage: Record<string, string> = {};
 
 const localStorageMock = {
@@ -17,7 +19,12 @@ const localStorageMock = {
   get length() {
     return Object.keys(storage).length;
   },
+} as const;
+
+const g = globalThis as unknown as {
+  localStorage: typeof localStorageMock;
+  window: { localStorage: typeof localStorageMock };
 };
 
-(global as any).localStorage = localStorageMock;
-(global as any).window = { localStorage: localStorageMock };
+g.localStorage = localStorageMock;
+g.window = { localStorage: localStorageMock };

--- a/src/tests/talentforge/dataStore.test.ts
+++ b/src/tests/talentforge/dataStore.test.ts
@@ -1,6 +1,18 @@
 import { importFromJson, MESSAGES_VERSION, OFFERS_VERSION, APPLICATIONS_VERSION } from "../../utils/talentforge/dataStore";
 import { loadItem } from "../../utils/storage";
 
+interface Message {
+  replies: { body: string }[];
+}
+
+interface Offer {
+  compensation: { notes: string }[];
+}
+
+interface JobApplication {
+  role: { title: string };
+}
+
 describe("dataStore migrations", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -41,15 +53,15 @@ describe("dataStore migrations", () => {
 
     importFromJson(JSON.stringify(legacySnapshot));
 
-    const messages = loadItem<any>("messages", MESSAGES_VERSION);
+    const messages = loadItem<Message[]>("messages", MESSAGES_VERSION)!;
     expect(messages).toHaveLength(1);
     expect(messages[0].replies[0].body).toBe("thanks");
 
-    const offers = loadItem<any>("offers", OFFERS_VERSION);
+    const offers = loadItem<Offer[]>("offers", OFFERS_VERSION)!;
     expect(offers).toHaveLength(1);
     expect(offers[0].compensation[0].notes).toBe("100k");
 
-    const apps = loadItem<any>("jobApplications", APPLICATIONS_VERSION);
+    const apps = loadItem<JobApplication[]>("jobApplications", APPLICATIONS_VERSION)!;
     expect(apps).toHaveLength(1);
     expect(apps[0].role.title).toBe("Engineer");
   });

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -91,7 +91,12 @@ export const mockOffers: Offer[] = [
 ];
 
 mockUserProfile.resumeVariants = mockResumes.map(
-  ({ content, parsed, tags, ...rv }) => rv,
+  ({ content, parsed, tags, ...rv }) => {
+    void content;
+    void parsed;
+    void tags;
+    return rv;
+  },
 );
 mockUserProfile.applications = mockApplications;
 


### PR DESCRIPTION
## Summary
- remove `any` usage in tests by using typed global setup and explicit interfaces
- clean mock data mapping to eliminate unused vars

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6ea416d1083308b726c68aa219dbd