### PR TITLE
fix: ensure marked parse result is string

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -930,7 +930,9 @@ export default function ApplicationBoard() {
                   {m.text ? (
                     <Box
                       dangerouslySetInnerHTML={{
-                        __html: DOMPurify.sanitize(marked.parse(m.text)),
+                        __html: DOMPurify.sanitize(
+                          marked.parse(m.text) as string
+                        ),
                       }}
                     />
                   ) : m.data ? (


### PR DESCRIPTION
## Summary
- cast `marked.parse` output to string before sanitization to satisfy DOMPurify and type checker

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c78ba467548330b9adf307dfe6f35c