### PR TITLE
feat: add job description field and tests

### DIFF
--- a/src/components/talentforge/ChatWorkspace.tsx
+++ b/src/components/talentforge/ChatWorkspace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button, Stack, Typography, TextField } from "@mui/material";
 
 import PromptTileGrid from "./promptTiles/PromptTileGrid";
 
@@ -15,6 +15,7 @@ export default function ChatWorkspace({
   onSaveResumeVariant,
 }: ChatWorkspaceProps) {
   const [output, setOutput] = useState("");
+  const [jobDescription, setJobDescription] = useState("");
 
   const handleCopy = () => {
     if (navigator.clipboard && output) {
@@ -39,7 +40,19 @@ export default function ChatWorkspace({
       }}
     >
       <Box sx={{ flex: 1 }}>
-        <PromptTileGrid onResponse={setOutput} />
+        <TextField
+          label="Job Description"
+          multiline
+          minRows={4}
+          fullWidth
+          value={jobDescription}
+          onChange={(e) => setJobDescription(e.target.value)}
+          sx={{ mb: 2 }}
+        />
+        <PromptTileGrid
+          onResponse={setOutput}
+          initialValues={{ jdRequirements: { jobDescription } }}
+        />
       </Box>
       <Box
         sx={{

--- a/src/tests/talentforge/jdRequirements.test.ts
+++ b/src/tests/talentforge/jdRequirements.test.ts
@@ -1,0 +1,22 @@
+import { PROMPT_TILES } from "@/consts/promptTiles";
+
+describe("jdRequirements tile", () => {
+  test("requires jobDescription input", () => {
+    const tile = PROMPT_TILES.jdRequirements;
+    expect(tile).toBeDefined();
+    expect(tile.inputs).toEqual(["jobDescription"]);
+  });
+
+  test("prompt asks for bullet points", () => {
+    const tile = PROMPT_TILES.jdRequirements;
+    expect(tile.fullPrompt).toMatch(/bullet points/i);
+  });
+
+  test("sample output is bullet list", () => {
+    const sample = "- item 1\n- item 2";
+    const lines = sample.trim().split("\n");
+    lines.forEach((line) => {
+      expect(line.trim().startsWith("-")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared Job Description text field in ChatWorkspace and forward value to prompts
- ensure `jdRequirements` tile collects requirements as bullet points
- test that jdRequirements tile expects jobDescription and indicates bullet list output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c78ef8645083309e21a75ad8349265