### PR TITLE
Add test for object content in autoReply

### DIFF
--- a/src/tests/talentforge/autoReply.test.ts
+++ b/src/tests/talentforge/autoReply.test.ts
@@ -46,6 +46,18 @@ describe("autoReply utilities", () => {
     expect(result).toBe("foo bar");
   });
 
+  test("autoReply returns object text content", async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: { text: "hello" } } }],
+      }),
+    });
+    setOpenAIKey("key");
+    const result = await autoReply([] as AutoReplyMessage[]);
+    expect(result).toBe("hello");
+  });
+
   test("autoReply throws on non-ok response", async () => {
     (fetch as jest.Mock).mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## Summary
- add test for object `content` responses in autoReply

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c78d98ec688330897e6547488b9793