### PR TITLE
Rename SidebetLosings to SidebetLosses

### DIFF
--- a/go/blackjack/game/game.go
+++ b/go/blackjack/game/game.go
@@ -26,7 +26,7 @@ type BlackjackState struct {
 	BustCards        []cards.Card            `yaml:"bust-cards"`
 	BustCounts       map[cards.CardValue]int `yaml:"bust-counts"`
 	SidebetWinnings  int                     `yaml:"sidebet-winnings"`
-	SidebetLosings   int                     `yaml:"sidebet-losings"`
+	SidebetLosses    int                     `yaml:"sidebet-losses"`
 	Dealer           player.Player           `yaml:"dealer"`
 	Players          []player.Player         `yaml:"players"`
 	Shoe             Shoe                    `yaml:"shoe"`

--- a/go/blackjack/main.go
+++ b/go/blackjack/main.go
@@ -98,7 +98,7 @@ func initBlackjack() {
 			BustCards:        []cards.Card{},
 			BustCounts:       make(map[cards.CardValue]int),
 			SidebetWinnings:  0,
-			SidebetLosings:   0,
+			SidebetLosses:    0,
 			Players:          make([]player.Player, 0),
 			Dealer:           player.Player{Dealer: true},
 			Rounds:           0,

--- a/go/blackjack/sidebets/sidebets.go
+++ b/go/blackjack/sidebets/sidebets.go
@@ -239,7 +239,7 @@ func PayJackAttack() {
 			// track our winnings
 			game.State.SidebetWinnings += winnings
 		} else {
-			game.State.SidebetLosings += hand.TrifectaWager
+			game.State.SidebetLosses += hand.TrifectaWager
 		}
 	}
 
@@ -339,7 +339,7 @@ func PayTrifecta() {
 			// track our winnings
 			game.State.SidebetWinnings += trifectaWinnings
 		} else {
-			game.State.SidebetLosings += hand.TrifectaWager
+			game.State.SidebetLosses += hand.TrifectaWager
 		}
 	}
 
@@ -370,7 +370,7 @@ func PayTrifecta3() {
 			// track our winnings
 			game.State.SidebetWinnings += trifectaWinnings
 		} else {
-			game.State.SidebetLosings += hand.TrifectaWager
+			game.State.SidebetLosses += hand.TrifectaWager
 		}
 	}
 
@@ -422,7 +422,7 @@ func PayTrifectaStax() {
 			// track our winnings
 			game.State.SidebetWinnings += trifectaWinnings
 		} else {
-			game.State.SidebetLosings += hand.TrifectaWager
+			game.State.SidebetLosses += hand.TrifectaWager
 		}
 	}
 

--- a/go/blackjack/state.out
+++ b/go/blackjack/state.out
@@ -24,7 +24,7 @@ bust-counts:
   13: 0
   14: 0
 sidebet-winnings: 75
-sidebet-losings: 0
+sidebet-losses: 0
 dealer:
   hands:
   - active: true

--- a/go/blackjack/ui/terminal/print.go
+++ b/go/blackjack/ui/terminal/print.go
@@ -287,7 +287,7 @@ func PrintStats(trifectaStax bool) {
 	winPct := float32(game.State.Wins) / float32(utils.Max(hands-state.Pushes, 1)) * 100
 	fmt.Printf(constants.BoldOn+"Round #%d"+constants.BoldOff+"\n\n   Wins | Losses | Pushes\n"+constants.Reset+"     %d | %d | %d\n\n   Hands: %d   Win Pct: %.2f%%\n", state.Rounds, state.Wins, state.Losses, state.Pushes, hands, winPct)
 	if trifectaStax {
-		fmt.Printf("   %s Earnings:  %s\n", PrintGameString(trifectaStax), PrintCurrency((game.State.SidebetWinnings-state.SidebetLosings)*100))
+		fmt.Printf("   %s Earnings:  %s\n", PrintGameString(trifectaStax), PrintCurrency((game.State.SidebetWinnings-state.SidebetLosses)*100))
 	}
 
 	totalNet := 0

--- a/go/blackjack/wasm_main.go
+++ b/go/blackjack/wasm_main.go
@@ -80,7 +80,7 @@ func Start(this js.Value, args []js.Value) any {
 			BustCards:        []cards.Card{},
 			BustCounts:       make(map[cards.CardValue]int),
 			SidebetWinnings:  0,
-			SidebetLosings:   0,
+			SidebetLosses:    0,
 			Players:          make([]player.Player, 0),
 			Dealer:           player.Player{Dealer: true},
 			Rounds:           0,


### PR DESCRIPTION
## Summary
- rename `SidebetLosings` field in `BlackjackState` to `SidebetLosses`
- update all references and YAML tags to `sidebet-losses`
- refresh state serialization sample

## Testing
- `go test ./...` (within `go/blackjack` module)


------
https://chatgpt.com/codex/tasks/task_e_68c71b7efc688330aee922fa4f430a8c