### PR TITLE
fix Asparagine abbreviation in DNA constants

### DIFF
--- a/src/consts/dna/consts.ts
+++ b/src/consts/dna/consts.ts
@@ -30,7 +30,7 @@ export const PROTEINS = {
     polar: true,
   },
   N: {
-    abbrevName: "Asp",
+    abbrevName: "Asn",
     charCode: "N",
     charge: "neutral",
     fullName: "Asparagine",


### PR DESCRIPTION
## Summary
- correct the N protein entry to use "Asn" abbreviation for Asparagine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7170ba2008330971d8502df481c1d