### PR TITLE
Add secondary color test for Thinking component

### DIFF
--- a/src/components/showcase/Thinking/Thinking.test.tsx
+++ b/src/components/showcase/Thinking/Thinking.test.tsx
@@ -40,4 +40,14 @@ describe("<Thinking />", () => {
     expect(spinner).toBeInTheDocument();
     expect(spinner).toHaveStyle({ width: "32px", height: "32px" });
   });
+
+  it("applies the secondary color class when indicatorProps.color is secondary", () => {
+    renderComponent({
+      showIndicator: true,
+      indicatorProps: { color: "secondary" },
+    });
+    const spinner = screen.getByRole("progressbar");
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveClass("MuiCircularProgress-colorSecondary");
+  });
 });


### PR DESCRIPTION
## Summary
- add test ensuring Thinking spinner uses MUI secondary color class when `indicatorProps.color` is `secondary`

## Testing
- `npm test`
- `npx jest src/components/showcase/Thinking/Thinking.test.tsx --env=jsdom` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f9bd58c88330ab7055e7d8ea03ce