### PR TITLE
feat: collect current compensation during onboarding

### DIFF
--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -12,12 +12,14 @@ import {
 import KeyEntryStep from "./onboarding/KeyEntryStep";
 import ResumeImportStep from "./onboarding/ResumeImportStep";
 import ConnectorMockStep from "./onboarding/ConnectorMockStep";
+import CompensationStep from "./onboarding/CompensationStep";
 import GoalSelectionStep from "./onboarding/GoalSelectionStep";
 
 const steps = [
   { label: "Enter API Key", Component: KeyEntryStep },
   { label: "Import Resume", Component: ResumeImportStep },
   { label: "Connect Accounts", Component: ConnectorMockStep },
+  { label: "Enter Compensation", Component: CompensationStep },
   { label: "Select Goals", Component: GoalSelectionStep },
 ];
 

--- a/src/components/talentforge/onboarding/CompensationStep.tsx
+++ b/src/components/talentforge/onboarding/CompensationStep.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { Button, Stack, TextField, Typography } from "@mui/material";
+
+interface StepProps {
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+export default function CompensationStep({ onNext, onBack }: StepProps) {
+  const [comp, setComp] = useState({
+    salary: "",
+    benefits: "",
+    stock: "",
+  });
+
+  const handleChange = (field: "salary" | "benefits" | "stock") => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setComp((c) => ({ ...c, [field]: event.target.value }));
+  };
+
+  const hasValue = Object.values(comp).some((v) => v.trim() !== "");
+
+  return (
+    <Stack spacing={2} aria-label="Enter current compensation">
+      <Typography variant="body2" tabIndex={0}>
+        This information is only used to negotiate better offers on your
+        behalf and compare them against your current compensation.
+      </Typography>
+      <TextField
+        label="Current Salary"
+        value={comp.salary}
+        onChange={handleChange("salary")}
+        inputProps={{ "aria-label": "Current salary" }}
+      />
+      <TextField
+        label="Benefits"
+        value={comp.benefits}
+        onChange={handleChange("benefits")}
+        inputProps={{ "aria-label": "Benefits" }}
+      />
+      <TextField
+        label="Stock Options / RSUs"
+        value={comp.stock}
+        onChange={handleChange("stock")}
+        inputProps={{ "aria-label": "Stock options and RSUs" }}
+      />
+      <Stack direction="row" spacing={1}>
+        {onBack && (
+          <Button onClick={onBack} aria-label="Back">
+            Back
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          onClick={onNext}
+          disabled={!hasValue}
+          aria-label="Next"
+        >
+          Next
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add compensation step asking for salary, benefits, and stock options
- include message explaining data use
- integrate compensation step into onboarding flow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c77c21c1a08330b0fde0de449797ce