### PR TITLE
feat: add launch button for accolades

### DIFF
--- a/src/components/app/AccoladesCarousel.tsx
+++ b/src/components/app/AccoladesCarousel.tsx
@@ -88,6 +88,16 @@ export default function AccoladesCarousel({
           </CardContent>
           {(acc.launchUrl || acc.githubUrl) && (
             <CardActions>
+              {acc.launchUrl && (
+                <Button
+                  size="small"
+                  href={withBasePath(acc.launchUrl)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Launch
+                </Button>
+              )}
               {acc.githubUrl && (
                 <Button
                   size="small"


### PR DESCRIPTION
## Summary
- show Launch button for accolades with launch URLs
- allow Launch and GitHub buttons to display together

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78d897cac8330a1aa381de9bfe3d4