### PR TITLE
refactor: centralize talentforge types

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -34,13 +34,13 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
-import type { ApplicationStatus } from "@/types/talentforge/job";
 import type {
+  ApplicationStatus,
   JobApplication,
   ResumeEntry,
   Offer,
-} from "@/utils/talentforge/dataStore";
-import type { OfferComp } from "@/types";
+  OfferComp,
+} from "@/types";
 import {
   addJobApplication,
   getJobApplications,

--- a/src/components/talentforge/ChatAssistant.tsx
+++ b/src/components/talentforge/ChatAssistant.tsx
@@ -19,7 +19,7 @@ import {
 import { exportElementToPdf } from "@/utils/pdfExport";
 import OpenAIKeyModal from "./OpenAiKeyModal";
 import RequireAIKey from "./RequireAIKey";
-import { ChatMessage } from "@/types/talentforge/types";
+import { ChatMessage } from "@/types";
 export default function ChatAssistant() {
   const [selectedTile, setSelectedTile] = useState<string>("");
   const [chatHistory, setChatHistory] = useState<(ChatMessage | null)[]>([]);

--- a/src/components/talentforge/Hero.tsx
+++ b/src/components/talentforge/Hero.tsx
@@ -22,7 +22,7 @@ import {
   summarizePDFPrompt,
   userQuestionPrompt,
 } from "@/consts/talentforge/consts";
-import { ChatMessage } from "@/types/talentforge/types";
+import { ChatMessage } from "@/types";
 import {
   askOpenAI,
   pdfToMarkdown,

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/utils/autoReply";
 
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-import { Message, RecruiterEntry } from "@/utils/talentforge/dataStore";
+import type { Message, RecruiterEntry } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 import PromptSelector from "./PromptSelector";
 import Tile from "./promptTiles/Tile";

--- a/src/components/talentforge/JobApplications.tsx
+++ b/src/components/talentforge/JobApplications.tsx
@@ -10,8 +10,7 @@ import {
   Typography,
 } from "@mui/material";
 import { v4 as uuid } from "uuid";
-import type { ApplicationStatus } from "@/types/talentforge/job";
-import type { JobApplication } from "@/utils/talentforge/dataStore";
+import type { ApplicationStatus, JobApplication } from "@/types";
 import {
   addJobApplication,
   getJobApplications,

--- a/src/components/talentforge/JobListings.tsx
+++ b/src/components/talentforge/JobListings.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
 } from "@mui/material";
 import { v4 as uuid } from "uuid";
-import type { JobListing } from "@/types/talentforge/job";
+import type { JobListing } from "@/types";
 import jobAggregator from "@/utils/talentforge/jobAggregator";
 import { addJobApplication } from "@/utils/talentforge/dataStore";
 

--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -20,13 +20,9 @@ import {
   hasOpenAIKey,
 } from "@/utils/talentforge/utils";
 import OpenAIKeyModal from "./OpenAiKeyModal";
-import {
-  addOffer,
-  type Offer,
-  type Message,
-} from "@/utils/talentforge/dataStore";
+import { addOffer } from "@/utils/talentforge/dataStore";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-import type { ApplicationRecord } from "@/types";
+import type { Offer, Message, ApplicationRecord } from "@/types";
 
 interface OfferCompareProps {
   onSave?: () => void;

--- a/src/components/talentforge/Offers/OfferDetail.tsx
+++ b/src/components/talentforge/Offers/OfferDetail.tsx
@@ -8,13 +8,8 @@ import {
   Stack,
   TextField,
 } from "@mui/material";
-import {
-  addOffer,
-  updateOffer,
-  deleteOffer,
-  type Offer,
-} from "@/utils/talentforge/dataStore";
-import type { ApplicationRecord, OfferComp } from "@/types";
+import { addOffer, updateOffer, deleteOffer } from "@/utils/talentforge/dataStore";
+import type { Offer, ApplicationRecord, OfferComp } from "@/types";
 
 interface OfferDetailProps {
   offer?: Offer;

--- a/src/components/talentforge/Offers/OfferList.tsx
+++ b/src/components/talentforge/Offers/OfferList.tsx
@@ -19,7 +19,8 @@ import {
   TableRow,
   Paper,
 } from "@mui/material";
-import { getOffers, type Offer } from "@/utils/talentforge/dataStore";
+import { getOffers } from "@/utils/talentforge/dataStore";
+import type { Offer } from "@/types";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import EmptyState from "../EmptyState";
 

--- a/src/components/talentforge/Recruiters/List.tsx
+++ b/src/components/talentforge/Recruiters/List.tsx
@@ -10,10 +10,7 @@ import {
   Button,
 } from "@mui/material";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-import type {
-  RecruiterEntry,
-  Message,
-} from "@/utils/talentforge/dataStore";
+import type { RecruiterEntry, Message } from "@/types";
 
 export default function RecruiterList() {
   const data = useTalentForgeData();

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -14,11 +14,8 @@ import {
 } from "@mui/material";
 import { filterByTag, filterByText } from "@/utils/search";
 
-import {
-  getResumes,
-  addResume,
-  type ResumeEntry,
-} from "@/utils/talentforge/dataStore";
+import { getResumes, addResume } from "@/utils/talentforge/dataStore";
+import type { ResumeEntry } from "@/types";
 
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { pdfToText, parseResumeText } from "@/utils/talentforge/pdfParser";

--- a/src/components/talentforge/ResumeVariants/Detail.tsx
+++ b/src/components/talentforge/ResumeVariants/Detail.tsx
@@ -12,7 +12,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import type { ResumeEntry } from "@/utils/talentforge/dataStore";
+import type { ResumeEntry } from "@/types";
 import { updateResume } from "@/utils/talentforge/dataStore";
 
 interface Props {

--- a/src/components/talentforge/ResumeVariants/List.tsx
+++ b/src/components/talentforge/ResumeVariants/List.tsx
@@ -20,8 +20,8 @@ import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import DifferenceIcon from "@mui/icons-material/Difference";
 import { v4 as uuid } from "uuid";
+import type { ResumeEntry } from "@/types";
 import {
-  type ResumeEntry,
   deleteResume,
   updateResume,
   cloneResume,

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -17,17 +17,11 @@ import Markdown from "react-markdown";
 
 import OpenAIKeyModal from "../OpenAiKeyModal";
 import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
-import {
-  getResumes,
-  addResume,
-  addOffer,
-  type ResumeEntry,
-  type Offer,
-} from "@/utils/talentforge/dataStore";
+import { getResumes, addResume, addOffer } from "@/utils/talentforge/dataStore";
 import { tagResume } from "@/utils/talentforge/tagging";
 import { parseResumeText } from "@/utils/talentforge/pdfParser";
 import { v4 as uuid } from "uuid";
-import type { ApplicationRecord } from "@/types";
+import type { ApplicationRecord, ResumeEntry, Offer } from "@/types";
 
 export interface PromptTileProps {
   id: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,4 @@
-export type {
-  User,
-  ResumeVariant,
-  RolePosting,
-  ApplicationRecord,
-  Recruiter,
-  Thread,
-  Message,
-  Offer,
-  OfferComp,
-} from "./talentforge/models";
+export * from "./talentforge/models";
+export * from "./talentforge/job";
+export * from "./talentforge/resume";
+export * from "./talentforge/types";

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -1,4 +1,5 @@
 import type { ApplicationStatus, StatusChange } from "./job";
+import type { ParsedResume } from "./resume";
 
 export interface User {
   /** Unique identifier for the user. */
@@ -26,9 +27,20 @@ export interface ResumeVariant {
   title: string;
   /** URL where the resume file is stored. */
   url: string;
+  /** Raw text content of the resume. */
+  content: string;
+  /** Parsed resume sections extracted from the content. */
+  parsed: ParsedResume;
+  /** Tags describing the resume. */
+  tags: string[];
   /** Additional notes about this resume variant. */
   notes?: string;
 }
+
+/**
+ * Alias maintained for backwards compatibility with older imports.
+ */
+export type ResumeEntry = ResumeVariant;
 
 export interface RolePosting {
   /** Unique identifier for the role posting. */
@@ -57,7 +69,7 @@ export interface ApplicationRecord {
   /** Role being applied to. */
   role: RolePosting;
   /** Resume variant used for the application, if any. */
-  resumeVariant?: ResumeVariant;
+  resumeVariant?: ResumeEntry;
   /** Current status of the application. */
   status: ApplicationStatus;
   /** History of status changes for the application. */
@@ -73,7 +85,7 @@ export interface ApplicationRecord {
   /** Offer details if an offer has been made. */
   offer?: Offer;
   /** Generated offer negotiations attached to this application. */
-  offerHistory?: string[];
+  offerHistory: string[];
 }
 
 export interface Recruiter {
@@ -86,14 +98,19 @@ export interface Recruiter {
   /** Applications managed by this recruiter. */
   applications?: ApplicationRecord[];
   /** Connector that surfaced this recruiter. */
-  connector?: string;
+  connector: string;
   /** Tags describing the recruiter. */
-  tags?: string[];
+  tags: string[];
   /** Notes about the recruiter. */
-  notes?: string;
+  notes: string;
   /** Message thread IDs linked to this recruiter. */
-  threadIds?: string[];
+  threadIds: string[];
 }
+
+/**
+ * Alias maintained for backwards compatibility with older imports.
+ */
+export type RecruiterEntry = Recruiter;
 
 export interface Thread {
   /** Unique identifier for the thread. */
@@ -104,6 +121,17 @@ export interface Thread {
   participantIds: string[];
   /** Messages that belong to this thread. */
   messages: Message[];
+}
+
+export interface MessageReply {
+  /** Unique identifier for the message reply. */
+  id: string;
+  /** Body content of the reply. */
+  body: string;
+  /** Timestamp in ISO format indicating when the reply was sent. */
+  sentAt: string;
+  /** Connector through which the reply was sent. */
+  connector: string;
 }
 
 export interface Message {
@@ -119,6 +147,12 @@ export interface Message {
   sentAt: string;
   /** Body content of the message. */
   body: string;
+  /** Connector through which the message was received. */
+  connector: string;
+  /** Current read status of the message. */
+  status: "unread" | "read";
+  /** Replies to the message, if any. */
+  replies: MessageReply[];
 }
 
 export interface Offer {

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -1,6 +1,12 @@
-import type { ApplicationRecord, RolePosting, Offer, OfferComp, User } from "@/types";
-import type { ResumeEntry } from "@/utils/talentforge/dataStore";
-import type { ParsedResume } from "@/types/talentforge/resume";
+import type {
+  ApplicationRecord,
+  RolePosting,
+  Offer,
+  OfferComp,
+  User,
+  ResumeEntry,
+  ParsedResume,
+} from "@/types";
 
 const mockUserProfile: User = {
   id: "user-1",

--- a/src/utils/talentforge/connectors/indeed.ts
+++ b/src/utils/talentforge/connectors/indeed.ts
@@ -5,7 +5,7 @@
  * application can be developed without external API access.
  */
 
-import type { JobListing } from "@/types/talentforge/job";
+import type { JobListing } from "@/types";
 import type { ConnectorToken } from "@/types/connector";
 
 /** Sample job listings returned by the mocked Indeed connector. */

--- a/src/utils/talentforge/connectors/linkedin.ts
+++ b/src/utils/talentforge/connectors/linkedin.ts
@@ -1,4 +1,4 @@
-import type { JobListing } from "@/types/talentforge/job";
+import type { JobListing } from "@/types";
 
 export interface LinkedInProfile {
   id: string;

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -11,50 +11,20 @@ import type {
   ApplicationStatus,
   JobListing,
   StatusChange,
-} from "@/types/talentforge/job";
-import { AUTO_REPLY_TEMPLATES } from "@/utils/autoReply";
-import type {
   User,
-  ResumeVariant,
-  Message as ModelMessage,
-  Offer as ModelOffer,
+  ResumeEntry,
+  Message,
+  MessageReply,
+  Offer,
   ApplicationRecord,
   OfferComp,
-  Recruiter,
+  RecruiterEntry,
 } from "@/types";
-import { ParsedResume } from "@/types/talentforge/resume";
+import { AUTO_REPLY_TEMPLATES } from "@/utils/autoReply";
 
 export type UserProfile = User;
 
-export type ResumeEntry = ResumeVariant & {
-  content: string;
-  parsed: ParsedResume;
-  tags: string[];
-};
-
-export type MessageReply = {
-  id: string;
-  body: string;
-  sentAt: string;
-  connector: string;
-};
-
-export interface Message extends ModelMessage {
-  connector: string;
-  status: "unread" | "read";
-  replies: MessageReply[];
-}
-
-export type Offer = ModelOffer;
-
 export type JobApplication = ApplicationRecord;
-
-export type RecruiterEntry = Recruiter & {
-  connector: string;
-  tags: string[];
-  notes: string;
-  threadIds: string[];
-};
 
 export interface CurrentCompensation {
   salary: string;

--- a/src/utils/talentforge/demoData.ts
+++ b/src/utils/talentforge/demoData.ts
@@ -1,7 +1,12 @@
 "use client";
 
-import type { User, ResumeVariant, RolePosting, ApplicationRecord } from "@/types";
-import type { ResumeEntry } from "./dataStore";
+import type {
+  User,
+  ResumeVariant,
+  RolePosting,
+  ApplicationRecord,
+  ResumeEntry,
+} from "@/types";
 import dataStore from "./dataStore";
 
 /**

--- a/src/utils/talentforge/jobAggregator.ts
+++ b/src/utils/talentforge/jobAggregator.ts
@@ -1,4 +1,4 @@
-import type { JobListing } from "@/types/talentforge/job";
+import type { JobListing } from "@/types";
 import { LinkedInConnector } from "./connectors/linkedin";
 import { IndeedConnector } from "./connectors/indeed";
 

--- a/src/utils/talentforge/pdfParser.ts
+++ b/src/utils/talentforge/pdfParser.ts
@@ -3,7 +3,7 @@
 import * as pdfjs from "pdfjs-dist";
 
 import { Buffer } from "buffer";
-import { ParsedResume } from "@/types/talentforge/resume";
+import { ParsedResume } from "@/types";
 
 declare global {
   interface Window {

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -2,7 +2,7 @@
 
 import * as pdfjs from "pdfjs-dist";
 
-import { ChatMessage } from "@/types/talentforge/types";
+import { ChatMessage } from "@/types";
 import { aiBufferSize } from "@/consts/talentforge/consts";
 
 import { Buffer } from "buffer";


### PR DESCRIPTION
## Summary
- align TalentForge models with persisted shapes
- export shared types from single index
- update components to import unified models

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78ecd05ac8330a0b736d9d0e8ae11