### PR TITLE
test: handle singular skill section

### DIFF
--- a/src/tests/pdfParser.test.ts
+++ b/src/tests/pdfParser.test.ts
@@ -88,5 +88,12 @@ describe("parseResumeText", () => {
       skills: ["javascript"],
     });
   });
+
+  test("parses singular Skill section header", () => {
+    const text = `John Doe\njohn@example.com\nSkill\nJavaScript\nTypeScript`;
+
+    const result = parseResumeText(text);
+    expect(result.skills).toEqual(["JavaScript", "TypeScript"]);
+  });
 });
 


### PR DESCRIPTION
## Summary
- add test verifying resume parser handles singular `Skill` section

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7851df5e4833090df9094fe107713