### PR TITLE
fix: align JobApplication type with role field

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./talentforge/models";
-export * from "./talentforge/job";
+export type { JobListing, ApplicationStatus, StatusChange } from "./talentforge/job";
 export * from "./talentforge/resume";
 export * from "./talentforge/types";
+export type { ApplicationRecord as JobApplication } from "./talentforge/models";

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -85,7 +85,7 @@ export interface ApplicationRecord {
   /** Offer details if an offer has been made. */
   offer?: Offer;
   /** Generated offer negotiations attached to this application. */
-  offerHistory: string[];
+  offerHistory?: string[];
 }
 
 export interface Recruiter {

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -101,7 +101,7 @@ mockUserProfile.resumeVariants = mockResumes.map(
     void content;
     void parsed;
     void tags;
-    return rv;
+    return { ...rv, content: "", parsed: { ...emptyParsed }, tags: [] };
   },
 );
 mockUserProfile.applications = mockApplications;


### PR DESCRIPTION
## Summary
- expose JobApplication as ApplicationRecord to include role details
- relax ApplicationRecord and mock resume data so build can succeed

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c79144b3948330a87fa7b8e69dbf8c