### PR TITLE
feat: allow updating compensation in settings

### DIFF
--- a/src/components/talentforge/Settings.tsx
+++ b/src/components/talentforge/Settings.tsx
@@ -10,6 +10,7 @@ import {
   ListItem,
   ListItemText,
   Stack,
+  TextField,
   Typography,
 } from "@mui/material";
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
@@ -22,10 +23,16 @@ export default function Settings() {
   const dataStore = useTalentForgeData();
   const [openKeyModal, setOpenKeyModal] = React.useState(false);
   const [openAiKeySet, setOpenAiKeySet] = React.useState(false);
+  const [comp, setComp] = React.useState({
+    salary: "",
+    benefits: "",
+    stock: "",
+  });
 
   React.useEffect(() => {
     setOpenAiKeySet(hasOpenAIKey());
-  }, []);
+    setComp(dataStore.getCurrentCompensation());
+  }, [dataStore]);
 
   const handleRemoveKey = () => {
     setOpenAIKey("");
@@ -73,6 +80,15 @@ export default function Settings() {
     clearDemoData();
   };
 
+  const handleCompChange = (field: "salary" | "benefits" | "stock") =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setComp((c) => ({ ...c, [field]: e.target.value }));
+    };
+  const handleSaveComp = () => {
+    dataStore.saveCurrentCompensation(comp);
+  };
+  const compHasValue = Object.values(comp).some((v) => v.trim() !== "");
+
   return (
     <ErrorBoundary>
       <Stack spacing={4}>
@@ -90,6 +106,42 @@ export default function Settings() {
               {openAiKeySet ? "Update Key" : "Set Key"}
             </Button>
             {openAiKeySet && <Button onClick={handleRemoveKey}>Remove Key</Button>}
+          </CardActions>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              Current Compensation
+            </Typography>
+            <Stack spacing={2} aria-label="Update current compensation">
+              <Typography variant="body2" color="text.secondary">
+                This information is only used to negotiate better offers on your behalf and compare them against your current compensation.
+              </Typography>
+              <TextField
+                label="Current Salary"
+                value={comp.salary}
+                onChange={handleCompChange("salary")}
+                inputProps={{ "aria-label": "Current salary" }}
+              />
+              <TextField
+                label="Benefits"
+                value={comp.benefits}
+                onChange={handleCompChange("benefits")}
+                inputProps={{ "aria-label": "Benefits" }}
+              />
+              <TextField
+                label="Stock Options / RSUs"
+                value={comp.stock}
+                onChange={handleCompChange("stock")}
+                inputProps={{ "aria-label": "Stock options and RSUs" }}
+              />
+            </Stack>
+          </CardContent>
+          <CardActions>
+            <Button variant="contained" onClick={handleSaveComp} disabled={!compHasValue}>
+              Save
+            </Button>
           </CardActions>
         </Card>
 

--- a/src/components/talentforge/onboarding/CompensationStep.tsx
+++ b/src/components/talentforge/onboarding/CompensationStep.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
+import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 
 interface StepProps {
   onNext: () => void;
@@ -9,11 +10,17 @@ interface StepProps {
 }
 
 export default function CompensationStep({ onNext, onBack }: StepProps) {
+  const dataStore = useTalentForgeData();
   const [comp, setComp] = useState({
     salary: "",
     benefits: "",
     stock: "",
   });
+
+  useEffect(() => {
+    const existing = dataStore.getCurrentCompensation();
+    setComp(existing);
+  }, [dataStore]);
 
   const handleChange = (field: "salary" | "benefits" | "stock") => (
     event: React.ChangeEvent<HTMLInputElement>
@@ -55,7 +62,10 @@ export default function CompensationStep({ onNext, onBack }: StepProps) {
         )}
         <Button
           variant="contained"
-          onClick={onNext}
+        onClick={() => {
+          dataStore.saveCurrentCompensation(comp);
+          onNext();
+        }}
           disabled={!hasValue}
           aria-label="Next"
         >

--- a/src/tests/talentforge/dataStore.test.ts
+++ b/src/tests/talentforge/dataStore.test.ts
@@ -1,4 +1,11 @@
-import { importFromJson, MESSAGES_VERSION, OFFERS_VERSION, APPLICATIONS_VERSION } from "../../utils/talentforge/dataStore";
+import {
+  importFromJson,
+  MESSAGES_VERSION,
+  OFFERS_VERSION,
+  APPLICATIONS_VERSION,
+  getCurrentCompensation,
+  saveCurrentCompensation,
+} from "../../utils/talentforge/dataStore";
 import { loadItem } from "../../utils/storage";
 
 interface Message {
@@ -92,5 +99,11 @@ describe("dataStore migrations", () => {
   test("importFromJson ignores malformed json", () => {
     expect(() => importFromJson("{invalid")).not.toThrow();
     expect(localStorage.length).toBe(0);
+  });
+
+  test("current compensation save and load", () => {
+    const comp = { salary: "100k", benefits: "health", stock: "50" };
+    saveCurrentCompensation(comp);
+    expect(getCurrentCompensation()).toEqual(comp);
   });
 });

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -56,6 +56,12 @@ export type RecruiterEntry = Recruiter & {
   threadIds: string[];
 };
 
+export interface CurrentCompensation {
+  salary: string;
+  benefits: string;
+  stock: string;
+}
+
 interface StoreSchema {
   user: UserProfile | undefined;
   resumes: ResumeEntry[];
@@ -67,6 +73,7 @@ interface StoreSchema {
   openai: string | undefined;
   connectorTokens: Record<string, ConnectorToken>;
   autoReplyTemplates: Record<string, string>;
+  currentCompensation: CurrentCompensation;
 }
 
 // Storage keys for each entity
@@ -81,6 +88,7 @@ const KEYS: { [K in keyof StoreSchema]: string } = {
   openai: "talentforge-openai-key",
   connectorTokens: "connectorTokens",
   autoReplyTemplates: "autoReplyTemplates",
+  currentCompensation: "currentCompensation",
 } as const;
 
 // Version constants per entity so tests and other modules can reference them.
@@ -94,6 +102,7 @@ export const ONBOARDING_VERSION = 1;
 export const OPENAI_VERSION = 1;
 export const CONNECTOR_TOKENS_VERSION = 1;
 export const AUTO_REPLY_TEMPLATES_VERSION = 1;
+export const CURRENT_COMP_VERSION = 1;
 
 const VERSION: { [K in keyof StoreSchema]: number } = {
   user: USER_VERSION,
@@ -106,6 +115,7 @@ const VERSION: { [K in keyof StoreSchema]: number } = {
   openai: OPENAI_VERSION,
   connectorTokens: CONNECTOR_TOKENS_VERSION,
   autoReplyTemplates: AUTO_REPLY_TEMPLATES_VERSION,
+  currentCompensation: CURRENT_COMP_VERSION,
 } as const;
 
 export const SNAPSHOT_VERSION = 3;
@@ -213,6 +223,23 @@ function migrateAutoReplyTemplates(
   );
 }
 
+function migrateCurrentCompensation(
+  data: unknown,
+  version: number,
+): CurrentCompensation {
+  return migrate<CurrentCompensation>(
+    data,
+    version,
+    CURRENT_COMP_VERSION,
+    {
+      0: (d) =>
+        d && typeof d === "object"
+          ? (d as CurrentCompensation)
+          : { salary: "", benefits: "", stock: "" },
+    },
+  );
+}
+
 const MIGRATORS: {
   [K in keyof StoreSchema]: (
     data: unknown,
@@ -229,6 +256,7 @@ const MIGRATORS: {
   openai: migrateOpenAI,
   connectorTokens: migrateConnectorTokens,
   autoReplyTemplates: migrateAutoReplyTemplates,
+  currentCompensation: migrateCurrentCompensation,
 };
 
 const DEFAULTS: { [K in keyof StoreSchema]: StoreSchema[K] } = {
@@ -242,6 +270,7 @@ const DEFAULTS: { [K in keyof StoreSchema]: StoreSchema[K] } = {
   openai: undefined,
   connectorTokens: {},
   autoReplyTemplates: AUTO_REPLY_TEMPLATES as Record<string, string>,
+  currentCompensation: { salary: "", benefits: "", stock: "" },
 } as const;
 
 function load<K extends keyof StoreSchema>(
@@ -346,6 +375,13 @@ export function getUserProfile(): UserProfile | undefined {
 }
 export function saveUserProfile(profile: UserProfile): void {
   save("user", profile);
+}
+
+export function getCurrentCompensation(): CurrentCompensation {
+  return load("currentCompensation", { salary: "", benefits: "", stock: "" });
+}
+export function saveCurrentCompensation(comp: CurrentCompensation): void {
+  save("currentCompensation", comp);
 }
 
 // Resumes
@@ -761,6 +797,8 @@ export function importFromJson(json: string): void {
 const dataStore = {
   getUserProfile,
   saveUserProfile,
+  getCurrentCompensation,
+  saveCurrentCompensation,
   getResumes,
   saveResumes,
   addResume,


### PR DESCRIPTION
## Summary
- persist current compensation details in data store
- allow onboarding and settings pages to save and edit current compensation
- cover compensation persistence with a unit test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c781939fa08330a08d9e673ccd224a