### PR TITLE
Fix mock offer summary type mismatch

### DIFF
--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -80,13 +80,13 @@ export const mockOffers: Offer[] = [
     id: "offer-1",
     application: mockApplications[0],
     compensation: [{ type: "base", amount: 120000 } as OfferComp],
-    summary: "Offer details for job application app-1",
+    summary: ["Offer details for job application app-1"],
   },
   {
     id: "offer-2",
     application: mockApplications[1],
     compensation: [{ type: "base", amount: 135000 } as OfferComp],
-    summary: "Offer details for job application app-2",
+    summary: ["Offer details for job application app-2"],
   },
 ];
 


### PR DESCRIPTION
## Summary
- Update mockOffers to use string arrays for `summary`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c72ffadfac833090d6a4c2c1fd86dc