### PR TITLE
Handle malformed mermaid timeline lines

### DIFF
--- a/src/components/showcase/Timeline/Timeline.test.tsx
+++ b/src/components/showcase/Timeline/Timeline.test.tsx
@@ -103,7 +103,7 @@ describe("Timeline component", () => {
       timeline
       05/16 12∶30 : Event A: Detail A : notes : 123
       05/16 13∶00:Event B:Detail B : testResults : 123
-      05/16 14∶00 : Event C : labs : 123
+      05/16 14∶00 : Event C: Detail C : labs : 123
     `;
 
     it("overrides events with parsed mermaid lines", () => {
@@ -119,15 +119,33 @@ describe("Timeline component", () => {
 
       expect(screen.getByText("05/16 14∶00")).toBeInTheDocument();
       expect(screen.getByText("Event C")).toBeInTheDocument();
+      expect(screen.getByText("Detail C")).toBeInTheDocument();
     });
 
     it("respects reverseOrder for mermaid", () => {
       renderWithTheme(
         <Timeline mermaid={mermaid} reverseOrder alignment="right" />,
       );
-      // first title now the bad line
+      // first title now the last line
       const titles = screen.getAllByText(/Event A|Event B|Event C/);
       expect(titles[0].textContent).toBe("Event C");
+    });
+
+    it("ignores malformed lines", () => {
+      const badMermaid = `
+        timeline
+        05/16 12∶30 : Good: Detail : notes : 123
+        05/16 13∶00 : MissingParts
+        05/16 14∶00 : Also : missing : id
+      `;
+      const { container } = renderWithTheme(
+        <Timeline mermaid={badMermaid} />,
+      );
+      // Only the well-formed line should render
+      expect(container.querySelectorAll(".MuiTimelineItem-root")).toHaveLength(1);
+      expect(screen.getByText("Good")).toBeInTheDocument();
+      expect(screen.queryByText("MissingParts")).not.toBeInTheDocument();
+      expect(screen.queryByText("Also")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/showcase/Timeline/index.tsx
+++ b/src/components/showcase/Timeline/index.tsx
@@ -74,15 +74,29 @@ const Timeline: React.FC<TimelineProps> = ({
       .map((line) => {
         // format is expected to be one of "<dateTime>: <title>: <detail>: <category>: <id>"
         // but detail could contain colons, so we need to handle that
-        const rawTime = line.slice(0, line.indexOf(":")).trim();
-        line = line.slice(line.indexOf(":") + 1);
-        const title = line.slice(0, line.indexOf(":")).trim();
-        line = line.slice(line.indexOf(":") + 1);
-        const id = line.slice(line.lastIndexOf(":") + 1).trim();
-        line = line.slice(0, line.lastIndexOf(":"));
-        const category = line.slice(line.lastIndexOf(":") + 1).trim();
-        line = line.slice(0, line.lastIndexOf(":"));
-        const detail = line.trim();
+        let working = line;
+
+        const firstColon = working.indexOf(":");
+        if (firstColon === -1) return null;
+        const rawTime = working.slice(0, firstColon).trim();
+        working = working.slice(firstColon + 1);
+
+        const secondColon = working.indexOf(":");
+        if (secondColon === -1) return null;
+        const title = working.slice(0, secondColon).trim();
+        working = working.slice(secondColon + 1);
+
+        const lastColon = working.lastIndexOf(":");
+        if (lastColon === -1) return null;
+        const id = working.slice(lastColon + 1).trim();
+        working = working.slice(0, lastColon);
+
+        const penultimateColon = working.lastIndexOf(":");
+        if (penultimateColon === -1) return null;
+        const category = working.slice(penultimateColon + 1).trim();
+        working = working.slice(0, penultimateColon);
+
+        const detail = working.trim();
 
         return {
           label: rawTime,
@@ -105,7 +119,8 @@ const Timeline: React.FC<TimelineProps> = ({
             }
           },
         };
-      });
+      })
+      .filter((e): e is TimelineEvent => e !== null);
   }, [mermaid, events]);
 
   // if reverseOrder is true, reverse the order of events


### PR DESCRIPTION
## Summary
- guard mermaid timeline parsing by checking for required colons and skipping malformed lines
- add tests for mermaid parsing and malformed line handling

## Testing
- `npm test`
- `npx jest --testMatch '**/src/components/showcase/Timeline/Timeline.test.tsx'` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68c77f2363548330a7eb3f029ecaad5a