### PR TITLE
Preserve capitalization for equity notes in offer parser

### DIFF
--- a/src/tests/talentforge/offerParser.test.ts
+++ b/src/tests/talentforge/offerParser.test.ts
@@ -8,7 +8,7 @@ describe("parseOfferText", () => {
       expect.arrayContaining([
         { type: "base", amount: 120000 },
         { type: "bonus", amount: 10000 },
-        { type: "equity", amount: 1000, notes: "RSUS" },
+        { type: "equity", amount: 1000, notes: "RSUs" },
         { type: "start", amount: 0, notes: "June 1, 2024" },
       ]),
     );

--- a/src/utils/talentforge/offerParser.ts
+++ b/src/utils/talentforge/offerParser.ts
@@ -29,7 +29,7 @@ export function parseOfferText(text: string): ParsedOffer {
     comps.push({
       type: "equity",
       amount: extractAmount(equity[1]),
-      notes: equity[2]?.toUpperCase(),
+      notes: equity[2]?.trim(),
     });
   }
 


### PR DESCRIPTION
## Summary
- Keep equity notes capitalization when parsing offers
- Fix unit test to expect `RSUs`

## Testing
- `npm test -- src/tests/talentforge/offerParser.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c726c6babc833081cf198fbede9d9e