### PR TITLE
Limit fetchAiTags retries to maxRetries

### DIFF
--- a/src/utils/talentforge/tagging.ts
+++ b/src/utils/talentforge/tagging.ts
@@ -69,7 +69,7 @@ async function fetchAiTags(
   maxRetries = 3,
   baseDelay = 500,
 ): Promise<string[]> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
       const res = await askOpenAI({
         context: content,
@@ -90,7 +90,7 @@ async function fetchAiTags(
       const msg = message?.toLowerCase?.() ?? "";
       const isNetworkError =
         (code && NETWORK_ERROR_CODES.includes(code)) || msg.includes("network");
-      if (!isNetworkError || attempt === maxRetries) {
+      if (!isNetworkError || attempt === maxRetries - 1) {
         throw err;
       }
       const delay = baseDelay * 2 ** attempt;


### PR DESCRIPTION
## Summary
- ensure fetchAiTags attempts run fewer times by limiting loop to `maxRetries`
- adjust final attempt check when retrying AI tags

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78b3f15888330b5cd452b244d7ee6