### PR TITLE
refactor: tighten auto reply template types

### DIFF
--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -72,11 +72,11 @@ export default function Inbox() {
 
   const selected = threads.find((m) => m.id === selectedId) || null;
 
-  const templateNames = Object.keys(templateDefs);
-  const defaultTemplate = templateDefs.general
+  const templateNames = Object.keys(templateDefs) as AutoReplyTemplate[];
+  const defaultTemplate: AutoReplyTemplate = templateDefs.general
     ? "general"
-    : templateNames[0] || "";
-  const defaultQuickTone = templateDefs.politeFollowUp
+    : templateNames[0];
+  const defaultQuickTone: AutoReplyTemplate = templateDefs.politeFollowUp
     ? "politeFollowUp"
     : defaultTemplate;
 

--- a/src/utils/autoReply.ts
+++ b/src/utils/autoReply.ts
@@ -16,12 +16,12 @@ export const AUTO_REPLY_TEMPLATES = {
     "You are a helpful assistant that requests more information when needed while remaining courteous.",
 } as const;
 
-export type AutoReplyTemplate = string;
+export type AutoReplyTemplate = keyof typeof AUTO_REPLY_TEMPLATES;
 
 export const buildAutoReplyMessages = (
   template: AutoReplyTemplate,
   content: string,
-  templates: Record<string, string> = AUTO_REPLY_TEMPLATES,
+  templates: Record<AutoReplyTemplate, string> = AUTO_REPLY_TEMPLATES,
 ): AutoReplyMessage[] => [
   { role: "system", content: templates[template] || templates.general },
   { role: "user", content },


### PR DESCRIPTION
## Summary
- type `AutoReplyTemplate` as union of defined templates
- enforce `buildAutoReplyMessages` to take typed template map
- adjust inbox usage for stricter template typing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f5a9089083308d8988b22f10661f