### PR TITLE
test: exclude sequential page numbers

### DIFF
--- a/src/tests/pdfParser.test.ts
+++ b/src/tests/pdfParser.test.ts
@@ -34,7 +34,7 @@ describe("cleanPdfText", () => {
   test("removes numeric page headers and footers", () => {
     const pages = [
       ["1", "Experience", "Company A", "2"],
-      ["1", "Education", "2"],
+      ["2", "Education", "3"],
     ];
 
     const result = cleanPdfText(pages);


### PR DESCRIPTION
## Summary
- ensure pdf parser test removes sequential numeric headers/footers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7171dc61883309b0b897bced8eacb