### PR TITLE
fix: correct footer contact email

### DIFF
--- a/src/components/talentforge/Footer.tsx
+++ b/src/components/talentforge/Footer.tsx
@@ -54,7 +54,7 @@ Our team consists of passionate individuals dedicated to making document handlin
 
 ## Contact Us
 
-Have questions or feedback? We'd love to hear from you! Feel free to reach out to us at [richardfrankskr@hotmail.com](mailto:richardfranksjr@hotmail.com) and join us on our mission to revolutionize document handling and comprehension with TalentForge.
+Have questions or feedback? We'd love to hear from you! Feel free to reach out to us at [richardfranksjr@hotmail.com](mailto:richardfranksjr@hotmail.com) and join us on our mission to revolutionize document handling and comprehension with TalentForge.
 `;
 
 function Copyright() {


### PR DESCRIPTION
## Summary
- fix incorrect contact address in TalentForge footer so visible email matches mailto link

## Testing
- `npm test` *(fails: npm not installed)*
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c78b595a5c8330b8e845055836f370