### PR TITLE
fix: ensure timeline parser returns valid events

### DIFF
--- a/src/components/showcase/Timeline/index.tsx
+++ b/src/components/showcase/Timeline/index.tsx
@@ -71,7 +71,7 @@ const Timeline: React.FC<TimelineProps> = ({
       .split("\n")
       .map((l) => l.trim())
       .filter((l) => l && !/^timeline\b/.test(l))
-      .map((line) => {
+      .map((line): TimelineEvent | null => {
         // format is expected to be one of "<dateTime>: <title>: <detail>: <category>: <id>"
         // but detail could contain colons, so we need to handle that
         let working = line;


### PR DESCRIPTION
## Summary
- type timeline parser map as `TimelineEvent | null` so filtered results are `TimelineEvent[]`

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c785df7c248330912d116df6ba84dc