### PR TITLE
fix basepair histogram index

### DIFF
--- a/src/components/dna/charts/BasepairHistogram.tsx
+++ b/src/components/dna/charts/BasepairHistogram.tsx
@@ -31,8 +31,6 @@ export type BasepairHistogramProps = {
 export function BasepairHistogram(props: BasepairHistogramProps) {
   const { sequences = [], bpRange = [] } = props || {};
 
-  debugger;
-
   const ref = useRef<HTMLDivElement | null>(null);
 
   if (!sequences) {
@@ -56,7 +54,7 @@ export function BasepairHistogram(props: BasepairHistogramProps) {
   sequences.forEach((seq) => {
     const seqBPCounts = getBasepairCounts(
       seq.sequence.substring(
-        Math.max(minBasePair - 1) || 0,
+        Math.max(minBasePair - 1, 0),
         (bpRange?.[1] || seq.sequence.length) + 1
       )
     );


### PR DESCRIPTION
## Summary
- remove stray debugger from BasepairHistogram component
- guard against negative start index when counting base pairs

## Testing
- `npm test`
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68c6edcb82d083309654c8ba03922bf9