### PR TITLE
feat: support docx resume ingestion

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  testPathIgnorePatterns: ['/src/tests/pdfParser.test.ts'],
+  testPathIgnorePatterns: ['/src/tests/resumeIngest.test.ts'],
   setupFiles: ['<rootDir>/src/tests/setup.ts'],
   globals: {
     'ts-jest': {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-refresh": "^0.11.0",
     "recharts": "^2.10.3",
     "uuid": "^11.1.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "docx-parser": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/talentforge/ResumeManager.tsx
+++ b/src/components/talentforge/ResumeManager.tsx
@@ -18,7 +18,7 @@ import { getResumes, addResume } from "@/utils/talentforge/dataStore";
 import type { ResumeEntry } from "@/types";
 
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
-import { pdfToText, parseResumeText } from "@/utils/talentforge/pdfParser";
+import { fileToText, parseResumeText } from "@/utils/talentforge/resumeIngest";
 import { parsePastedHtml } from "@/utils/talentforge/pasteParser";
 import { tagResume } from "@/utils/talentforge/tagging";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
@@ -101,19 +101,32 @@ export default function ResumeManager() {
         onClose={() => setOpenKeyModal(false)}
       />
       <FileUploader
-        accept=".pdf,.txt,.md"
+        accept=".pdf,.docx,.txt,.md"
         label="Upload your resume"
         outputType="files"
+        limit={10}
         sx={{ mb: 2 }}
         onChange={async (filesFromParam) => {
           const files = filesFromParam as File[];
           if (!files || files.length === 0) return;
-          const file = files[0];
-          const content =
-            file.type === "application/pdf"
-              ? await pdfToText(file)
-              : await file.text();
-          setText(content);
+          for (const file of files) {
+            const content = await fileToText(file);
+            const tags = await tagResume(content);
+            const parsed = parseResumeText(content);
+            addResume({
+              id: uuid(),
+              userId: "",
+              label: "",
+              title: "",
+              url: "",
+              content,
+              parsed,
+              tags,
+            });
+          }
+          setResumes(getResumes());
+          setText("");
+          setToastOpen(true);
         }}
       />
       <TextField

--- a/src/components/talentforge/ResumePaste.tsx
+++ b/src/components/talentforge/ResumePaste.tsx
@@ -13,7 +13,7 @@ import {
 
 import useResumeParser from "@/hooks/useResumeParser";
 import { parsePastedHtml } from "@/utils/talentforge/pasteParser";
-import { parseResumeText } from "@/utils/talentforge/pdfParser";
+import { parseResumeText } from "@/utils/talentforge/resumeIngest";
 import { addResume } from "@/utils/talentforge/dataStore";
 import { v4 as uuid } from "uuid";
 

--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button, Stack } from "@mui/material";
 import { v4 as uuid } from "uuid";
 
-import { pdfToText, parseResumeText } from "@/utils/talentforge/pdfParser";
+import { fileToText, parseResumeText } from "@/utils/talentforge/resumeIngest";
 import { addResume } from "@/utils/talentforge/dataStore";
 import { tagResume } from "@/utils/talentforge/tagging";
 
@@ -26,7 +26,7 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
     if (!file) return;
     setLoading(true);
     try {
-      const text = await pdfToText(file);
+      const text = await fileToText(file);
       const tags = await tagResume(text);
       const parsed = parseResumeText(text);
       addResume({
@@ -51,6 +51,7 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
           Upload Resume
           <input
             type="file"
+            accept=".pdf,.docx,.txt,.md"
             hidden
             onChange={handleFileChange}
           />

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -19,7 +19,7 @@ import OpenAIKeyModal from "../OpenAiKeyModal";
 import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
 import { getResumes, addResume, addOffer } from "@/utils/talentforge/dataStore";
 import { tagResume } from "@/utils/talentforge/tagging";
-import { parseResumeText } from "@/utils/talentforge/pdfParser";
+import { parseResumeText } from "@/utils/talentforge/resumeIngest";
 import { v4 as uuid } from "uuid";
 import type { ApplicationRecord, ResumeEntry, Offer } from "@/types";
 

--- a/src/hooks/useResumeParser.ts
+++ b/src/hooks/useResumeParser.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 
-import { pdfToText } from "@/utils/talentforge/pdfParser";
+import { fileToText } from "@/utils/talentforge/resumeIngest";
 
 export default function useResumeParser() {
   const [resume, setResume] = useState("");
@@ -10,7 +10,7 @@ export default function useResumeParser() {
       setResume(input);
       return input;
     }
-    const text = await pdfToText(input);
+    const text = await fileToText(input);
     setResume(text);
     return text;
   }, []);

--- a/src/tests/resumeIngest.test.ts
+++ b/src/tests/resumeIngest.test.ts
@@ -1,4 +1,4 @@
-import { cleanPdfText, parseResumeText } from "@/utils/talentforge/pdfParser";
+import { cleanPdfText, parseResumeText } from "@/utils/talentforge/resumeIngest";
 
 // pdfjs-dist is only needed for pdf parsing, which these tests don't exercise.
 // Mock it to avoid issues loading the actual ESM bundle in Jest.

--- a/src/tests/talentforge/loaders.test.tsx
+++ b/src/tests/talentforge/loaders.test.tsx
@@ -54,7 +54,7 @@ jest.mock('@/utils/talentforge/utils', () => ({
   pdfToMarkdown: jest.fn(),
   pdfToText: jest.fn(),
 }));
-jest.mock('@/utils/talentforge/pdfParser', () => ({
+jest.mock('@/utils/talentforge/resumeIngest', () => ({
   parseResumeText: jest.fn(),
 }));
 jest.mock('@/utils/talentforge/pasteParser', () => ({

--- a/src/types/docx-parser.d.ts
+++ b/src/types/docx-parser.d.ts
@@ -1,0 +1,8 @@
+declare module "docx-parser" {
+  export default function parseDocx(
+    buffer: ArrayBuffer | Uint8Array | Buffer,
+  ): Promise<string>;
+  export function parseDocx(
+    buffer: ArrayBuffer | Uint8Array | Buffer,
+  ): Promise<string>;
+}

--- a/src/utils/talentforge/resumeIngest.ts
+++ b/src/utils/talentforge/resumeIngest.ts
@@ -127,6 +127,37 @@ export async function pdfToText(file: File): Promise<string> {
 }
 
 /**
+ * Extract plain text from a DOCX file using docx-parser.
+ */
+export async function docxToText(file: File): Promise<string> {
+  const arrayBuffer = await file.arrayBuffer();
+  const parser = (await import("docx-parser")) as {
+    default?: (b: ArrayBuffer | Uint8Array | Buffer) => Promise<string>;
+    parseDocx?: (b: ArrayBuffer | Uint8Array | Buffer) => Promise<string>;
+  };
+  const fn = parser.default || parser.parseDocx;
+  return fn ? await fn(arrayBuffer) : "";
+}
+
+/**
+ * Extract text from a file, supporting PDF and DOCX.
+ */
+export async function fileToText(file: File): Promise<string> {
+  const name = file.name.toLowerCase();
+  if (file.type === "application/pdf" || name.endsWith(".pdf")) {
+    return pdfToText(file);
+  }
+  if (
+    file.type ===
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+    name.endsWith(".docx")
+  ) {
+    return docxToText(file);
+  }
+  return await file.text();
+}
+
+/**
  * Naively extract sections from resume text.
  * Everything before the first recognized section header is treated as contact information.
  */
@@ -178,6 +209,20 @@ export async function parsePdf(
   file: File,
 ): Promise<{ text: string; parsed: ParsedResume }> {
   const text = await pdfToText(file);
+  return { text, parsed: parseResumeText(text) };
+}
+
+export async function parseDocx(
+  file: File,
+): Promise<{ text: string; parsed: ParsedResume }> {
+  const text = await docxToText(file);
+  return { text, parsed: parseResumeText(text) };
+}
+
+export async function parseResumeFile(
+  file: File,
+): Promise<{ text: string; parsed: ParsedResume }> {
+  const text = await fileToText(file);
   return { text, parsed: parseResumeText(text) };
 }
 


### PR DESCRIPTION
## Summary
- rename pdf parser to `resumeIngest` and add `docx` parsing
- allow multiple resume uploads with one entry per file
- accept `.docx` files during onboarding and resume management

## Testing
- `npm test`
- `npm run lint && echo LINT_OK`


------
https://chatgpt.com/codex/tasks/task_e_68c791a463e483308f88fc7628fc0414