### PR TITLE
Clear delayed resize timeout in useDimensions

### DIFF
--- a/src/hooks/useDimensions.ts
+++ b/src/hooks/useDimensions.ts
@@ -100,13 +100,14 @@ export function useDimensions(
     // update the dimensions on window resize
     window.addEventListener("resize", handleResize);
 
-    setTimeout(() => {
+    const timeoutId: ReturnType<typeof setTimeout> = setTimeout(() => {
       handleResize();
     }, 150);
 
     return () => {
       // remove the event listener during cleanup
       window.removeEventListener("resize", handleResize);
+      clearTimeout(timeoutId);
       handleResize.cancel();
       if (interval) {
         clearInterval(interval);


### PR DESCRIPTION
## Summary
- store timeout ID to clear delayed resize
- cleanup clears timeout before cancelling debounced handler

## Testing
- `npm test src/tests/useDimensions.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c71b84be908330bea5ba436b83399a