### PR TITLE
Expand keyboard move tests for additional arrow keys

### DIFF
--- a/src/tests/talentforge/keyboardMoves.test.ts
+++ b/src/tests/talentforge/keyboardMoves.test.ts
@@ -1,16 +1,24 @@
 import { getNextStatus } from "@/utils/talentforge/keyboard";
 
+const advancingKeys = ["ArrowRight", "ArrowDown"] as const;
+const retreatingKeys = ["ArrowLeft", "ArrowUp"] as const;
+const clampCases = [
+  ["applied", "ArrowLeft"],
+  ["applied", "ArrowUp"],
+  ["rejected", "ArrowRight"],
+  ["rejected", "ArrowDown"],
+] as const;
+
 describe("keyboard move helpers", () => {
-  test("ArrowRight advances status", () => {
-    expect(getNextStatus("applied", "ArrowRight")).toBe("interview");
+  test.each(advancingKeys)("%s advances status", (key) => {
+    expect(getNextStatus("applied", key)).toBe("interview");
   });
 
-  test("ArrowLeft goes back", () => {
-    expect(getNextStatus("offer", "ArrowLeft")).toBe("interview");
+  test.each(retreatingKeys)("%s goes back", (key) => {
+    expect(getNextStatus("offer", key)).toBe("interview");
   });
 
-  test("clamps at ends", () => {
-    expect(getNextStatus("applied", "ArrowLeft")).toBe("applied");
-    expect(getNextStatus("rejected", "ArrowRight")).toBe("rejected");
+  test.each(clampCases)("clamps %s when pressing %s", (status, key) => {
+    expect(getNextStatus(status, key)).toBe(status);
   });
 });


### PR DESCRIPTION
## Summary
- cover the keyboard move helper with parameterized tests for all arrow directions
- assert clamping behavior when navigating beyond the first and last statuses

## Testing
- npm test -- --runTestsByPath src/tests/talentforge/keyboardMoves.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb8f9bbaf08330b8476b7ace4a394f