### PR TITLE
fix: open ApplicationBoard drawer on prompt actions

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -102,10 +102,18 @@ function Card({
       </Typography>
       {app.role.description && (
         <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-          <Button size="small" onClick={() => onRunTile("screenRole", app)}>
+          <Button
+            size="small"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={() => onRunTile("screenRole", app)}
+          >
             Analyze Risks
           </Button>
-          <Button size="small" onClick={() => onRunTile("resumeRewrite", app)}>
+          <Button
+            size="small"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={() => onRunTile("resumeRewrite", app)}
+          >
             Compare to Resume
           </Button>
         </Stack>


### PR DESCRIPTION
## Summary
- allow prompt action buttons on application cards to trigger the AI drawer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6ed4b7a60833084cf4a7275fb38ba