### PR TITLE
Fix possessive typo in testimonial copy

### DIFF
--- a/src/consts/resumeData.ts
+++ b/src/consts/resumeData.ts
@@ -398,7 +398,7 @@ I enjoy working with Richard very much, and would choose to be on a team with hi
       imageSrcUrl: "/colleagues/satyajeet_nandekar.jpeg",
       text: `It is a pleasure to work with Richard Franks in the same team for more than 5 years. During this time, we worked very closely on multiple successful projects from start to finish. He is creative, energetic, solution oriented, highly motivated with great communication skills and aims for excellence all the time.
 
-Richards’s deeper understanding of the technical nuances always helped us during the tough time of our project. His inputs in design discussions and architecture meetings have always been valuable. From my past experience, I can easily say that a problem assigned to him is already half solved. He is an asset to any company.`,
+Richard’s deeper understanding of the technical nuances always helped us during the tough time of our project. His inputs in design discussions and architecture meetings have always been valuable. From my past experience, I can easily say that a problem assigned to him is already half solved. He is an asset to any company.`,
     },
     {
       name: "Jane Florins",


### PR DESCRIPTION
## Summary
- correct the Satyajeet Nandekar testimonial to use the proper "Richard’s" possessive

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb8f7579788330b10b7dc64bb5224c