### PR TITLE
docs: clarify pdf export text-only

### DIFF
--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -1,3 +1,9 @@
+/**
+ * Export the text content of an HTML element to a PDF.
+ *
+ * Only plain text is preserved; styling and layout are not captured.
+ * To capture full styling, consider a different approach such as html2canvas.
+ */
 type JsPdf = {
   new (): {
     text: (content: string, x: number, y: number) => void;


### PR DESCRIPTION
## Summary
- document pdfExport only exports plain text
- mention html2canvas for full styling capture

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c785179d608330ac449b513e76aa92