### PR TITLE
docs: clarify connector authentication API

### DIFF
--- a/docs/talentforge.md
+++ b/docs/talentforge.md
@@ -24,9 +24,9 @@ TalentForge uses TypeScript interfaces to describe core entities:
 
 ## Connector Architecture
 
-Connectors abstract external services behind a common interface defined in `src/types/connector.ts`. Each method accepts a `ConnectorToken` representing the authenticated account and implements:
+Connectors abstract external services behind a common interface defined in `src/types/connector.ts`. They expose methods to authenticate and interact with a service, using a `ConnectorToken` to authorize requests:
 
-- `authenticate(token)` – prepare access to the service.
+- `authenticate()` – return a `ConnectorToken` for the connector account.
 - `fetchData(token)` – retrieve data such as profiles or job listings.
 - `sendMessage(token, message)` – deliver outbound messages; the token identifies the connector account.
 


### PR DESCRIPTION
## Summary
- update Connector Architecture docs to describe `authenticate()` returning credentials without parameters

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c781dc075c833093f89a8d60deac7c