### PR TITLE
Render markdown tables in ApplicationBoard drawer

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -32,7 +32,8 @@ import {
   type DragEndEvent,
 } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
-import Markdown from "react-markdown";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
 import type { ApplicationStatus } from "@/types/talentforge/job";
 import type {
   JobApplication,
@@ -927,7 +928,11 @@ export default function ApplicationBoard() {
                   }}
                 >
                   {m.text ? (
-                    <Markdown>{m.text}</Markdown>
+                    <Box
+                      dangerouslySetInnerHTML={{
+                        __html: DOMPurify.sanitize(marked.parse(m.text)),
+                      }}
+                    />
                   ) : m.data ? (
                     <>
                       {m.data.compensation &&


### PR DESCRIPTION
## Summary
- use `marked` and `dompurify` to render assistant messages as HTML
- enable proper rendering of markdown tables in the ApplicationBoard drawer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7887e981c8330a81b7488116da43d