### PR TITLE
Handle empty PDF context progress and add tests

### DIFF
--- a/src/tests/bookworm/utils.test.ts
+++ b/src/tests/bookworm/utils.test.ts
@@ -1,0 +1,43 @@
+import { askOpenAI } from "../../utils/bookworm/utils";
+
+jest.mock("pdfjs-dist", () => ({
+  GlobalWorkerOptions: { workerSrc: "" },
+  version: "test-version",
+  getDocument: jest.fn(() => ({ promise: Promise.resolve({ numPages: 0 }) })),
+}));
+
+describe("bookworm askOpenAI", () => {
+  const globalWithFetch = global as unknown as { fetch: jest.Mock };
+
+  beforeEach(() => {
+    globalWithFetch.fetch = jest.fn();
+  });
+
+  test("onPDFProgressChange receives numeric progress for empty context", async () => {
+    globalWithFetch.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{
+          message: { content: "response" },
+        }],
+      }),
+    });
+
+    const onPDFProgressChange = jest.fn();
+
+    await askOpenAI({
+      context: "",
+      user: "Question?",
+      system: "System with {{context}}",
+      chatHistory: [],
+      onChatHistoryChange: jest.fn(),
+      onPDFProgressChange,
+    });
+
+    expect(onPDFProgressChange).toHaveBeenCalled();
+    const progressValue = onPDFProgressChange.mock.calls[0][0];
+    expect(typeof progressValue).toBe("number");
+    expect(Number.isNaN(progressValue)).toBe(false);
+    expect(progressValue).toBe(100);
+  });
+});

--- a/src/tests/talentforge/utils.test.ts
+++ b/src/tests/talentforge/utils.test.ts
@@ -1,0 +1,43 @@
+import { askOpenAI } from "../../utils/talentforge/utils";
+
+jest.mock("pdfjs-dist", () => ({
+  GlobalWorkerOptions: { workerSrc: "" },
+  version: "test-version",
+  getDocument: jest.fn(() => ({ promise: Promise.resolve({ numPages: 0 }) })),
+}));
+
+describe("talentforge askOpenAI", () => {
+  const globalWithFetch = global as unknown as { fetch: jest.Mock };
+
+  beforeEach(() => {
+    globalWithFetch.fetch = jest.fn();
+  });
+
+  test("onPDFProgressChange receives numeric progress for empty context", async () => {
+    globalWithFetch.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{
+          message: { content: "response" },
+        }],
+      }),
+    });
+
+    const onPDFProgressChange = jest.fn();
+
+    await askOpenAI({
+      context: "",
+      user: "Question?",
+      system: "System with {{context}}",
+      chatHistory: [],
+      onChatHistoryChange: jest.fn(),
+      onPDFProgressChange,
+    });
+
+    expect(onPDFProgressChange).toHaveBeenCalled();
+    const progressValue = onPDFProgressChange.mock.calls[0][0];
+    expect(typeof progressValue).toBe("number");
+    expect(Number.isNaN(progressValue)).toBe(false);
+    expect(progressValue).toBe(100);
+  });
+});

--- a/src/utils/bookworm/utils.ts
+++ b/src/utils/bookworm/utils.ts
@@ -96,6 +96,7 @@ export const askOpenAI = async ({
 
   const newChatIndex = newChatHistory.length - 1;
   const initialContext = `${context}`;
+  const totalContextLength = initialContext.length;
 
   let responseText = "";
 
@@ -122,10 +123,13 @@ export const askOpenAI = async ({
     };
 
     context = rest;
-    onPDFProgressChange?.(
-      ((initialContext.length - rest.length) / (1.0 * initialContext.length)) *
-        100
-    );
+
+    const progress =
+      totalContextLength === 0
+        ? 100
+        : ((totalContextLength - rest.length) / totalContextLength) * 100;
+
+    onPDFProgressChange?.(progress);
 
     if (returnFirstResponse && responseText) {
       break;

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -129,6 +129,7 @@ export const askOpenAI = async ({
 
   const newChatIndex = newChatHistory.length - 1;
   const initialContext = `${context}`;
+  const totalContextLength = initialContext.length;
 
   let responseText = "";
 
@@ -155,10 +156,13 @@ export const askOpenAI = async ({
     };
 
     context = rest;
-    onPDFProgressChange?.(
-      ((initialContext.length - rest.length) / (1.0 * initialContext.length)) *
-        100
-    );
+
+    const progress =
+      totalContextLength === 0
+        ? 100
+        : ((totalContextLength - rest.length) / totalContextLength) * 100;
+
+    onPDFProgressChange?.(progress);
 
     if (returnFirstResponse && responseText) {
       break;


### PR DESCRIPTION
## Summary
- guard the PDF progress calculation in Talentforge and Bookworm askOpenAI helpers so an empty context does not divide by zero
- add targeted Talentforge and Bookworm Jest specs that confirm the progress callback receives a concrete value when the context string is empty

## Testing
- npm test -- --runTestsByPath src/tests/talentforge/utils.test.ts
- npm test -- --runTestsByPath src/tests/bookworm/utils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb8f81b5e0833084173b95e75d94ed