### PR TITLE
docs: clarify connector token usage

### DIFF
--- a/docs/talentforge.md
+++ b/docs/talentforge.md
@@ -24,11 +24,11 @@ TalentForge uses TypeScript interfaces to describe core entities:
 
 ## Connector Architecture
 
-Connectors abstract external services behind a common interface defined in `src/types/connector.ts`. Each connector implements:
+Connectors abstract external services behind a common interface defined in `src/types/connector.ts`. Each method accepts a `ConnectorToken` representing the authenticated account and implements:
 
-- `authenticate()` – prepare access to the service.
-- `fetchData()` – retrieve data such as profiles or job listings.
-- `sendMessage(message)` – deliver outbound messages.
+- `authenticate(token)` – prepare access to the service.
+- `fetchData(token)` – retrieve data such as profiles or job listings.
+- `sendMessage(token, message)` – deliver outbound messages; the token identifies the connector account.
 
 The repository includes mocked connectors for LinkedIn and Indeed in `src/utils/talentforge/connectors/` that return sample data so the application can run without live API access. Additional connectors can follow the same pattern.
 


### PR DESCRIPTION
## Summary
- specify that connector methods take a `ConnectorToken`
- document `sendMessage(token, message)` and its token purpose

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c72d513c1083309e39c80f0fd7441d