### PR TITLE
Track application source and show hiring company

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -118,6 +118,11 @@ function Card({
       <Typography variant="body2" color="text.secondary">
         {app.role.company} – {app.role.location}
       </Typography>
+      {app.role.source && (
+        <Typography variant="body2" color="text.secondary">
+          Source: {app.role.source}
+        </Typography>
+      )}
       {resumes.length > 0 && (
         <TextField
           select
@@ -171,6 +176,7 @@ export default function ApplicationBoard() {
   const [location, setLocation] = useState("");
   const [description, setDescription] = useState("");
   const [resumeId, setResumeId] = useState("");
+  const [source, setSource] = useState("Company Site");
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerTitle, setDrawerTitle] = useState("");
   const [drawerLoading, setDrawerLoading] = useState(false);
@@ -221,7 +227,7 @@ export default function ApplicationBoard() {
     const newApp: JobApplication = {
       id: uuid(),
       applicant: { id: "", name: "", email: "" },
-      role: { id: uuid(), title, company, location, description },
+      role: { id: uuid(), title, company, location, description, source },
       resumeVariant: resume,
       status: "applied",
       history: [{ status: "applied", changedAt: new Date().toISOString() }],
@@ -234,6 +240,7 @@ export default function ApplicationBoard() {
     setLocation("");
     setDescription("");
     setResumeId("");
+    setSource("Company Site");
   };
 
   const runTile = async (tileId: string, app: JobApplication) => {
@@ -432,6 +439,19 @@ export default function ApplicationBoard() {
               onChange={(e) => setLocation(e.target.value)}
               fullWidth
             />
+            <TextField
+              label="Source"
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              select
+              fullWidth
+            >
+              {['LinkedIn', 'Indeed', 'Company Site'].map((s) => (
+                <MenuItem key={s} value={s}>
+                  {s}
+                </MenuItem>
+              ))}
+            </TextField>
             {resumes.length > 0 && (
               <TextField
                 label="Resume"

--- a/src/utils/talentforge/connectors/indeed.ts
+++ b/src/utils/talentforge/connectors/indeed.ts
@@ -11,17 +11,17 @@ import type { JobListing } from "@/types/talentforge/job";
 const SAMPLE_LISTINGS: JobListing[] = [
   {
     title: "Software Engineer",
-    company: "Indeed",
+    company: "DataWorks",
     location: "Remote",
     url: "https://www.indeed.com/jobs/software-engineer-remote",
-    source: "indeed",
+    source: "Indeed",
   },
   {
     title: "Data Analyst",
-    company: "Indeed",
+    company: "Analytics LLC",
     location: "Austin, TX",
     url: "https://www.indeed.com/jobs/data-analyst-austin",
-    source: "indeed",
+    source: "Indeed",
   },
 ];
 

--- a/src/utils/talentforge/connectors/linkedin.ts
+++ b/src/utils/talentforge/connectors/linkedin.ts
@@ -28,17 +28,17 @@ export class LinkedInConnector {
       listings: [
         {
           title: "Software Engineer",
-          company: "LinkedIn",
+          company: "Tech Corp",
           location: "Remote",
           url: "https://www.linkedin.com/jobs/123",
-          source: "linkedin",
+          source: "LinkedIn",
         },
         {
           title: "Product Manager",
-          company: "LinkedIn",
+          company: "Startup Hub",
           location: "San Francisco, CA",
           url: "https://www.linkedin.com/jobs/456",
-          source: "linkedin",
+          source: "LinkedIn",
         },
       ],
     };


### PR DESCRIPTION
## Summary
- Display job application source alongside company details
- Allow selecting LinkedIn, Indeed, or Company Site when adding applications
- Use sample hiring company names instead of connector names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6f99506d0833096cfd58f0a8ad9cc