### PR TITLE
docs: correct possessive in FileUploader outputType JSDoc

### DIFF
--- a/src/components/talentforge/FileUploader.tsx
+++ b/src/components/talentforge/FileUploader.tsx
@@ -56,7 +56,7 @@ export interface FileUploaderProps
   ) => void;
 
   /**
-   * The type of output to return from the FileUploader in it's onChange callback.
+   * The type of output to return from the FileUploader in its onChange callback.
    * @default content
    */
   outputType?: "content" | "object" | "files";


### PR DESCRIPTION
## Summary
- correct grammatical error in FileUploader `outputType` JSDoc comment

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6f5a5168c83308b7c571dac46bdfd