### PR TITLE
chore: capitalize GitHub in resume skills

### DIFF
--- a/src/consts/resumeData.ts
+++ b/src/consts/resumeData.ts
@@ -105,7 +105,7 @@ export const competencies = {
     "IntelliJ IDEA",
     "Eclipse",
     "Maven",
-    "Github",
+    "GitHub",
     "UML",
     "Windows",
     "Mac OS X",


### PR DESCRIPTION
## Summary
- fix capitalization of GitHub in resume data skills array

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c77c34a5208330b8f06c07a4ee7f61