### PR TITLE
feat: add snapshot import export

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ For quick configuration, you can copy `talentforge.env.example` to `talentforge.
 - `NEXT_PUBLIC_OPENAI_API_KEY` – OpenAI API key.
 - `NEXT_PUBLIC_APP_NAME` – application name displayed in the UI.
 
+### Snapshot Versioning
+
+TalentForge exports and imports data as versioned snapshots. Each snapshot includes a `version` field that corresponds to the `SNAPSHOT_VERSION` constant in `src/utils/talentforge/dataStore.ts`. When importing, older snapshots are migrated to the latest format automatically. Update this version number whenever the data schema changes.
+
 ## Getting Started
 
 First, run the development server:

--- a/src/components/talentforge/Settings.tsx
+++ b/src/components/talentforge/Settings.tsx
@@ -9,6 +9,7 @@ import {
   List,
   ListItem,
   ListItemText,
+  Snackbar,
   Stack,
   TextField,
   Typography,
@@ -18,6 +19,8 @@ import OpenAIKeyModal from "@/components/talentforge/OpenAiKeyModal";
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
 import { loadDemoData, clearDemoData } from "@/utils/talentforge/demoData";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import { exportSnapshot, importSnapshot } from "@/utils/talentforge/snapshot";
+import { SNAPSHOT_VERSION } from "@/utils/talentforge/dataStore";
 
 export default function Settings() {
   const dataStore = useTalentForgeData();
@@ -28,6 +31,8 @@ export default function Settings() {
     benefits: "",
     stock: "",
   });
+  const [toastOpen, setToastOpen] = React.useState(false);
+  const [toastMessage, setToastMessage] = React.useState("");
 
   React.useEffect(() => {
     setOpenAiKeySet(hasOpenAIKey());
@@ -43,14 +48,21 @@ export default function Settings() {
   };
 
   const handleExport = () => {
-    const data = dataStore.exportToJson();
-    const blob = new Blob([data], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "talentforge-data.json";
-    a.click();
-    URL.revokeObjectURL(url);
+    try {
+      const data = exportSnapshot();
+      const blob = new Blob([data], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `talentforge-snapshot-v${SNAPSHOT_VERSION}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setToastMessage("Snapshot exported");
+      setToastOpen(true);
+    } catch {
+      setToastMessage("Export failed");
+      setToastOpen(true);
+    }
   };
 
   const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -60,8 +72,15 @@ export default function Settings() {
     reader.onload = () => {
       const text = reader.result;
       if (typeof text === "string") {
-        dataStore.importFromJson(text);
-        setOpenAiKeySet(hasOpenAIKey());
+        try {
+          importSnapshot(text);
+          setOpenAiKeySet(hasOpenAIKey());
+          setToastMessage("Snapshot imported");
+        } catch {
+          setToastMessage("Import failed");
+        } finally {
+          setToastOpen(true);
+        }
       }
     };
     reader.readAsText(file);
@@ -167,15 +186,15 @@ export default function Settings() {
               Data
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Export or import your stored TalentForge data.
+              Export or import a snapshot of your stored TalentForge data.
             </Typography>
           </CardContent>
           <CardActions>
             <Button onClick={handleExport} variant="contained">
-              Export Data
+              Export Snapshot
             </Button>
             <Button component="label">
-              Import Data
+              Import Snapshot
               <input type="file" accept="application/json" hidden onChange={handleImport} />
             </Button>
           </CardActions>
@@ -199,6 +218,12 @@ export default function Settings() {
         </Card>
 
         <OpenAIKeyModal open={openKeyModal} onClose={handleCloseModal} />
+        <Snackbar
+          open={toastOpen}
+          autoHideDuration={3000}
+          message={toastMessage}
+          onClose={() => setToastOpen(false)}
+        />
       </Stack>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary
- add snapshot export/import buttons with toast feedback
- document snapshot versioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c78eac083083308315af9772c42891