### PR TITLE
Hide renegotiation prompt behind accordion

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -261,7 +261,7 @@ function Card({
                 fullWidth
                 sx={{ mt: 1 }}
               >
-                Renegotiate Offer
+                {PROMPT_TILES.offerNegotiation.display}
               </Button>
             </>
           )}
@@ -434,7 +434,6 @@ export default function ApplicationBoard() {
       setDrawerMessages((prev) => [
         ...prev,
         { role: "assistant", text: "Generating negotiation..." },
-        { role: "user", text: prompt },
       ]);
       setDrawerLoading(true);
       try {
@@ -797,7 +796,7 @@ export default function ApplicationBoard() {
           >
             <Close />
           </IconButton>
-          {drawerTileId === "screenRole" ? (
+          {drawerTileId === "screenRole" || drawerTileId === "offerNegotiation" ? (
             <Accordion sx={{ mb: 2 }}>
               <AccordionSummary expandIcon={<ExpandMore />}>
                 <Typography variant="h6">{drawerTitle}</Typography>

--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -85,7 +85,7 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
   },
   offerNegotiation: {
     id: "offerNegotiation",
-    display: "Renegotiate Offer",
+    display: "Renegotiation Offer",
     fullPrompt:
       "Using the job description, resume, current offer summary, and recent market job listings, craft a persuasive counteroffer in the candidate's favor. Reference the resume and market data to justify improved compensation. Provide only the negotiation message.\n\nJob Description:\n{{jobDescription}}\n\nResume:\n{{resumeContent}}\n\nCurrent Offer:\n{{offerSummary}}\n\nMarket Data:\n{{marketData}}",
     inputs: [


### PR DESCRIPTION
## Summary
- Rename renegotiation tile and conceal its full prompt behind an accordion
- Prevent renegotiation prompt text from appearing in ApplicationBoard drawer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c77f0788a48330913fe4d574d212de