### PR TITLE
docs: fix typo in accessibility overview

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,7 +1,8 @@
 # Accessibility Audit
 
 ## Overview
-An accessibility audit was attempted on the TalentForge pages using the Axe CLI. The CLI installation failed with an HTTP 403 error, indicating the package registry was inaccessible from the current environment.
+An accessibility audit was attempted on the TalentForge pages using the Axe CLI.
+The CLI installation failed with an HTTP 403 error, indicating the package registry was inaccessible from the current environment.
 
 ## Implemented Improvements
 - Labeled the main navigation toolbar and added ARIA labels to the Sign In and Sign Up buttons.


### PR DESCRIPTION
## Summary
- fix broken "error" text in accessibility overview

## Testing
- `npm test` (fails: command not found: npm)
- `apt-get update` (fails: repository not signed / 403)


------
https://chatgpt.com/codex/tasks/task_e_68c6fc82980083308361ba30599398b6