### PR TITLE
feat: add offer negotiation tile

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -241,16 +241,28 @@ function Card({
             </Stack>
           )}
           {app.offer?.summary && (
-            <List dense sx={{ mt: 1, listStyleType: "disc", pl: 2 }}>
-              {app.offer.summary.map((line, idx) => (
-                <ListItem key={idx} sx={{ display: "list-item", py: 0 }}>
-                  <ListItemText
-                    primary={line}
-                    primaryTypographyProps={{ variant: "body2" }}
-                  />
-                </ListItem>
-              ))}
-            </List>
+            <>
+              <List dense sx={{ mt: 1, listStyleType: "disc", pl: 2 }}>
+                {app.offer.summary.map((line, idx) => (
+                  <ListItem key={idx} sx={{ display: "list-item", py: 0 }}>
+                    <ListItemText
+                      primary={line}
+                      primaryTypographyProps={{ variant: "body2" }}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+              <Button
+                size="small"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={() => onRunTile("offerNegotiation", app)}
+                variant="outlined"
+                fullWidth
+                sx={{ mt: 1 }}
+              >
+                Negotiate Offer
+              </Button>
+            </>
           )}
         </Box>
       )}
@@ -385,6 +397,60 @@ export default function ApplicationBoard() {
       setDrawerOpen(true);
       setDrawerMode("offerUpload");
       setDrawerApp(app);
+      return;
+    }
+    if (tileId === "offerNegotiation") {
+      setDrawerTitle(tile.display);
+      setDrawerTileId(tile.id);
+      setDrawerMessages([
+        { role: "assistant", text: "Gathering market data..." },
+      ]);
+      setDrawerAnalysis(null);
+      setDrawerOpen(true);
+      setDrawerApp(app);
+      const resume: ResumeEntry | undefined = app.resumeVariant
+        ? getResumes().find((r) => r.id === app.resumeVariant?.id)
+        : getResumes()[0];
+      const offerLines: string[] = [];
+      app.offer?.compensation.forEach((c) =>
+        offerLines.push(
+          `${c.type}: $${c.amount.toLocaleString()}${c.notes ? ` (${c.notes})` : ""}`,
+        ),
+      );
+      app.offer?.summary.forEach((s) => offerLines.push(s));
+      const offerSummary = offerLines.join("\n");
+      const listings = await fetchAllListings(app.role.title);
+      const marketData = listings
+        .map((l) => `${l.title} at ${l.company} – ${l.location}`)
+        .join("\n");
+      const prompt = tile.fullPrompt
+        .replaceAll("{{jobDescription}}", app.role.description || "")
+        .replaceAll("{{resumeContent}}", resume?.content || "")
+        .replaceAll("{{offerSummary}}", offerSummary)
+        .replaceAll("{{marketData}}", marketData);
+      setDrawerPrompt(prompt);
+      setDrawerMessages((prev) => [
+        ...prev,
+        { role: "assistant", text: "Generating negotiation..." },
+        { role: "user", text: prompt },
+      ]);
+      setDrawerLoading(true);
+      try {
+        const res = await askOpenAI({
+          context: "",
+          user: prompt,
+          system: "You are a helpful assistant.",
+          returnFirstResponse: true,
+          chatHistory: [],
+        });
+        const message = res?.message || "";
+        setDrawerMessages((prev) => [
+          ...prev,
+          { role: "assistant", text: message },
+        ]);
+      } finally {
+        setDrawerLoading(false);
+      }
       return;
     }
     setDrawerTitle(tile.display);

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -83,6 +83,18 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Extract base salary, bonus, equity, start date, and other key details from the following offer letter. Return ONLY valid JSON with keys compensation (array of {type:string, amount:number, notes?:string}) and summary (array of strings). Do not include any text outside the JSON.\n\n{{offerText}}",
     inputs: ["offerText"],
   },
+  offerNegotiation: {
+    id: "offerNegotiation",
+    display: "Negotiate Offer",
+    fullPrompt:
+      "Using the job description, resume, current offer summary, and recent market job listings, craft a persuasive counteroffer in the candidate's favor. Reference the resume and market data to justify improved compensation. Provide only the negotiation message.\n\nJob Description:\n{{jobDescription}}\n\nResume:\n{{resumeContent}}\n\nCurrent Offer:\n{{offerSummary}}\n\nMarket Data:\n{{marketData}}",
+    inputs: [
+      "jobDescription",
+      "resumeContent",
+      "offerSummary",
+      "marketData",
+    ],
+  },
   screenRole: {
     ...BASE_TILES.screenRole,
     fullPrompt:


### PR DESCRIPTION
## Summary
- add `offerNegotiation` prompt tile for counter-offer generation
- show Negotiate Offer button after parsed offer details in ApplicationBoard
- fetch resume, JD, offer summary, and market listings to build negotiation prompt

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c77100f5d48330a27e99f09e0904d4