### PR TITLE
Add tests for resume cloning and diff logic

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     'ts-jest': {
       tsconfig: {
         module: 'commonjs',
+        jsx: 'react-jsx',
       },
     },
   },

--- a/src/components/talentforge/ResumeVariants/Diff.tsx
+++ b/src/components/talentforge/ResumeVariants/Diff.tsx
@@ -2,12 +2,12 @@
 
 import { Box, Typography, useTheme } from "@mui/material";
 
-interface DiffLine {
+export interface DiffLine {
   text: string | null;
   type: "same" | "added" | "removed";
 }
 
-interface DiffRow {
+export interface DiffRow {
   original: DiffLine;
   updated: DiffLine;
 }
@@ -17,7 +17,7 @@ interface Props {
   updated: string;
 }
 
-function computeDiff(a: string, b: string): DiffRow[] {
+export function computeDiff(a: string, b: string): DiffRow[] {
   const aLines = a.split("\n");
   const bLines = b.split("\n");
   const max = Math.max(aLines.length, bLines.length);

--- a/src/tests/talentforge/resumeVariants.test.ts
+++ b/src/tests/talentforge/resumeVariants.test.ts
@@ -1,0 +1,49 @@
+import { addResume, cloneResume, type ResumeEntry } from "../../utils/talentforge/dataStore";
+import { computeDiff } from "../../components/talentforge/ResumeVariants/Diff";
+
+describe("resume cloning", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("cloneResume duplicates resume with unique id and title", () => {
+    const resume: ResumeEntry = {
+      id: "r1",
+      userId: "",
+      label: "",
+      title: "My Resume",
+      url: "",
+      content: "content A",
+      tags: [],
+      parsed: { contact: "", experience: [], education: [], skills: [] },
+    };
+    addResume(resume);
+    const updated = cloneResume(resume);
+    expect(updated).toHaveLength(2);
+    const clone = updated.find((r) => r.id !== resume.id)!;
+    expect(clone.content).toBe(resume.content);
+    expect(clone.id).not.toBe(resume.id);
+    expect(clone.title).toBe("My Resume (2)");
+  });
+});
+
+describe("resume diff", () => {
+  test("computeDiff marks added and removed lines", () => {
+    const original = "line1\nline2";
+    const updated = "line1\nline3\nline4";
+    const diff = computeDiff(original, updated);
+    expect(diff[0]).toEqual({
+      original: { text: "line1", type: "same" },
+      updated: { text: "line1", type: "same" },
+    });
+    expect(diff[1]).toEqual({
+      original: { text: "line2", type: "removed" },
+      updated: { text: "line3", type: "added" },
+    });
+    expect(diff[2]).toEqual({
+      original: { text: null, type: "same" },
+      updated: { text: "line4", type: "added" },
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- expose `computeDiff` in Resume variant diff component for unit testing
- configure Jest to transpile TSX components
- add unit tests for resume cloning and diff computation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c78ed9b5f08330af1c366a984dcd76