### PR TITLE
feat: parse offer letters as structured data

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -19,6 +19,9 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  List,
+  ListItem,
+  ListItemText,
 } from "@mui/material";
 import { Close, ExpandMore } from "@mui/icons-material";
 import { v4 as uuid } from "uuid";
@@ -238,9 +241,16 @@ function Card({
             </Stack>
           )}
           {app.offer?.summary && (
-            <Box sx={{ mt: 1 }}>
-              <Markdown>{app.offer.summary}</Markdown>
-            </Box>
+            <List dense sx={{ mt: 1, listStyleType: "disc", pl: 2 }}>
+              {app.offer.summary.map((line, idx) => (
+                <ListItem key={idx} sx={{ display: "list-item", py: 0 }}>
+                  <ListItemText
+                    primary={line}
+                    primaryTypographyProps={{ variant: "body2" }}
+                  />
+                </ListItem>
+              ))}
+            </List>
           )}
         </Box>
       )}
@@ -263,7 +273,11 @@ export default function ApplicationBoard() {
   const [drawerPrompt, setDrawerPrompt] = useState("");
   const [drawerLoading, setDrawerLoading] = useState(false);
   const [drawerMessages, setDrawerMessages] = useState<
-    { role: "user" | "assistant"; text: string }[]
+    {
+      role: "user" | "assistant";
+      text?: string;
+      data?: { compensation?: OfferComp[]; summary?: string[] };
+    }[]
   >([]);
   const [drawerAnalysis, setDrawerAnalysis] = useState<Analysis | null>(null);
   const [drawerMode, setDrawerMode] = useState<
@@ -483,27 +497,32 @@ export default function ApplicationBoard() {
         chatHistory: [],
       });
       const message = res?.message || "";
-      let parsed: { compensation?: OfferComp[]; summary?: string } = {};
+      let parsed: { compensation?: OfferComp[]; summary?: string[] | string } = {};
       try {
         parsed = JSON.parse(message);
       } catch {
         parsed.summary = message;
       }
-      const bulletSummary = (parsed.summary || "")
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean)
-        .map((line) => (line.startsWith("-") ? line : `- ${line}`))
-        .join("\n");
+      const summaryLines = Array.isArray(parsed.summary)
+        ? parsed.summary
+        : (parsed.summary || "")
+            .split(/\r?\n/)
+            .map((line) => line.replace(/^\-\s*/, "").trim())
+            .filter(Boolean);
       const offer: Offer = {
         id: uuid(),
         application: drawerApp,
         compensation: parsed.compensation || [],
-        summary: bulletSummary,
+        summary: summaryLines,
       };
       const updated = updateJobApplication(drawerApp.id, { offer });
       setApplications(updated);
-      setDrawerMessages([{ role: "assistant", text: bulletSummary }]);
+      setDrawerMessages([
+        {
+          role: "assistant",
+          data: { compensation: offer.compensation, summary: offer.summary },
+        },
+      ]);
     } finally {
       setDrawerLoading(false);
     }
@@ -751,7 +770,34 @@ export default function ApplicationBoard() {
                     maxWidth: "100%",
                   }}
                 >
-                  <Markdown>{m.text}</Markdown>
+                  {m.text ? (
+                    <Markdown>{m.text}</Markdown>
+                  ) : m.data ? (
+                    <>
+                      {m.data.compensation && m.data.compensation.length > 0 && (
+                        <Stack spacing={0.5}>
+                          {m.data.compensation.map((c) => (
+                            <Typography key={c.type} variant="body2">
+                              {c.type.charAt(0).toUpperCase() + c.type.slice(1)}: {"$"}
+                              {c.amount.toLocaleString()} {c.notes ? `(${c.notes})` : ""}
+                            </Typography>
+                          ))}
+                        </Stack>
+                      )}
+                      {m.data.summary && (
+                        <List dense sx={{ mt: 1, listStyleType: "disc", pl: 2 }}>
+                          {m.data.summary.map((line, i) => (
+                            <ListItem key={i} sx={{ display: "list-item", py: 0 }}>
+                              <ListItemText
+                                primary={line}
+                                primaryTypographyProps={{ variant: "body2" }}
+                              />
+                            </ListItem>
+                          ))}
+                        </List>
+                      )}
+                    </>
+                  ) : null}
                 </Box>
               ))}
               {drawerMode === "resumeCompare" && !drawerLoading && (

--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -96,12 +96,12 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
         id: uuid(),
         application: {} as ApplicationRecord,
         compensation: [{ type: "note", amount: 0, notes: compensation }],
-        summary:
-          `**Analysis:**\n${parsed.analysis || ""}\n\n**Email Draft:**\n${
-            parsed.email || ""
-          }\n\n**LinkedIn Draft:**\n${parsed.linkedin || ""}\n\n**Indeed Draft:**\n${
-            parsed.indeed || ""
-          }`,
+        summary: [
+          `Analysis: ${parsed.analysis || ""}`,
+          `Email Draft: ${parsed.email || ""}`,
+          `LinkedIn Draft: ${parsed.linkedin || ""}`,
+          `Indeed Draft: ${parsed.indeed || ""}`,
+        ],
       };
       addOffer(offer);
     } catch {
@@ -111,7 +111,7 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
         id: uuid(),
         application: {} as ApplicationRecord,
         compensation: [{ type: "note", amount: 0, notes: compensation }],
-        summary: message,
+        summary: [message],
       };
       addOffer(offer);
     }

--- a/src/components/talentforge/Offers/OfferDetail.tsx
+++ b/src/components/talentforge/Offers/OfferDetail.tsx
@@ -31,11 +31,13 @@ export default function OfferDetail({ offer, onSave }: OfferDetailProps) {
   const [compensation, setCompensation] = useState<OfferComp[]>(
     offer?.compensation ?? defaultComp,
   );
-  const [summary, setSummary] = useState(offer?.summary || "");
+  const [summary, setSummary] = useState(
+    offer?.summary?.join("\n") || "",
+  );
 
   useEffect(() => {
     setCompensation(offer?.compensation ?? defaultComp);
-    setSummary(offer?.summary || "");
+    setSummary(offer?.summary?.join("\n") || "");
   }, [offer]);
 
   const handleCompChange = (
@@ -68,7 +70,10 @@ export default function OfferDetail({ offer, onSave }: OfferDetailProps) {
       id: offer?.id || uuid(),
       application: offer?.application || ({} as ApplicationRecord),
       compensation: filtered,
-      summary,
+      summary: summary
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean),
     };
 
     if (offer) {

--- a/src/components/talentforge/Offers/OfferList.tsx
+++ b/src/components/talentforge/Offers/OfferList.tsx
@@ -125,7 +125,7 @@ export default function OfferList({ refreshKey, onSelect }: OfferListProps) {
               <ListItemText
                 primary={`Offer ${index + 1}`}
                 secondary={
-                  offer.summary ||
+                  offer.summary?.join(", ") ||
                   offer.compensation
                     .map((c) => `${c.type}: ${c.amount}`)
                     .join(", ")

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -124,7 +124,12 @@ export default function Tile({
           id: uuid(),
           application: {} as ApplicationRecord,
           compensation: [],
-          summary: message,
+          summary: [
+            ...message
+              .split(/\r?\n/)
+              .map((s) => s.trim())
+              .filter(Boolean),
+          ],
         };
         addOffer(offer);
         onResponse?.(message);

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -80,7 +80,7 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
     id: "offerDetails",
     display: "Offer Letter",
     fullPrompt:
-      "Extract base salary, bonus, equity, start date, and other key details from the following offer letter. Respond in JSON with keys compensation (array of {type:string, amount:number, notes?:string}) and summary (markdown bullet list).\n\n{{offerText}}",
+      "Extract base salary, bonus, equity, start date, and other key details from the following offer letter. Return ONLY valid JSON with keys compensation (array of {type:string, amount:number, notes?:string}) and summary (array of strings). Do not include any text outside the JSON.\n\n{{offerText}}",
     inputs: ["offerText"],
   },
   screenRole: {

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -127,7 +127,7 @@ export interface Offer {
   /** Compensation components that make up the offer. */
   compensation: OfferComp[];
   /** Optional summary or notes about the offer. */
-  summary?: string;
+  summary?: string[];
 }
 
 export interface OfferComp {

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -295,7 +295,7 @@ function migrateLegacyOffers(data: unknown): Offer[] {
     compensation: [
       { type: "note", amount: 0, notes: o.compensation } as OfferComp,
     ],
-    summary: o.result,
+    summary: o.result ? [o.result] : [],
   }));
 }
 


### PR DESCRIPTION
## Summary
- require offer letter prompts to return pure JSON
- store offer summaries as string arrays and render with MUI lists
- display parsed compensation and summary lines in ApplicationBoard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c72e41fa9c83309f6e01abb77ef231