### PR TITLE
Add null ref coverage for useDimensions hook

### DIFF
--- a/src/hooks/useDimensions.ts
+++ b/src/hooks/useDimensions.ts
@@ -42,10 +42,14 @@ export function useDimensions(
   const theme = useTheme();
 
   useEffect(() => {
+    if (!ref || !ref.current) {
+      return;
+    }
+
     const getDimensions = (): Dimensions => {
       const dimensions = {
-        width: (ref && ref.current && ref.current.offsetWidth) || 0,
-        height: (ref && ref.current && ref.current.offsetHeight) || 0,
+        width: ref.current?.offsetWidth || 0,
+        height: ref.current?.offsetHeight || 0,
         breakpoint: "xs" as Breakpoint,
       };
 
@@ -72,29 +76,26 @@ export function useDimensions(
 
     let interval: ReturnType<typeof setInterval> | null = null;
 
-    // set the initial dimensions if ref is defined
-    if (ref && ref.current) {
-      const dimensions = getDimensions();
-      setDimensions(dimensions);
+    const dimensions = getDimensions();
+    setDimensions(dimensions);
 
-      if (dimensions.height === 0 || dimensions.width === 0) {
-        // if the element is not visible, or has not rendered content yet,
-        // we need to wait for the element to become visible or render content
-        // before we can get the dimensions
-        interval = setInterval(() => {
-          if (
-            ref.current &&
-            ref.current.offsetHeight > 0 &&
-            ref.current.offsetWidth > 0
-          ) {
-            if (interval) {
-              clearInterval(interval);
-              interval = null;
-            }
-            handleResize();
+    if (dimensions.height === 0 || dimensions.width === 0) {
+      // if the element is not visible, or has not rendered content yet,
+      // we need to wait for the element to become visible or render content
+      // before we can get the dimensions
+      interval = setInterval(() => {
+        if (
+          ref.current &&
+          ref.current.offsetHeight > 0 &&
+          ref.current.offsetWidth > 0
+        ) {
+          if (interval) {
+            clearInterval(interval);
+            interval = null;
           }
-        }, 15);
-      }
+          handleResize();
+        }
+      }, 15);
     }
 
     // update the dimensions on window resize

--- a/src/tests/useDimensions.test.ts
+++ b/src/tests/useDimensions.test.ts
@@ -126,3 +126,46 @@ describe("useDimensions breakpoints", () => {
     );
   });
 });
+
+describe("useDimensions with null ref", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("returns default dimensions without attaching listeners", () => {
+    const addEventListener = jest.fn();
+    const removeEventListener = jest.fn();
+    const g = globalThis as unknown as {
+      window: {
+        addEventListener: typeof addEventListener;
+        removeEventListener: typeof removeEventListener;
+      };
+    };
+    g.window = { addEventListener, removeEventListener };
+    const addEventListenerSpy = jest.spyOn(window, "addEventListener");
+
+    const setSpy = jest.fn();
+    const originalUseState = React.useState;
+    jest.spyOn(React, "useState").mockImplementation((init: unknown) => {
+      if (
+        typeof init === "object" &&
+        init !== null &&
+        "width" in (init as Record<string, unknown>) &&
+        "height" in (init as Record<string, unknown>) &&
+        "breakpoint" in (init as Record<string, unknown>)
+      ) {
+        return [init, setSpy];
+      }
+      return originalUseState(init);
+    });
+
+    jest.spyOn(React, "useEffect").mockImplementation((effect: () => void) => {
+      effect();
+    });
+
+    const dimensions = useDimensions(null as any);
+
+    expect(dimensions).toEqual({ width: 0, height: 0, breakpoint: "xs" });
+    expect(addEventListenerSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- guard useDimensions from registering resize listeners when the ref is null
- test null ref behavior for useDimensions

## Testing
- `npm test src/tests/useDimensions.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c71b8fedd483309cb620b0b25e6a7f