### PR TITLE
Fix breakpoint thresholds in useDimensions hook

### DIFF
--- a/src/hooks/useDimensions.ts
+++ b/src/hooks/useDimensions.ts
@@ -50,13 +50,13 @@ export function useDimensions(
       };
 
       // calculate the breakpoint based on the theme's breakpoints and the width of the component
-      if (dimensions.width < theme.breakpoints.values["xs"]) {
+      if (dimensions.width < theme.breakpoints.values["sm"]) {
         dimensions.breakpoint = "xs";
-      } else if (dimensions.width < theme.breakpoints.values["sm"]) {
-        dimensions.breakpoint = "sm";
       } else if (dimensions.width < theme.breakpoints.values["md"]) {
-        dimensions.breakpoint = "md";
+        dimensions.breakpoint = "sm";
       } else if (dimensions.width < theme.breakpoints.values["lg"]) {
+        dimensions.breakpoint = "md";
+      } else if (dimensions.width < theme.breakpoints.values["xl"]) {
         dimensions.breakpoint = "lg";
       } else {
         dimensions.breakpoint = "xl";

--- a/src/tests/useDimensions.test.ts
+++ b/src/tests/useDimensions.test.ts
@@ -71,3 +71,58 @@ describe("useDimensions cleanup", () => {
     expect(removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
   });
 });
+
+describe("useDimensions breakpoints", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    { width: 599, expected: "xs" },
+    { width: 600, expected: "sm" },
+    { width: 900, expected: "md" },
+    { width: 1200, expected: "lg" },
+    { width: 1536, expected: "xl" },
+  ])("width $width => breakpoint $expected", ({ width, expected }) => {
+    const addEventListener = jest.fn();
+    const removeEventListener = jest.fn();
+    const g = globalThis as unknown as {
+      window: {
+        addEventListener: typeof addEventListener;
+        removeEventListener: typeof removeEventListener;
+      };
+    };
+    g.window = { addEventListener, removeEventListener };
+
+    const ref = {
+      current: { offsetWidth: width, offsetHeight: 100 },
+    } as React.RefObject<HTMLElement>;
+
+    const setSpy = jest.fn();
+    const originalUseState = React.useState;
+    jest.spyOn(React, "useState").mockImplementation((init: unknown) => {
+      if (
+        typeof init === "object" &&
+        init !== null &&
+        "width" in (init as Record<string, unknown>) &&
+        "height" in (init as Record<string, unknown>) &&
+        "breakpoint" in (init as Record<string, unknown>)
+      ) {
+        return [init, setSpy];
+      }
+      return originalUseState(init);
+    });
+
+    jest
+      .spyOn(React, "useEffect")
+      .mockImplementation((effect: () => void | (() => void)) => {
+        effect();
+      });
+
+    useDimensions(ref);
+
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ breakpoint: expected }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- correct breakpoint comparisons in `useDimensions` to start at `sm`
- add unit tests covering width-to-breakpoint mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c717102a5c8330a735b219e9ad2b77