### PR TITLE
feat: add accessible loading states and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/src/tests/**/*.test.ts'],
+  testMatch: ['**/src/tests/**/*.test.ts', '**/src/tests/**/*.test.tsx'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
@@ -11,6 +11,7 @@ module.exports = {
     'ts-jest': {
       tsconfig: {
         module: 'commonjs',
+        jsx: 'react-jsx',
       },
     },
   },

--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -285,6 +285,7 @@ function Card({
 
 export default function ApplicationBoard() {
   const [applications, setApplications] = useState<JobApplication[]>([]);
+  const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [company, setCompany] = useState("");
@@ -332,11 +333,26 @@ export default function ApplicationBoard() {
           });
         });
         setApplications(apps);
+        setLoading(false);
       });
     } else {
       setApplications(existing);
+      setLoading(false);
     }
   }, []);
+
+  if (loading) {
+    return (
+      <Stack
+        spacing={2}
+        alignItems="center"
+        aria-busy="true"
+        aria-label="Loading applications"
+      >
+        <CircularProgress />
+      </Stack>
+    );
+  }
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -56,10 +56,13 @@ export default function Inbox() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setThreads(data.getThreads());
-    setRecruiters(data.getRecruiters());
-    setTemplateDefs(data.getAutoReplyTemplates());
-    setLoading(false);
+    const id = setTimeout(() => {
+      setThreads(data.getThreads());
+      setRecruiters(data.getRecruiters());
+      setTemplateDefs(data.getAutoReplyTemplates());
+      setLoading(false);
+    }, 0);
+    return () => clearTimeout(id);
   }, [data]);
 
   const handleFilterChange = (event: SelectChangeEvent) => {
@@ -218,7 +221,7 @@ export default function Inbox() {
   }
 
   return (
-    <Box>
+    <Box aria-busy={loading} aria-label={loading ? "Loading inbox" : undefined}>
       <Stack direction="row" spacing={2} sx={{ height: "100%" }}>
         <Box sx={{ width: 300 }}>
           <Stack spacing={2}>

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -42,8 +42,11 @@ export default function ResumeManager() {
   const [toastOpen, setToastOpen] = useState(false);
 
   useEffect(() => {
-    setResumes(getResumes());
-    setLoadingResumes(false);
+    const id = setTimeout(() => {
+      setResumes(getResumes());
+      setLoadingResumes(false);
+    }, 0);
+    return () => clearTimeout(id);
   }, []);
 
   const handleSave = async () => {
@@ -156,7 +159,11 @@ export default function ResumeManager() {
         </Button>
       </Stack>
       {loadingCompare && (
-        <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+        <Box
+          sx={{ display: "flex", justifyContent: "center", mt: 2 }}
+          aria-busy="true"
+          aria-label="Comparing resume"
+        >
           <CircularProgress />
         </Box>
       )}

--- a/src/tests/talentforge/loaders.test.tsx
+++ b/src/tests/talentforge/loaders.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import ResumeManager from '@/components/talentforge/ResumeManager';
+import Inbox from '@/components/talentforge/Inbox';
+import ApplicationBoard from '@/components/talentforge/ApplicationBoard';
+
+jest.mock('@/utils/talentforge/dataStore', () => ({
+  getResumes: jest.fn(() => []),
+  addResume: jest.fn(),
+  getJobApplications: jest.fn(() => []),
+  addJobApplication: jest.fn(),
+  updateJobApplicationStatus: jest.fn(),
+  updateJobApplication: jest.fn(),
+  getRecruiters: jest.fn(() => []),
+  getThreads: jest.fn(() => []),
+  getAutoReplyTemplates: jest.fn(() => ({})),
+  linkThreadToRecruiter: jest.fn(),
+  saveAutoReplyTemplates: jest.fn(),
+  getCurrentCompensation: jest.fn(),
+}));
+
+jest.mock('@/contexts/TalentForgeDataContext', () => ({
+  useTalentForgeData: () => ({
+    getThreads: () => [],
+    getRecruiters: () => [],
+    getAutoReplyTemplates: () => ({}),
+    updateThreadStatus: jest.fn(),
+    addThreadReply: jest.fn(),
+    linkThreadToRecruiter: jest.fn(),
+    saveAutoReplyTemplates: jest.fn(),
+  }),
+}));
+
+jest.mock('@/utils/talentforge/jobAggregator', () => ({
+  fetchAllListings: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('@/utils/autoReply', () => ({
+  autoReply: jest.fn(),
+  buildAutoReplyMessages: jest.fn(),
+}));
+
+jest.mock('@/components/talentforge/PromptSelector', () => () => null);
+jest.mock('@/components/talentforge/promptTiles/Tile', () => () => null);
+jest.mock('@/components/talentforge/EmptyState', () => () => null);
+jest.mock('@/components/talentforge/OpenAiKeyModal', () => () => null);
+jest.mock('@/components/talentforge/FileUploader', () => () => null);
+jest.mock('@/components/talentforge/ResumeVariants/List', () => () => null);
+jest.mock('@/utils/talentforge/tagging', () => ({ tagResume: jest.fn() }));
+jest.mock('@/utils/talentforge/utils', () => ({
+  askOpenAI: jest.fn(),
+  hasOpenAIKey: jest.fn(() => false),
+  hasValidOpenAIKey: jest.fn(() => true),
+  pdfToMarkdown: jest.fn(),
+  pdfToText: jest.fn(),
+}));
+jest.mock('@/utils/talentforge/pdfParser', () => ({
+  parseResumeText: jest.fn(),
+}));
+jest.mock('@/utils/talentforge/pasteParser', () => ({
+  parsePastedHtml: jest.fn((t: string) => t),
+}));
+jest.mock('@/consts/prompts', () => ({ PROMPT_TEMPLATES: {} }));
+jest.mock('@/consts/promptTiles', () => ({ PROMPT_TILES: {} }));
+
+describe('Loader visuals', () => {
+  test('ResumeManager initial render shows loader', () => {
+    const html = renderToString(<ResumeManager />);
+    expect(html).toContain('aria-label="Loading resumes"');
+  });
+
+  test('Inbox initial render shows loader', () => {
+    const html = renderToString(<Inbox />);
+    expect(html).toContain('aria-label="Loading inbox"');
+  });
+
+  test('ApplicationBoard initial render shows loader', () => {
+    const html = renderToString(<ApplicationBoard />);
+    expect(html).toContain('aria-label="Loading applications"');
+  });
+});


### PR DESCRIPTION
## Summary
- show progress indicator while comparing resumes
- ensure inbox and resume manager loaders are accessible
- add loading state to application board with spinner and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c78eb1e2ec8330949f8d999df86829