### PR TITLE
fix: allow file upload browse in draggable cards

### DIFF
--- a/src/components/talentforge/FileUploader.tsx
+++ b/src/components/talentforge/FileUploader.tsx
@@ -259,6 +259,7 @@ export default function FileUploader(props: FileUploaderProps) {
               <Button
                 color="primary"
                 variant="outlined"
+                onPointerDown={(e) => e.stopPropagation()}
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
@@ -271,7 +272,7 @@ export default function FileUploader(props: FileUploaderProps) {
                 sx={{ p: 1, zIndex: 1 }}
                 aria-label="browse files"
               >
-                <Box sx={{ p: 1 }}>Browse</Box>
+              <Box sx={{ p: 1 }}>Browse</Box>
               </Button>
               <Box
                 ref={wrapperRef}
@@ -325,6 +326,7 @@ export default function FileUploader(props: FileUploaderProps) {
                         </Box>
                       </Box>
                       <Button
+                        onPointerDown={(e) => e.stopPropagation()}
                         onClick={(e) => {
                           e.stopPropagation();
                           e.preventDefault();


### PR DESCRIPTION
## Summary
- ensure FileUploader buttons stop pointer events from triggering card drag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71bd10d80833095415ab92b80fbc1