### PR TITLE
Fix power-of-two wager calculation

### DIFF
--- a/go/blackjack/wasm_main.go
+++ b/go/blackjack/wasm_main.go
@@ -118,7 +118,7 @@ func Start(this js.Value, args []js.Value) any {
 					if cardPlayer.WinStreak > 6 {
 						return cardPlayer.Stack
 					} else if cardPlayer.WinStreak > 3 {
-						return utils.Min(cardPlayer.Stack, (2^cardPlayer.WinStreak%3)*cfg.MinWager)
+						return utils.Min(cardPlayer.Stack, (1<<(cardPlayer.WinStreak%3))*cfg.MinWager)
 					}
 					return cfg.MinWager
 				}


### PR DESCRIPTION
## Summary
- use bit shifting for power-of-two calculation when auto-placing wagers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68c6fc845d948330b4aaf7ea8ab6462b