### PR TITLE
Fix resume handling for cover letter generation

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -285,7 +285,9 @@ export default function ApplicationBoard() {
       prompt = prompt.replaceAll(`{{${key}}}`, values[key] || "");
     }
     if (tileId === "coverLetter") {
-      const resume = app.resumeVariant || getResumes()[0];
+      const resume: ResumeEntry | undefined = app.resumeVariant
+        ? getResumes().find((r) => r.id === app.resumeVariant?.id)
+        : getResumes()[0];
       if (resume) {
         prompt = `${prompt}\n\nJob Description:\n${values.jobDescription}\n\nResume:\n${resume.content}`;
       } else if (values.jobDescription) {


### PR DESCRIPTION
## Summary
- Fetch resume content when generating cover letter prompt

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f5922ab483308b4d9e656b87ec55