### PR TITLE
docs: clarify audio rewinding behavior

### DIFF
--- a/src/utils/lightgun-web/audio.ts
+++ b/src/utils/lightgun-web/audio.ts
@@ -11,13 +11,16 @@ export const pauseAudio = (audioRef?: RefObject<HTMLAudioElement | null>) => {
 };
 
 /**
- * Reset an audio element to the beginning and play it.
+ * Reset an audio element to the beginning and play it. Optionally replaces the
+ * audio source, automatically converting unsupported extensions to `.mp3`
+ * before loading.
  *
  * @param audioRef React ref to the audio element.
- * @param srcOrOptions Either the path to a new audio file that replaces the current
- * audio source or an object with playback options (`loop` to repeat, `volume` 0-1).
- * @param maybeOptions Playback options (`loop`, `volume`) applied when a source path is
- * provided as the second argument.
+ * @param srcOrOptions Either the path to a new audio file that replaces the
+ * current audio source (unsupported extensions are converted to `.mp3`) or an
+ * object with playback options (`loop` to repeat, `volume` 0-1).
+ * @param maybeOptions Playback options (`loop`, `volume`) applied when a source
+ * path is provided as the second argument.
  */
 export const rewindAndPlayAudio = (
   audioRef?: RefObject<HTMLAudioElement | null>,


### PR DESCRIPTION
## Summary
- document that `rewindAndPlayAudio` can replace the audio source and will convert unsupported extensions to mp3

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78b428084833080c13d9b56a15e1b