### PR TITLE
Refactor job aggregator to use searchJobs

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -277,7 +277,7 @@ export default function ApplicationBoard() {
   useEffect(() => {
     const existing = getJobApplications();
     if (existing.length === 0) {
-      fetchAllListings().then((listings) => {
+      fetchAllListings("").then((listings) => {
         let apps = existing;
         listings.forEach((listing) => {
           apps = addJobApplication({

--- a/src/components/talentforge/JobApplications.tsx
+++ b/src/components/talentforge/JobApplications.tsx
@@ -33,7 +33,7 @@ export default function JobApplications() {
     const existing = getJobApplications();
     if (existing.length === 0) {
       // Seed applications using aggregated listings from connectors
-      fetchAllListings().then((listings) => {
+      fetchAllListings("").then((listings) => {
         let apps = existing;
         listings.forEach((listing) => {
           apps = addJobApplication({

--- a/src/components/talentforge/JobListings.tsx
+++ b/src/components/talentforge/JobListings.tsx
@@ -25,7 +25,7 @@ export default function JobListings() {
   const [saved, setSaved] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    jobAggregator.fetchAllListings().then((results) => {
+    jobAggregator.fetchAllListings("").then((results) => {
       setListings(results);
     });
   }, []);

--- a/src/utils/talentforge/connectors/indeed.ts
+++ b/src/utils/talentforge/connectors/indeed.ts
@@ -44,6 +44,11 @@ export class IndeedConnector {
     return SAMPLE_LISTINGS;
   }
 
+  async searchJobs(query: string): Promise<JobListing[]> {
+    void query;
+    return SAMPLE_LISTINGS;
+  }
+
   /**
    * Send a message through Indeed.
    *

--- a/src/utils/talentforge/connectors/linkedin.ts
+++ b/src/utils/talentforge/connectors/linkedin.ts
@@ -44,6 +44,12 @@ export class LinkedInConnector {
     };
   }
 
+  async searchJobs(query: string): Promise<JobListing[]> {
+    void query;
+    const data = await this.fetchData();
+    return data.listings;
+  }
+
   async sendMessage(message: string): Promise<void> {
     void message; // mock does nothing
   }

--- a/src/utils/talentforge/jobAggregator.ts
+++ b/src/utils/talentforge/jobAggregator.ts
@@ -10,19 +10,18 @@ import { IndeedConnector } from "./connectors/indeed";
  * the {@link JobListing} format, or data that contains such listings. The
  * aggregator normalises these responses into a single array.
  */
-export async function fetchAllListings(): Promise<JobListing[]> {
+export async function fetchAllListings(query: string = ""): Promise<JobListing[]> {
   const linkedin = new LinkedInConnector();
   const indeed = new IndeedConnector();
 
-  // Fetch data from both connectors in parallel.
-  const [linkedinData, indeedListings] = await Promise.all([
-    linkedin.fetchData(),
-    indeed.fetchData(),
+  // Fetch job listings from both connectors in parallel using a job search query.
+  const [linkedinListings, indeedListings] = await Promise.all([
+    linkedin.searchJobs(query),
+    indeed.searchJobs(query),
   ]);
 
-  // LinkedIn returns an object with a `listings` property whereas Indeed
-  // returns the listings array directly. Combine and return them.
-  return [...linkedinData.listings, ...indeedListings];
+  // Both connectors return arrays of listings; combine and return them.
+  return [...linkedinListings, ...indeedListings];
 }
 
 const jobAggregator = {


### PR DESCRIPTION
## Summary
- Aggregate job listings by calling each connector's `searchJobs` with an optional query
- Expose `searchJobs` on mocked LinkedIn and Indeed connectors
- Update TalentForge components to supply a query string when fetching listings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c726c9b6d08330aae64b11049baf96