### PR TITLE
Rename suite field to suit in blackjack modules

### DIFF
--- a/go/blackjack/cards/cards.go
+++ b/go/blackjack/cards/cards.go
@@ -89,7 +89,7 @@ var CardValueToString = map[CardValue]string{
 }
 
 type Card struct {
-	Suite      CardSuit  `yaml:"suite"`
+	Suit       CardSuit  `yaml:"suit"`
 	Value      CardValue `yaml:"value"`
 	Masked     bool      `yaml:"masked"`  // only hidden cards are masked
 	Demoted    bool      `yaml:"demoted"` // means our value is One
@@ -99,7 +99,7 @@ type Card struct {
 func CardToGlyph(card Card) string {
 	switch card.Value {
 	case One, Ace:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂡"
 		case Hearts:
@@ -110,7 +110,7 @@ func CardToGlyph(card Card) string {
 			return "🃑"
 		}
 	case Two:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂢"
 		case Hearts:
@@ -121,7 +121,7 @@ func CardToGlyph(card Card) string {
 			return "🃒"
 		}
 	case Three:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂣"
 		case Hearts:
@@ -132,7 +132,7 @@ func CardToGlyph(card Card) string {
 			return "🃓"
 		}
 	case Four:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂤"
 		case Hearts:
@@ -143,7 +143,7 @@ func CardToGlyph(card Card) string {
 			return "🃔"
 		}
 	case Five:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂥"
 		case Hearts:
@@ -154,7 +154,7 @@ func CardToGlyph(card Card) string {
 			return "🃕"
 		}
 	case Six:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂦"
 		case Hearts:
@@ -165,7 +165,7 @@ func CardToGlyph(card Card) string {
 			return "🃖"
 		}
 	case Seven:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂧"
 		case Hearts:
@@ -176,7 +176,7 @@ func CardToGlyph(card Card) string {
 			return "🃗"
 		}
 	case Eight:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂨"
 		case Hearts:
@@ -187,7 +187,7 @@ func CardToGlyph(card Card) string {
 			return "🃘"
 		}
 	case Nine:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂩"
 		case Hearts:
@@ -198,7 +198,7 @@ func CardToGlyph(card Card) string {
 			return "🃙"
 		}
 	case Ten:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂪"
 		case Hearts:
@@ -209,7 +209,7 @@ func CardToGlyph(card Card) string {
 			return "🃚"
 		}
 	case Jack:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂫"
 		case Hearts:
@@ -220,7 +220,7 @@ func CardToGlyph(card Card) string {
 			return "🃛"
 		}
 	case Queen:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂭"
 		case Hearts:
@@ -231,7 +231,7 @@ func CardToGlyph(card Card) string {
 			return "🃝"
 		}
 	case King:
-		switch card.Suite {
+		switch card.Suit {
 		case Spades:
 			return "🂮"
 		case Hearts:
@@ -296,9 +296,9 @@ func CardToString(card Card, printValue bool, useGlyphs bool, colorTerminal bool
 	if useGlyphs {
 		return fmt.Sprintf("%s ", CardToGlyph(card))
 	} else {
-		suitStr := SuitToString[card.Suite]
+		suitStr := SuitToString[card.Suit]
 		if colorTerminal {
-			suitStr = SuitToColorString[card.Suite]
+			suitStr = SuitToColorString[card.Suit]
 		}
 
 		if printValue {
@@ -397,7 +397,7 @@ func ToCard(cardString string) Card {
 
 func CreateCard(suit CardSuit, value CardValue) Card {
 	card := Card{Demoted: false, DoubleDown: false, Masked: false}
-	card.Suite = suit
+	card.Suit = suit
 	card.Value = value
 	return card
 }
@@ -433,7 +433,7 @@ func IsAce(card Card) bool {
 }
 
 func IsOneEyedJack(card Card) bool {
-	return card.Value == Jack && (card.Suite == Hearts || card.Suite == Spades)
+	return card.Value == Jack && (card.Suit == Hearts || card.Suit == Spades)
 }
 
 func ShuffleCards(cards []Card) {

--- a/go/blackjack/cards/cards_test.go
+++ b/go/blackjack/cards/cards_test.go
@@ -8,9 +8,9 @@ import (
 // TestCreateCard verifies that CreateCard sets basic fields correctly
 func TestCreateCard(t *testing.T) {
 	ForAllCards(func(card Card) {
-		created := CreateCard(card.Suite, card.Value)
-		if created.Suite != card.Suite || created.Value != card.Value {
-			t.Fatalf("CreateCard(%v,%v)=%v want %v", card.Suite, card.Value, created, card)
+		created := CreateCard(card.Suit, card.Value)
+		if created.Suit != card.Suit || created.Value != card.Value {
+			t.Fatalf("CreateCard(%v,%v)=%v want %v", card.Suit, card.Value, created, card)
 		}
 		if created.Demoted || created.DoubleDown || created.Masked {
 			t.Fatalf("new card has unexpected flags: %+v", created)
@@ -41,7 +41,7 @@ func TestToCard(t *testing.T) {
 		}
 		s := CardToString(card, false, false, false)
 		got := ToCard(s)
-		if got.Suite != card.Suite || got.Value != card.Value {
+		if got.Suit != card.Suit || got.Value != card.Value {
 			t.Fatalf("ToCard(%s)=%v want %v", s, got, card)
 		}
 	})

--- a/go/blackjack/dealer/dealer.go
+++ b/go/blackjack/dealer/dealer.go
@@ -428,7 +428,7 @@ func PayWinners(payBlackjacks bool, payAllOthers bool, updateStats bool) {
 				game.State.DealerBlackjacks += 1
 			} else if dealerValue > 21 {
 				game.State.DealerBusts += 1
-				firstCard := cards.CreateCard(dealerHand.Cards[0].Suite, dealerHand.Cards[0].Value)
+				firstCard := cards.CreateCard(dealerHand.Cards[0].Suit, dealerHand.Cards[0].Value)
 				game.State.BustCards = append(game.State.BustCards, firstCard)
 				game.State.BustCounts[firstCard.Value] += 1
 			}
@@ -452,7 +452,7 @@ func PayWinners(payBlackjacks bool, payAllOthers bool, updateStats bool) {
 
 				if playerValue > 21 {
 					game.State.PlayerBusts += 1
-					game.State.BustCards = append(game.State.BustCards, cards.CreateCard(hand.Cards[0].Suite, hand.Cards[0].Value))
+					game.State.BustCards = append(game.State.BustCards, cards.CreateCard(hand.Cards[0].Suit, hand.Cards[0].Value))
 					game.State.BustCounts[hand.Cards[0].Value] += 1
 				}
 

--- a/go/blackjack/rules/rules.go
+++ b/go/blackjack/rules/rules.go
@@ -485,9 +485,9 @@ func IsFlush(hand player.Hand) bool {
 	for i := 0; i < len(hand.Cards); i++ {
 		card := hand.Cards[i]
 		if i == 0 {
-			suit = card.Suite
+			suit = card.Suit
 		}
-		isFlush = isFlush && card.Suite == suit
+		isFlush = isFlush && card.Suit == suit
 	}
 
 	return isFlush
@@ -508,7 +508,7 @@ func IsPairHand(hand player.Hand, value cards.CardValue, suited bool) bool {
 
 	isPair := hand.Cards[0].Value == value && hand.Cards[1].Value == value
 	if suited {
-		return isPair && hand.Cards[0].Suite == hand.Cards[1].Suite
+		return isPair && hand.Cards[0].Suit == hand.Cards[1].Suit
 	} else {
 		return isPair
 	}

--- a/go/blackjack/rules/rules_test.go
+++ b/go/blackjack/rules/rules_test.go
@@ -50,7 +50,7 @@ func suitsAreEqual(hand player.Hand) bool {
 			continue
 		}
 
-		suitsAreEqual = suitsAreEqual && hand.Cards[i].Suite == hand.Cards[i-1].Suite
+		suitsAreEqual = suitsAreEqual && hand.Cards[i].Suit == hand.Cards[i-1].Suit
 		if !suitsAreEqual {
 			return false
 		}

--- a/go/blackjack/sidebets/sidebets.go
+++ b/go/blackjack/sidebets/sidebets.go
@@ -25,9 +25,9 @@ func HandToTrifectaHand(hand player.Hand) player.Hand {
 	trifectaHand.Player = hand.Player
 
 	for i := 0; i < len(hand.Cards); i++ {
-		trifectaHand.Cards = append(trifectaHand.Cards, cards.CreateCard(hand.Cards[i].Suite, hand.Cards[i].Value))
+		trifectaHand.Cards = append(trifectaHand.Cards, cards.CreateCard(hand.Cards[i].Suit, hand.Cards[i].Value))
 	}
-	trifectaHand.Cards = append(trifectaHand.Cards, cards.CreateCard(game.State.Dealer.Hands[0].Cards[0].Suite, game.State.Dealer.Hands[0].Cards[0].Value))
+	trifectaHand.Cards = append(trifectaHand.Cards, cards.CreateCard(game.State.Dealer.Hands[0].Cards[0].Suit, game.State.Dealer.Hands[0].Cards[0].Value))
 
 	return trifectaHand
 }
@@ -183,11 +183,11 @@ func IsTrifectaTrips(hand player.Hand, suited bool) bool {
 
 	value := trifectaHand.Cards[0].Value
 	if suited {
-		suite := trifectaHand.Cards[0].Suite
+		suit := trifectaHand.Cards[0].Suit
 		return (trifectaHand.Cards[1].Value == value &&
 			trifectaHand.Cards[2].Value == value) || (cards.IsAce(trifectaHand.Cards[0]) && cards.IsAce(trifectaHand.Cards[1]) && cards.IsAce(trifectaHand.Cards[2])) &&
-			(trifectaHand.Cards[1].Suite == suite &&
-				trifectaHand.Cards[2].Suite == suite)
+			(trifectaHand.Cards[1].Suit == suit &&
+				trifectaHand.Cards[2].Suit == suit)
 	} else {
 		return (trifectaHand.Cards[1].Value == value &&
 			trifectaHand.Cards[2].Value == value) || (cards.IsAce(trifectaHand.Cards[0]) && cards.IsAce(trifectaHand.Cards[1]) && cards.IsAce(trifectaHand.Cards[2]))
@@ -257,7 +257,7 @@ func GetSpanish21Winnings(hand player.Hand) int {
 		dealerDownCard := DealerDownCard()
 
 		if firstCard.Value == dealerUpCard.Value {
-			if CardsMatchSuite(firstCard, dealerUpCard) {
+			if CardsMatchSuit(firstCard, dealerUpCard) {
 				winnings += Spanish21MatchSuitMultiplier * hand.TrifectaWager
 			} else {
 				winnings += Spanish21MatchUnsuitedMultiplier * hand.TrifectaWager
@@ -265,7 +265,7 @@ func GetSpanish21Winnings(hand player.Hand) int {
 		}
 
 		if secondCard.Value == dealerUpCard.Value {
-			if CardsMatchSuite(secondCard, dealerUpCard) {
+			if CardsMatchSuit(secondCard, dealerUpCard) {
 				winnings += Spanish21MatchSuitMultiplier * hand.TrifectaWager
 			} else {
 				winnings += Spanish21MatchUnsuitedMultiplier * hand.TrifectaWager
@@ -273,7 +273,7 @@ func GetSpanish21Winnings(hand player.Hand) int {
 		}
 
 		if firstCard.Value == dealerDownCard.Value {
-			if CardsMatchSuite(firstCard, dealerDownCard) {
+			if CardsMatchSuit(firstCard, dealerDownCard) {
 				winnings += Spanish21MatchSuitMultiplier * hand.TrifectaWager
 			} else {
 				winnings += Spanish21MatchUnsuitedMultiplier * hand.TrifectaWager
@@ -281,7 +281,7 @@ func GetSpanish21Winnings(hand player.Hand) int {
 		}
 
 		if secondCard.Value == dealerDownCard.Value {
-			if CardsMatchSuite(secondCard, dealerDownCard) {
+			if CardsMatchSuit(secondCard, dealerDownCard) {
 				winnings += Spanish21MatchSuitMultiplier * hand.TrifectaWager
 			} else {
 				winnings += Spanish21MatchUnsuitedMultiplier * hand.TrifectaWager
@@ -429,6 +429,6 @@ func PayTrifectaStax() {
 	game.SaveBlackjackStateYaml()
 }
 
-func CardsMatchSuite(aCard cards.Card, bCard cards.Card) bool {
-	return aCard.Suite == bCard.Suite
+func CardsMatchSuit(aCard cards.Card, bCard cards.Card) bool {
+	return aCard.Suit == bCard.Suit
 }

--- a/go/blackjack/sidebets/sidebets_test.go
+++ b/go/blackjack/sidebets/sidebets_test.go
@@ -21,7 +21,7 @@ func TestIsTrifectaFlush(t *testing.T) {
 	if !IsTrifectaFlush(hand) {
 		t.Fatalf("expected flush")
 	}
-	hand.Cards[1].Suite = cards.Hearts
+	hand.Cards[1].Suit = cards.Hearts
 	if IsTrifectaFlush(hand) {
 		t.Fatalf("expected not flush")
 	}

--- a/go/blackjack/ui/terminal/print.go
+++ b/go/blackjack/ui/terminal/print.go
@@ -29,9 +29,9 @@ func DrawHand(hand player.Hand, colorTerminal bool) {
 
 	for i := 0; i < len(hand.Cards); i++ {
 		card := hand.Cards[i]
-		suitStr := cards.SuitToString[card.Suite]
+		suitStr := cards.SuitToString[card.Suit]
 		if colorTerminal {
-			suitStr = cards.SuitToColorString[card.Suite]
+			suitStr = cards.SuitToColorString[card.Suit]
 		}
 
 		if card.Masked {
@@ -60,9 +60,9 @@ func DrawHand(hand player.Hand, colorTerminal bool) {
 	for i := 0; i < len(hand.Cards); i++ {
 		card := hand.Cards[i]
 
-		suitStr := cards.SuitToString[card.Suite]
+		suitStr := cards.SuitToString[card.Suit]
 		if colorTerminal {
-			suitStr = cards.SuitToColorString[card.Suite]
+			suitStr = cards.SuitToColorString[card.Suit]
 		}
 
 		if card.Masked {
@@ -537,16 +537,16 @@ func PrintSidebetsOutcome(hand player.Hand) string {
 		dealerDownCard := sidebets.DealerDownCard()
 
 		if firstCard.Value == dealerUpCard.Value {
-			if sidebets.CardsMatchSuite(firstCard, dealerUpCard) {
-				outcome += fmt.Sprintf("First Card Matches Up Card, Matches Suite! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
+			if sidebets.CardsMatchSuit(firstCard, dealerUpCard) {
+				outcome += fmt.Sprintf("First Card Matches Up Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
 			} else {
 				outcome += fmt.Sprintf("First Card Matches Up Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier)
 			}
 		}
 
 		if secondCard.Value == dealerUpCard.Value {
-			if sidebets.CardsMatchSuite(secondCard, dealerUpCard) {
-				outcome += fmt.Sprintf("Second Card Matches Up Card, Matches Suite! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
+			if sidebets.CardsMatchSuit(secondCard, dealerUpCard) {
+				outcome += fmt.Sprintf("Second Card Matches Up Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
 			} else {
 				outcome += fmt.Sprintf("Second Card Matches Up Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier)
 			}
@@ -554,16 +554,16 @@ func PrintSidebetsOutcome(hand player.Hand) string {
 
 		if !dealerDownCard.Masked {
 			if firstCard.Value == dealerDownCard.Value {
-				if sidebets.CardsMatchSuite(firstCard, dealerDownCard) {
-					outcome += fmt.Sprintf("First Card Matches Down Card, Matches Suite! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
+				if sidebets.CardsMatchSuit(firstCard, dealerDownCard) {
+					outcome += fmt.Sprintf("First Card Matches Down Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
 				} else {
 					outcome += fmt.Sprintf("First Card Matches Down Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier)
 				}
 			}
 
 			if secondCard.Value == dealerDownCard.Value {
-				if sidebets.CardsMatchSuite(secondCard, dealerDownCard) {
-					outcome += fmt.Sprintf("Second Card Matches Down Card, Matches Suite! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
+				if sidebets.CardsMatchSuit(secondCard, dealerDownCard) {
+					outcome += fmt.Sprintf("Second Card Matches Down Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
 				} else {
 					outcome += fmt.Sprintf("Second Card Matches Down Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier)
 				}

--- a/go/blackjack/ui/web/web.go
+++ b/go/blackjack/ui/web/web.go
@@ -296,19 +296,19 @@ func cardToImage(c cards.Card) string {
 	if c.Masked {
 		return "/assets/boardgame/PNG/Cards/cardBack_blue1.png"
 	}
-        suit := ""
-        switch c.Suite {
-        case cards.Spades:
-                suit = "Spades"
-        case cards.Hearts:
-                suit = "Hearts"
-        case cards.Diamonds:
-                suit = "Diamonds"
-        case cards.Clubs:
-                suit = "Clubs"
-        }
-        val := cards.CardValueToString[c.Value]
-        return fmt.Sprintf("/assets/boardgame/PNG/Cards/card%s%s.png", suit, val)
+	suit := ""
+	switch c.Suit {
+	case cards.Spades:
+		suit = "Spades"
+	case cards.Hearts:
+		suit = "Hearts"
+	case cards.Diamonds:
+		suit = "Diamonds"
+	case cards.Clubs:
+		suit = "Clubs"
+	}
+	val := cards.CardValueToString[c.Value]
+	return fmt.Sprintf("/assets/boardgame/PNG/Cards/card%s%s.png", suit, val)
 }
 
 func PrintCurrency(value int) string {


### PR DESCRIPTION
## Summary
- rename `Card` struct field `Suite` to `Suit` and adjust YAML tag
- update game logic, sidebet utilities, dealer, and UIs to use `Suit`
- align tests with renamed field and helper

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9a891a8833089fa8b6d40ebf2a4