### PR TITLE
fix: clarify resume absence message

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -380,7 +380,7 @@ export default function ApplicationBoard() {
       if (resumes.length === 0) {
         setDrawerTitle(tile.display);
         setDrawerTileId(tile.id);
-        setDrawerMessages([{ role: "assistant", text: "No resume available" }]);
+        setDrawerMessages([{ role: "assistant", text: "No resumes available" }]);
         setDrawerAnalysis(null);
         setDrawerOpen(true);
         setDrawerApp(app);


### PR DESCRIPTION
## Summary
- clarify drawer message when no resumes exist during resume comparison

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78d7fd5a0833094b12cce5ce512a1