### PR TITLE
Cancel pending resize updates in useDimensions

### DIFF
--- a/src/hooks/useDimensions.ts
+++ b/src/hooks/useDimensions.ts
@@ -5,6 +5,7 @@ import { Breakpoint, useTheme } from "@mui/material/styles";
 
 // utils
 import debounce from "lodash/debounce";
+import type { DebouncedFunc } from "lodash";
 
 /**
  * Dimensions of a component or element-its height, width, and breakpoint size.
@@ -63,7 +64,7 @@ export function useDimensions(
       return dimensions;
     };
 
-    const handleResize = debounce(() => {
+    const handleResize: DebouncedFunc<() => void> = debounce(() => {
       // updates the dimensions of the element on resize
       setDimensions(getDimensions());
     }, 100);
@@ -105,6 +106,7 @@ export function useDimensions(
     return () => {
       // remove the event listener during cleanup
       window.removeEventListener("resize", handleResize);
+      handleResize.cancel();
       if (interval) {
         clearInterval(interval);
       }

--- a/src/tests/useDimensions.test.ts
+++ b/src/tests/useDimensions.test.ts
@@ -1,0 +1,73 @@
+import React from "react";
+
+jest.mock("@mui/material/styles", () => ({
+  useTheme: () => ({
+    breakpoints: { values: { xs: 0, sm: 600, md: 900, lg: 1200, xl: 1536 } },
+  }),
+}));
+
+import { useDimensions } from "@/hooks/useDimensions";
+
+jest.useFakeTimers();
+
+describe("useDimensions cleanup", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  test("pending resize callbacks are cancelled on unmount", () => {
+    const listeners: Record<string, () => void> = {};
+    const addEventListener = jest.fn((event: string, handler: () => void) => {
+      listeners[event] = handler;
+    });
+    const removeEventListener = jest.fn((event: string, handler: () => void) => {
+      if (listeners[event] === handler) {
+        delete listeners[event];
+      }
+    });
+    const g = globalThis as unknown as {
+      window: {
+        addEventListener: typeof addEventListener;
+        removeEventListener: typeof removeEventListener;
+      };
+    };
+    g.window = { addEventListener, removeEventListener };
+
+    const ref = { current: { offsetWidth: 100, offsetHeight: 100 } } as React.RefObject<HTMLElement>;
+
+    const setSpy = jest.fn();
+    const originalUseState = React.useState;
+    jest.spyOn(React, "useState").mockImplementation((init: unknown) => {
+      if (
+        typeof init === "object" &&
+        init !== null &&
+        "width" in (init as Record<string, unknown>) &&
+        "height" in (init as Record<string, unknown>) &&
+        "breakpoint" in (init as Record<string, unknown>)
+      ) {
+        return [init, setSpy];
+      }
+      return originalUseState(init);
+    });
+
+    let cleanup: (() => void) | undefined;
+    jest.spyOn(React, "useEffect").mockImplementation((effect: () => void | (() => void)) => {
+      cleanup = effect() as () => void;
+    });
+
+    // mount
+    useDimensions(ref);
+    setSpy.mockClear();
+
+    // trigger resize before unmount to schedule debounced callback
+    listeners["resize"]?.();
+
+    // unmount
+    cleanup?.();
+
+    // advance timers to where debounced callback would normally run
+    jest.advanceTimersByTime(100);
+
+    expect(setSpy).not.toHaveBeenCalled();
+    expect(removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary
- cancel debounced resize handler on unmount in `useDimensions`
- type lodash debounce to access `cancel`
- add unit test ensuring no resize callback after unmount

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9b01858833087038e8fcc80eedb