### PR TITLE
Remove debugger statements from DNA charts

### DIFF
--- a/src/components/dna/charts/QiChart.tsx
+++ b/src/components/dna/charts/QiChart.tsx
@@ -93,8 +93,6 @@ export function QiChart({ sequences = [], bpRange }: QiChartProps) {
         </YAxis>
         <Tooltip
           formatter={function (value, name, index) {
-            debugger;
-
             return `${
               sequences?.find((seq) => seq.description === name)?.sequence[
                 Math.ceil(index?.payload?.x)

--- a/src/components/dna/charts/RandicChart.tsx
+++ b/src/components/dna/charts/RandicChart.tsx
@@ -93,8 +93,6 @@ export function RandicChart({ sequences = [], bpRange }: RandicChartProps) {
         </YAxis>
         <Tooltip
           formatter={function (value, name, index) {
-            debugger;
-
             return `${
               sequences?.find((seq) => seq.description === name)?.sequence[
                 Math.ceil(index?.payload?.x)


### PR DESCRIPTION
## Summary
- remove leftover `debugger` calls from DNA chart tooltips

## Testing
- `npm test`
- `npm run lint -- src/components/dna/charts/RandicChart.tsx src/components/dna/charts/QiChart.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c7712a0c348330b913b3dd307e35e9