### PR TITLE
Wrap TalentForge components with ErrorBoundary

### DIFF
--- a/src/app/talentforge/settings/page.tsx
+++ b/src/app/talentforge/settings/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import Settings from "@/components/talentforge/Settings";
+import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 export default function TalentForgeSettingsPage() {
-  return <Settings />;
+  return (
+    <ErrorBoundary>
+      <Settings />
+    </ErrorBoundary>
+  );
 }
 

--- a/src/components/talentforge/Workspace.tsx
+++ b/src/components/talentforge/Workspace.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Box, Button, Stack, Typography } from "@mui/material";
 
+import ErrorBoundary from "./ErrorBoundary";
 import { PROMPT_TILES } from "@/consts/promptTiles";
 import Tile from "./promptTiles/Tile";
 
@@ -32,64 +33,66 @@ export default function Workspace({
   };
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: { xs: "column", md: "row" },
-        gap: 2,
-      }}
-    >
+    <ErrorBoundary>
       <Box
         sx={{
-          flex: 1,
-          display: "grid",
-          gridTemplateColumns: {
-            xs: "1fr",
-            sm: "repeat(2, 1fr)",
-            md: "repeat(3, 1fr)",
-          },
+          display: "flex",
+          flexDirection: { xs: "column", md: "row" },
           gap: 2,
         }}
       >
-        {Object.values(PROMPT_TILES).map((tile) => (
-          <Tile key={tile.id} {...tile} onResponse={setOutput} />
-        ))}
+        <Box
+          sx={{
+            flex: 1,
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, 1fr)",
+              md: "repeat(3, 1fr)",
+            },
+            gap: 2,
+          }}
+        >
+          {Object.values(PROMPT_TILES).map((tile) => (
+            <Tile key={tile.id} {...tile} onResponse={setOutput} />
+          ))}
+        </Box>
+        <Box
+          sx={{
+            flexBasis: { md: "30%" },
+            border: 1,
+            borderColor: "divider",
+            p: 2,
+            borderRadius: 1,
+            minHeight: 200,
+          }}
+        >
+          <Typography variant="h6" gutterBottom>
+            Output
+          </Typography>
+          <Box sx={{ whiteSpace: "pre-wrap", mb: 2 }}>{output}</Box>
+          <Stack direction="row" spacing={1}>
+            <Button variant="outlined" onClick={handleCopy} disabled={!output}>
+              Copy
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={handleInsert}
+              disabled={!onInsertIntoThread || !output}
+            >
+              Insert into Thread
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleSave}
+              disabled={!onSaveResumeVariant || !output}
+            >
+              Save as Resume Variant
+            </Button>
+          </Stack>
+        </Box>
       </Box>
-      <Box
-        sx={{
-          flexBasis: { md: "30%" },
-          border: 1,
-          borderColor: "divider",
-          p: 2,
-          borderRadius: 1,
-          minHeight: 200,
-        }}
-      >
-        <Typography variant="h6" gutterBottom>
-          Output
-        </Typography>
-        <Box sx={{ whiteSpace: "pre-wrap", mb: 2 }}>{output}</Box>
-        <Stack direction="row" spacing={1}>
-          <Button variant="outlined" onClick={handleCopy} disabled={!output}>
-            Copy
-          </Button>
-          <Button
-            variant="outlined"
-            onClick={handleInsert}
-            disabled={!onInsertIntoThread || !output}
-          >
-            Insert into Thread
-          </Button>
-          <Button
-            variant="contained"
-            onClick={handleSave}
-            disabled={!onSaveResumeVariant || !output}
-          >
-            Save as Resume Variant
-          </Button>
-        </Stack>
-      </Box>
-    </Box>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
## Summary
- Wrap Workspace component with ErrorBoundary to guard prompt tiles
- Add ErrorBoundary around TalentForge settings page
- Utilize existing boundary that logs errors and offers retry UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78eb726648330a8fb20ea4dbf8abf