### PR TITLE
fix: use consistent base pair labels

### DIFF
--- a/src/components/dna/charts/BasepairHistogram.tsx
+++ b/src/components/dna/charts/BasepairHistogram.tsx
@@ -98,7 +98,7 @@ export function BasepairHistogram(props: BasepairHistogramProps) {
               key={`${seq.description}-${index}`}
               dataKey={seq.description}
               fill={getSequenceColor(index)}
-              label={"# of basepairs"}
+              label={"# of base pairs"}
             />
           ))}
         </BarChart>

--- a/src/components/dna/charts/GatesChart.tsx
+++ b/src/components/dna/charts/GatesChart.tsx
@@ -71,7 +71,7 @@ export function GatesChart({ sequences = [], bpRange }: GatesChartProps) {
               ...theme.typography.body1,
             }}
           >
-            # of basepairs
+            # of base pairs
           </Label>
         </XAxis>
         <YAxis
@@ -100,7 +100,7 @@ export function GatesChart({ sequences = [], bpRange }: GatesChartProps) {
             }  (${value})`;
           }}
           labelFormatter={(label) =>
-            `basepair #${Math.ceil(label) + 1}`
+            `base pair #${Math.ceil(label) + 1}`
           }
         />
         {sequences?.map((sequence, index) => (

--- a/src/components/dna/charts/QiChart.tsx
+++ b/src/components/dna/charts/QiChart.tsx
@@ -71,7 +71,7 @@ export function QiChart({ sequences = [], bpRange }: QiChartProps) {
               ...theme.typography.body1,
             }}
           >
-            # of basepairs
+            # of base pairs
           </Label>
         </XAxis>
         <YAxis
@@ -102,7 +102,7 @@ export function QiChart({ sequences = [], bpRange }: QiChartProps) {
             }  (${value})`;
           }}
           labelFormatter={(label) =>
-            `basepair #${Math.ceil(label) + 1}`
+            `base pair #${Math.ceil(label) + 1}`
           }
         />
         {sequences?.map((sequence, index) => (

--- a/src/components/dna/charts/RandicChart.tsx
+++ b/src/components/dna/charts/RandicChart.tsx
@@ -71,7 +71,7 @@ export function RandicChart({ sequences = [], bpRange }: RandicChartProps) {
               ...theme.typography.body1,
             }}
           >
-            # of basepairs
+            # of base pairs
           </Label>
         </XAxis>
         <YAxis
@@ -102,7 +102,7 @@ export function RandicChart({ sequences = [], bpRange }: RandicChartProps) {
             }  (${value})`;
           }}
           labelFormatter={(label) =>
-            `basepair #${Math.ceil(label) + 1}`
+            `base pair #${Math.ceil(label) + 1}`
           }
         />
         {sequences?.map((sequence, index) => (

--- a/src/components/dna/charts/SquiggleChart.tsx
+++ b/src/components/dna/charts/SquiggleChart.tsx
@@ -71,7 +71,7 @@ export function SquiggleChart({ sequences = [], bpRange }: SquiggleChartProps) {
               ...theme.typography.body1,
             }}
           >
-            # of basepairs
+            # of base pairs
           </Label>
         </XAxis>
         <YAxis
@@ -99,7 +99,7 @@ export function SquiggleChart({ sequences = [], bpRange }: SquiggleChartProps) {
               ]
             }  (${value})`;
           }}
-          labelFormatter={(label) => `basepair #${Math.ceil(label) + 1}`}
+          labelFormatter={(label) => `base pair #${Math.ceil(label) + 1}`}
         />
         {sequences?.map((sequence, index) => (
           <Line


### PR DESCRIPTION
## Summary
- update DNA charts to say "base pairs" instead of "basepairs"
- update chart tooltips to show `base pair #${...}`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c77113bb64833096c87c2046f6a211