### PR TITLE
test(pdfParser): handle lowercase headers

### DIFF
--- a/src/tests/pdfParser.test.ts
+++ b/src/tests/pdfParser.test.ts
@@ -76,5 +76,17 @@ describe("parseResumeText", () => {
     expect(result.education).toEqual(["University X", "University Y"]);
     expect(result.skills).toEqual(["JavaScript", "TypeScript"]);
   });
+
+  test("parses sections with lowercase headers", () => {
+    const text = `john doe\njohn@example.com\nexperience\ncompany a\neducation\nuniversity x\nskills\njavascript`;
+
+    const result = parseResumeText(text);
+    expect(result).toEqual({
+      contact: "john doe\njohn@example.com",
+      experience: ["company a"],
+      education: ["university x"],
+      skills: ["javascript"],
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- test `parseResumeText` handles lowercase section headers for experience, education, and skills

## Testing
- `npm test`
- `npm test -- src/tests/pdfParser.test.ts -t parseResumeText --testPathIgnorePatterns=`

------
https://chatgpt.com/codex/tasks/task_e_68c726c5e70c833099bb9d9c1a75109e