### PR TITLE
test: add tagging tests

### DIFF
--- a/src/tests/talentforge/tagging.test.ts
+++ b/src/tests/talentforge/tagging.test.ts
@@ -1,0 +1,37 @@
+import { tagResume } from "../../utils/talentforge/tagging";
+import { askOpenAI, hasOpenAIKey } from "../../utils/talentforge/utils";
+
+jest.mock("../../utils/talentforge/utils", () => ({
+  askOpenAI: jest.fn(),
+  hasOpenAIKey: jest.fn(),
+}));
+
+describe("tagResume", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("keyword-only content yields correct tags without calling askOpenAI", async () => {
+    (hasOpenAIKey as jest.Mock).mockReturnValue(true);
+
+    const content = "Experienced in React, Node, and AWS services.";
+    const tags = await tagResume(content);
+
+    expect(tags).toEqual(["React", "Node", "AWS"]);
+    expect(askOpenAI).not.toHaveBeenCalled();
+  });
+
+  test("duplicate tags from AI and keywords are merged case-insensitively and capped at five tags", async () => {
+    (hasOpenAIKey as jest.Mock).mockReturnValue(true);
+    (askOpenAI as jest.Mock).mockResolvedValue({
+      message: "React, Python, node, Go, AWS, Vue",
+    });
+
+    const content = "React and node developer";
+    const tags = await tagResume(content);
+
+    expect(askOpenAI).toHaveBeenCalledTimes(1);
+    expect(tags).toEqual(["React", "Node", "Python", "Go", "AWS"]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add test verifying keyword-only resume tagging bypasses OpenAI
- add test covering AI tag merging and cap at five tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c78b464f4c83308cf89f1f6a2a0a4e