### PR TITLE
Render resume compare response with markdown

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -26,6 +26,7 @@ import {
   type DragEndEvent,
 } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
+import Markdown from "react-markdown";
 import type { ApplicationStatus } from "@/types/talentforge/job";
 import type { JobApplication, ResumeEntry } from "@/utils/talentforge/dataStore";
 import {
@@ -543,10 +544,9 @@ export default function ApplicationBoard() {
                     p: 1.5,
                     borderRadius: 1,
                     maxWidth: "100%",
-                    whiteSpace: "pre-wrap",
                   }}
                 >
-                  {m.text}
+                  <Markdown>{m.text}</Markdown>
                 </Box>
               ))}
               {drawerMode === "resumeCompare" && !drawerLoading && (


### PR DESCRIPTION
## Summary
- Display ApplicationBoard drawer messages using Markdown so responses like "Compare to Resume" format correctly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6fbc3f4cc8330837cf93f5068e6f7