### PR TITLE
fix: use American spelling in aggregator comment

### DIFF
--- a/src/utils/talentforge/jobAggregator.ts
+++ b/src/utils/talentforge/jobAggregator.ts
@@ -8,7 +8,7 @@ import { IndeedConnector } from "./connectors/indeed";
  * This utility currently aggregates listings from the mocked LinkedIn and
  * Indeed connectors used within TalentForge. Each connector returns listings in
  * the {@link JobListing} format, or data that contains such listings. The
- * aggregator normalises these responses into a single array.
+ * aggregator normalizes these responses into a single array.
  */
 export async function fetchAllListings(query: string = ""): Promise<JobListing[]> {
   const linkedin = new LinkedInConnector();


### PR DESCRIPTION
## Summary
- replace 'normalises' with 'normalizes' in job aggregator comment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7850a058c83309967899e6d91d7e5