### PR TITLE
feat: render current comp comparison as markdown

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -471,6 +471,7 @@ export default function ApplicationBoard() {
       setDrawerMessages([{ role: "assistant", text: "Analyzing offer..." }]);
       setDrawerAnalysis(null);
       setDrawerOpen(true);
+      setDrawerMode("chat");
       setDrawerApp(app);
       const offerLines: string[] = [];
       app.offer?.compensation.forEach((c) =>
@@ -502,7 +503,8 @@ export default function ApplicationBoard() {
           chatHistory: [],
         });
         const message = res?.message || "";
-        setDrawerMessages([{ role: "assistant", text: message }]);
+        // Wrap response with newlines so Markdown tables render properly
+        setDrawerMessages([{ role: "assistant", text: `\n${message}\n` }]);
       } finally {
         setDrawerLoading(false);
       }


### PR DESCRIPTION
## Summary
- ensure Compare to Current Comp action uses chat drawer mode and formats response for markdown rendering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c785a1843883309f914e150c2a2da7