### PR TITLE
Enable offer letter upload to trigger analysis

### DIFF
--- a/src/components/bookworm/FileUploader.tsx
+++ b/src/components/bookworm/FileUploader.tsx
@@ -140,6 +140,18 @@ export default function FileUploader(props: FileUploaderProps) {
           } else if (variant === "dataUri") {
             reader.readAsDataURL(file);
           }
+        } else if (validFiles && validFiles.length > 0) {
+          onChange?.(
+            outputType === "files"
+              ? validFiles
+              : outputType === "content"
+              ? ""
+              : {
+                  filename: validFiles[0]?.name || "",
+                  type: validFiles[0]?.type || "",
+                  content: "",
+                }
+          );
         }
         // field.onChange(validFiles);
       }

--- a/src/components/talentforge/FileUploader.tsx
+++ b/src/components/talentforge/FileUploader.tsx
@@ -140,6 +140,18 @@ export default function FileUploader(props: FileUploaderProps) {
           } else if (variant === "dataUri") {
             reader.readAsDataURL(file);
           }
+        } else if (validFiles && validFiles.length > 0) {
+          onChange?.(
+            outputType === "files"
+              ? validFiles
+              : outputType === "content"
+              ? ""
+              : {
+                  filename: validFiles[0]?.name || "",
+                  type: validFiles[0]?.type || "",
+                  content: "",
+                }
+          );
         }
         // field.onChange(validFiles);
       }


### PR DESCRIPTION
## Summary
- trigger FileUploader onChange for non-text variants so offer analysis starts after upload
- mirror fix in bookworm FileUploader

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c72c37842083309ab3cdea70330bba