### PR TITLE
Introduce OpenAI key context for TalentForge

### DIFF
--- a/src/app/talentforge/layout.tsx
+++ b/src/app/talentforge/layout.tsx
@@ -5,6 +5,7 @@ import { CssBaseline, PaletteMode, ThemeProvider, useMediaQuery } from "@mui/mat
 import LayoutShell from "@/components/talentforge/LayoutShell";
 import getTalentforgeTheme from "@/themes/talentforgeTheme";
 import { TalentForgeDataProvider } from "@/contexts/TalentForgeDataContext";
+import { OpenAIKeyProvider } from "@/contexts/OpenAIKeyContext";
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 
 export default function TalentForgeLayout({
@@ -31,19 +32,21 @@ export default function TalentForgeLayout({
   ];
 
   return (
-    <TalentForgeDataProvider>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <ErrorBoundary>
-          <LayoutShell
-            navItems={navItems}
-            mode={mode}
-            toggleColorMode={toggleColorMode}
-          >
-            {children}
-          </LayoutShell>
-        </ErrorBoundary>
-      </ThemeProvider>
-    </TalentForgeDataProvider>
+    <OpenAIKeyProvider>
+      <TalentForgeDataProvider>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <ErrorBoundary>
+            <LayoutShell
+              navItems={navItems}
+              mode={mode}
+              toggleColorMode={toggleColorMode}
+            >
+              {children}
+            </LayoutShell>
+          </ErrorBoundary>
+        </ThemeProvider>
+      </TalentForgeDataProvider>
+    </OpenAIKeyProvider>
   );
 }

--- a/src/components/talentforge/OpenAiKeyModal.tsx
+++ b/src/components/talentforge/OpenAiKeyModal.tsx
@@ -17,12 +17,7 @@ import {
 } from "@mui/material";
 import { Close } from "@mui/icons-material";
 
-import { setOpenAIKey as setInMemoryKey } from "@/utils/talentforge/utils";
-import {
-  getOpenAIKey,
-  setOpenAIKey as persistOpenAIKey,
-  deleteOpenAIKey,
-} from "@/utils/talentforge/dataStore";
+import { useOpenAIKey } from "@/contexts/OpenAIKeyContext";
 
 export interface OpenAIKeyModalProps
   extends Omit<DialogProps, "open" | "onClose"> {
@@ -35,65 +30,27 @@ export default function OpenAIKeyModal({
   onClose,
   ...props
 }: OpenAIKeyModalProps) {
-  const [key, setKey] = React.useState("");
-  const [persist, setPersist] = React.useState(false);
-
-  const loadStoredKey = React.useCallback(() => {
-    if (typeof window === "undefined") return;
-
-    const storedPersist = window.localStorage.getItem(
-      "talentforge-openai-key-persist",
-    );
-    const shouldPersist = storedPersist === "true";
-    setPersist(shouldPersist);
-
-    const storedKey = shouldPersist
-      ? getOpenAIKey() || ""
-      : window.sessionStorage.getItem("talentforge-openai-key") || "";
-
-    if (storedKey) {
-      setInMemoryKey(storedKey);
-      if (!shouldPersist) {
-        deleteOpenAIKey();
-      }
-      setKey(storedKey);
-    }
-  }, []);
-
-  React.useEffect(() => {
-    loadStoredKey();
-  }, [loadStoredKey]);
+  const { key: storedKey, persist, setKey, setPersist, setValidity } =
+    useOpenAIKey();
+  const [draftKey, setDraftKey] = React.useState(storedKey);
 
   React.useEffect(() => {
     if (open) {
-      loadStoredKey();
+      setDraftKey(storedKey);
     }
-  }, [open, loadStoredKey]);
+  }, [open, storedKey]);
 
   const handleClose = () => {
-    setKey("");
+    setDraftKey(storedKey);
     onClose?.();
   };
 
   const handleSave = () => {
-    const trimmed = key.trim();
+    const trimmed = draftKey.trim();
     if (!trimmed) return;
 
-    setInMemoryKey(trimmed);
-    if (typeof window !== "undefined") {
-      window.sessionStorage.setItem("talentforge-openai-key", trimmed);
-      window.localStorage.setItem(
-        "talentforge-openai-key-persist",
-        persist ? "true" : "false",
-      );
-
-      if (persist) {
-        persistOpenAIKey(trimmed);
-      } else {
-        deleteOpenAIKey();
-      }
-    }
-
+    setKey(trimmed);
+    setDraftKey(trimmed);
     handleClose();
   };
 
@@ -102,20 +59,16 @@ export default function OpenAIKeyModal({
   ) => {
     const value = e.target.checked;
     setPersist(value);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(
-        "talentforge-openai-key-persist",
-        value ? "true" : "false",
-      );
-      if (!value) {
-        deleteOpenAIKey();
-      }
-    }
   };
 
   const handleTest = async () => {
-    const trimmed = key.trim();
+    const trimmed = draftKey.trim();
     if (!trimmed) return;
+    const normalizedStored = storedKey.trim();
+    const isCurrentKey = trimmed === normalizedStored;
+    if (isCurrentKey) {
+      setValidity("checking");
+    }
     try {
       const res = await fetch("/api/test-openai-key", {
         method: "POST",
@@ -124,11 +77,20 @@ export default function OpenAIKeyModal({
       });
       if (res.ok) {
         alert("Key is valid!");
+        if (isCurrentKey) {
+          setValidity("valid");
+        }
       } else {
         alert("Key test failed.");
+        if (isCurrentKey) {
+          setValidity("invalid");
+        }
       }
     } catch {
       alert("Key test failed.");
+      if (isCurrentKey) {
+        setValidity("invalid");
+      }
     }
   };
 
@@ -170,8 +132,8 @@ export default function OpenAIKeyModal({
           label="OpenAI API Key"
           type="password"
           fullWidth
-          value={key}
-          onChange={(e) => setKey(e.target.value)}
+          value={draftKey}
+          onChange={(e) => setDraftKey(e.target.value)}
         />
         <FormControlLabel
           control={<Switch checked={persist} onChange={handlePersistChange} />}
@@ -180,10 +142,10 @@ export default function OpenAIKeyModal({
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={handleTest} disabled={!key.trim()}>
+        <Button onClick={handleTest} disabled={!draftKey.trim()}>
           Test Key
         </Button>
-        <Button onClick={handleSave} disabled={!key.trim()}>
+        <Button onClick={handleSave} disabled={!draftKey.trim()}>
           Save
         </Button>
       </DialogActions>

--- a/src/components/talentforge/Settings.tsx
+++ b/src/components/talentforge/Settings.tsx
@@ -16,16 +16,15 @@ import {
 } from "@mui/material";
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 import OpenAIKeyModal from "@/components/talentforge/OpenAiKeyModal";
-import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
 import { loadDemoData, clearDemoData } from "@/utils/talentforge/demoData";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import { exportSnapshot, importSnapshot } from "@/utils/talentforge/snapshot";
 import { SNAPSHOT_VERSION } from "@/utils/talentforge/dataStore";
+import { useOpenAIKey } from "@/contexts/OpenAIKeyContext";
 
 export default function Settings() {
   const dataStore = useTalentForgeData();
   const [openKeyModal, setOpenKeyModal] = React.useState(false);
-  const [openAiKeySet, setOpenAiKeySet] = React.useState(false);
   const [comp, setComp] = React.useState({
     salary: "",
     benefits: "",
@@ -33,18 +32,14 @@ export default function Settings() {
   });
   const [toastOpen, setToastOpen] = React.useState(false);
   const [toastMessage, setToastMessage] = React.useState("");
+  const { hasKey, clearKey, reloadFromStorage } = useOpenAIKey();
 
   React.useEffect(() => {
-    setOpenAiKeySet(hasOpenAIKey());
     setComp(dataStore.getCurrentCompensation());
   }, [dataStore]);
 
   const handleRemoveKey = () => {
-    setOpenAIKey("");
-    if (typeof window !== "undefined") {
-      window.localStorage.removeItem("talentforge-openai-key");
-    }
-    setOpenAiKeySet(false);
+    clearKey();
   };
 
   const handleExport = () => {
@@ -74,7 +69,7 @@ export default function Settings() {
       if (typeof text === "string") {
         try {
           importSnapshot(text);
-          setOpenAiKeySet(hasOpenAIKey());
+          reloadFromStorage();
           setToastMessage("Snapshot imported");
         } catch {
           setToastMessage("Import failed");
@@ -88,7 +83,6 @@ export default function Settings() {
 
   const handleCloseModal = () => {
     setOpenKeyModal(false);
-    setOpenAiKeySet(hasOpenAIKey());
   };
 
   const handleLoadDemo = () => {
@@ -117,14 +111,14 @@ export default function Settings() {
               OpenAI API Key
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              {openAiKeySet ? "A key is currently stored." : "No key has been set."}
+              {hasKey ? "A key is currently stored." : "No key has been set."}
             </Typography>
           </CardContent>
           <CardActions>
             <Button variant="contained" onClick={() => setOpenKeyModal(true)}>
-              {openAiKeySet ? "Update Key" : "Set Key"}
+              {hasKey ? "Update Key" : "Set Key"}
             </Button>
-            {openAiKeySet && <Button onClick={handleRemoveKey}>Remove Key</Button>}
+            {hasKey && <Button onClick={handleRemoveKey}>Remove Key</Button>}
           </CardActions>
         </Card>
 

--- a/src/components/talentforge/onboarding/KeyEntryStep.tsx
+++ b/src/components/talentforge/onboarding/KeyEntryStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Button,
   CircularProgress,
@@ -10,7 +10,8 @@ import {
 } from "@mui/material";
 import CheckCircleOutline from "@mui/icons-material/CheckCircleOutline";
 import ErrorOutline from "@mui/icons-material/ErrorOutline";
-import { askOpenAI, setOpenAIKey } from "@/utils/talentforge/utils";
+import { askOpenAI } from "@/utils/talentforge/utils";
+import { useOpenAIKey } from "@/contexts/OpenAIKeyContext";
 
 interface StepProps {
   onNext: () => void;
@@ -22,41 +23,45 @@ export default function KeyEntryStep({ onNext }: StepProps) {
   const [status, setStatus] = useState<
     "idle" | "checking" | "success" | "error"
   >("idle");
+  const { setKey: setStoredKey, setValidity } = useOpenAIKey();
 
-  const validateKey = async (keyToCheck: string) => {
-    setStatus("checking");
-    setOpenAIKey(keyToCheck);
-    try {
-      await askOpenAI({
-        context: "",
-        user: "ping",
-        system: "{{context}}",
-        logMessagesToChatHistory: false,
-        returnFirstResponse: true,
-        chatHistory: [],
-      });
-      if (keyToCheck === key.trim()) {
-        setStatus("success");
+  const validateKey = useCallback(
+    async (keyToCheck: string) => {
+      setStatus("checking");
+      setStoredKey(keyToCheck, { validity: "checking" });
+      try {
+        await askOpenAI({
+          context: "",
+          user: "ping",
+          system: "{{context}}",
+          logMessagesToChatHistory: false,
+          returnFirstResponse: true,
+          chatHistory: [],
+        });
+        if (keyToCheck === key.trim()) {
+          setStatus("success");
+          setValidity("valid");
+        }
+      } catch {
+        if (keyToCheck === key.trim()) {
+          setStatus("error");
+          setStoredKey("", { validity: "invalid" });
+        }
       }
-    } catch {
-      if (keyToCheck === key.trim()) {
-        setStatus("error");
-        setOpenAIKey("");
-      }
-    }
-  };
+    },
+    [key, setStoredKey, setValidity],
+  );
 
   useEffect(() => {
     const trimmed = key.trim();
     if (!trimmed) {
       setStatus("idle");
-      setOpenAIKey("");
+      setStoredKey("", { validity: "unknown" });
       return;
     }
     const handle = setTimeout(() => validateKey(trimmed), 500);
     return () => clearTimeout(handle);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
+  }, [key, setStoredKey, validateKey]);
 
   const adornment =
     status === "checking"

--- a/src/contexts/OpenAIKeyContext.tsx
+++ b/src/contexts/OpenAIKeyContext.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import * as React from "react";
+import {
+  deleteOpenAIKey as removePersistedKey,
+  getOpenAIKey as loadPersistedKey,
+  setOpenAIKey as persistOpenAIKey,
+} from "@/utils/talentforge/dataStore";
+
+const SESSION_STORAGE_KEY = "talentforge-openai-key";
+const PERSIST_STORAGE_KEY = "talentforge-openai-key-persist";
+
+export type OpenAIKeyValidity = "unknown" | "checking" | "valid" | "invalid";
+
+export interface OpenAIKeyState {
+  key: string;
+  persist: boolean;
+  validity: OpenAIKeyValidity;
+}
+
+class OpenAIKeyStore {
+  private state: OpenAIKeyState;
+  private listeners: Set<() => void>;
+
+  constructor() {
+    this.listeners = new Set();
+    this.state = this.readInitialState();
+    if (typeof window !== "undefined") {
+      this.persistToStorage();
+    }
+  }
+
+  private readInitialState(): OpenAIKeyState {
+    const envKey = (process.env.NEXT_PUBLIC_OPENAI_API_KEY || "").trim();
+
+    if (typeof window === "undefined") {
+      return { key: envKey, persist: false, validity: "unknown" };
+    }
+
+    const storedPersist = window.localStorage.getItem(PERSIST_STORAGE_KEY);
+    const persist = storedPersist === "true";
+    const sessionKey = window.sessionStorage.getItem(SESSION_STORAGE_KEY) || "";
+    const persistedKey = persist ? loadPersistedKey() || "" : "";
+    const key = (sessionKey || persistedKey || envKey).trim();
+
+    return {
+      key,
+      persist,
+      validity: "unknown",
+    };
+  }
+
+  private persistToStorage() {
+    if (typeof window === "undefined") return;
+
+    const { key, persist } = this.state;
+    const trimmed = key.trim();
+
+    if (trimmed) {
+      window.sessionStorage.setItem(SESSION_STORAGE_KEY, trimmed);
+    } else {
+      window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+    }
+
+    window.localStorage.setItem(PERSIST_STORAGE_KEY, persist ? "true" : "false");
+
+    if (persist && trimmed) {
+      persistOpenAIKey(trimmed);
+    } else {
+      removePersistedKey();
+    }
+  }
+
+  getState = (): OpenAIKeyState => this.state;
+
+  private update(partial: Partial<OpenAIKeyState>) {
+    this.state = { ...this.state, ...partial };
+
+    if (!this.state.key.trim() && partial.validity === undefined) {
+      this.state = { ...this.state, validity: "unknown" };
+    }
+
+    if (typeof window !== "undefined") {
+      this.persistToStorage();
+    }
+
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  setKey(
+    key: string,
+    options?: { persist?: boolean; validity?: OpenAIKeyValidity },
+  ) {
+    const trimmed = key.trim();
+    const partial: Partial<OpenAIKeyState> = { key: trimmed };
+
+    if (typeof options?.persist === "boolean") {
+      partial.persist = options.persist;
+    }
+
+    if (options?.validity) {
+      partial.validity = options.validity;
+    } else {
+      partial.validity = "unknown";
+    }
+
+    this.update(partial);
+  }
+
+  setPersist(persist: boolean) {
+    this.update({ persist });
+  }
+
+  setValidity(validity: OpenAIKeyValidity) {
+    this.update({ validity });
+  }
+
+  clearKey() {
+    this.update({ key: "", validity: "unknown" });
+  }
+
+  ensureKey(): string {
+    const trimmed = this.state.key.trim();
+    if (!trimmed) {
+      throw new Error("OpenAI API key is not set");
+    }
+    return trimmed;
+  }
+
+  hasKey(): boolean {
+    return this.state.key.trim().length > 0;
+  }
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  reloadFromStorage() {
+    this.state = this.readInitialState();
+    if (typeof window !== "undefined") {
+      this.persistToStorage();
+    }
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+const store = new OpenAIKeyStore();
+
+const OpenAIKeyContext = React.createContext<OpenAIKeyStore | null>(null);
+
+export function OpenAIKeyProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <OpenAIKeyContext.Provider value={store}>
+      {children}
+    </OpenAIKeyContext.Provider>
+  );
+}
+
+export function useOpenAIKey() {
+  const keyStore = React.useContext(OpenAIKeyContext);
+  if (!keyStore) {
+    throw new Error("useOpenAIKey must be used within an OpenAIKeyProvider");
+  }
+
+  const state = React.useSyncExternalStore(
+    keyStore.subscribe,
+    keyStore.getState,
+    keyStore.getState,
+  );
+
+  const setKey = React.useCallback(
+    (value: string, options?: { persist?: boolean; validity?: OpenAIKeyValidity }) =>
+      keyStore.setKey(value, options),
+    [keyStore],
+  );
+  const setPersist = React.useCallback(
+    (value: boolean) => keyStore.setPersist(value),
+    [keyStore],
+  );
+  const setValidity = React.useCallback(
+    (value: OpenAIKeyValidity) => keyStore.setValidity(value),
+    [keyStore],
+  );
+  const clearKey = React.useCallback(() => keyStore.clearKey(), [keyStore]);
+  const ensureKey = React.useCallback(() => keyStore.ensureKey(), [keyStore]);
+  const hasKey = React.useMemo(() => state.key.trim().length > 0, [state.key]);
+  const reloadFromStorage = React.useCallback(
+    () => keyStore.reloadFromStorage(),
+    [keyStore],
+  );
+
+  return {
+    key: state.key,
+    persist: state.persist,
+    validity: state.validity,
+    hasKey,
+    setKey,
+    setPersist,
+    setValidity,
+    clearKey,
+    ensureKey,
+    reloadFromStorage,
+  };
+}
+
+export function ensureOpenAIKey(): string {
+  return store.ensureKey();
+}
+
+export function hasOpenAIKey(): boolean {
+  return store.hasKey();
+}
+
+export function setOpenAIKey(
+  key: string,
+  options?: { persist?: boolean; validity?: OpenAIKeyValidity },
+): void {
+  store.setKey(key, options);
+}
+
+export function setOpenAIKeyValidity(validity: OpenAIKeyValidity): void {
+  store.setValidity(validity);
+}
+
+export function clearStoredOpenAIKey(): void {
+  store.clearKey();
+}
+
+export function getOpenAIKeySnapshot(): OpenAIKeyState {
+  return store.getState();
+}
+
+export function reloadOpenAIKeyFromStorage(): void {
+  store.reloadFromStorage();
+}

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,30 +1,39 @@
 export {};
 
-const storage: Record<string, string> = {};
-
-const localStorageMock = {
-  getItem: (key: string) => (key in storage ? storage[key] : null),
-  setItem: (key: string, value: string) => {
-    storage[key] = String(value);
-  },
-  removeItem: (key: string) => {
-    delete storage[key];
-  },
-  clear: () => {
-    for (const key of Object.keys(storage)) {
+const createStorage = () => {
+  const storage: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in storage ? storage[key] : null),
+    setItem: (key: string, value: string) => {
+      storage[key] = String(value);
+    },
+    removeItem: (key: string) => {
       delete storage[key];
-    }
-  },
-  key: (index: number) => Object.keys(storage)[index] ?? null,
-  get length() {
-    return Object.keys(storage).length;
-  },
-} as const;
+    },
+    clear: () => {
+      for (const key of Object.keys(storage)) {
+        delete storage[key];
+      }
+    },
+    key: (index: number) => Object.keys(storage)[index] ?? null,
+    get length() {
+      return Object.keys(storage).length;
+    },
+  } as const;
+};
+
+const localStorageMock = createStorage();
+const sessionStorageMock = createStorage();
 
 const g = globalThis as unknown as {
   localStorage: typeof localStorageMock;
-  window: { localStorage: typeof localStorageMock };
+  sessionStorage: typeof sessionStorageMock;
+  window: {
+    localStorage: typeof localStorageMock;
+    sessionStorage: typeof sessionStorageMock;
+  };
 };
 
 g.localStorage = localStorageMock;
-g.window = { localStorage: localStorageMock };
+g.sessionStorage = sessionStorageMock;
+g.window = { localStorage: localStorageMock, sessionStorage: sessionStorageMock };

--- a/src/utils/autoReply.ts
+++ b/src/utils/autoReply.ts
@@ -1,22 +1,22 @@
 "use client";
 
+import {
+  ensureOpenAIKey as ensureStoredOpenAIKey,
+  hasOpenAIKey as hasStoredOpenAIKey,
+  setOpenAIKey as setStoredOpenAIKey,
+} from "@/contexts/OpenAIKeyContext";
+import {
+  AUTO_REPLY_TEMPLATES,
+  type AutoReplyTemplate,
+} from "./autoReply/templates";
+
+export { AUTO_REPLY_TEMPLATES };
+export type { AutoReplyTemplate };
+
 export interface AutoReplyMessage {
   role: "system" | "user" | "assistant";
   content: string;
 }
-
-export const AUTO_REPLY_TEMPLATES = {
-  general:
-    "You are a helpful assistant crafting concise professional replies to incoming messages.",
-  politeFollowUp:
-    "You are a helpful assistant that writes courteous follow-up messages to check in professionally.",
-  politeDecline:
-    "You are a helpful assistant that politely declines opportunities while maintaining professionalism.",
-  requestMoreInfo:
-    "You are a helpful assistant that requests more information when needed while remaining courteous.",
-} as const;
-
-export type AutoReplyTemplate = keyof typeof AUTO_REPLY_TEMPLATES;
 
 export const buildAutoReplyMessages = (
   template: AutoReplyTemplate,
@@ -27,17 +27,18 @@ export const buildAutoReplyMessages = (
   { role: "user", content },
 ];
 
-let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || "";
-
 export const setOpenAIKey = (key: string) => {
-  apiKey = key;
+  setStoredOpenAIKey(key);
 };
 
-export const hasOpenAIKey = () => apiKey.trim().length > 0;
+export const hasOpenAIKey = () => hasStoredOpenAIKey();
+
+export const ensureOpenAIKey = () => ensureStoredOpenAIKey();
 
 export async function autoReply(
   messages: AutoReplyMessage[],
 ): Promise<string> {
+  const apiKey = ensureStoredOpenAIKey();
   const response = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",
     headers: {

--- a/src/utils/autoReply/templates.ts
+++ b/src/utils/autoReply/templates.ts
@@ -1,0 +1,12 @@
+export const AUTO_REPLY_TEMPLATES = {
+  general:
+    "You are a helpful assistant crafting concise professional replies to incoming messages.",
+  politeFollowUp:
+    "You are a helpful assistant that writes courteous follow-up messages to check in professionally.",
+  politeDecline:
+    "You are a helpful assistant that politely declines opportunities while maintaining professionalism.",
+  requestMoreInfo:
+    "You are a helpful assistant that requests more information when needed while remaining courteous.",
+} as const;
+
+export type AutoReplyTemplate = keyof typeof AUTO_REPLY_TEMPLATES;

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -20,7 +20,7 @@ import type {
   OfferComp,
   RecruiterEntry,
 } from "@/types";
-import { AUTO_REPLY_TEMPLATES } from "@/utils/autoReply";
+import { AUTO_REPLY_TEMPLATES } from "@/utils/autoReply/templates";
 
 export type UserProfile = User;
 

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -7,33 +7,27 @@ import { aiBufferSize } from "@/consts/talentforge/consts";
 
 import { Buffer } from "buffer";
 import {
-  getOpenAIKey as loadOpenAIKey,
-  setOpenAIKey as storeOpenAIKey,
-} from "./dataStore";
+  ensureOpenAIKey as ensureStoredOpenAIKey,
+  hasOpenAIKey as hasStoredOpenAIKey,
+  setOpenAIKey as setStoredOpenAIKey,
+} from "@/contexts/OpenAIKeyContext";
+import type { OpenAIKeyValidity } from "@/contexts/OpenAIKeyContext";
 
-let apiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || "";
-if (typeof window !== "undefined" && !apiKey) {
-  apiKey = loadOpenAIKey() || "";
-}
-
-export const setOpenAIKey = (key: string) => {
-  apiKey = key;
-  storeOpenAIKey(key);
+export const setOpenAIKey = (
+  key: string,
+  options?: { persist?: boolean; validity?: OpenAIKeyValidity },
+) => {
+  setStoredOpenAIKey(key, options);
 };
 
-export const hasOpenAIKey = () => {
-  if (apiKey.trim().length > 0) return true;
-  const stored = loadOpenAIKey();
-  if (stored) {
-    apiKey = stored;
-    return true;
-  }
-  return false;
-};
+export const ensureOpenAIKey = () => ensureStoredOpenAIKey();
+
+export const hasOpenAIKey = () => hasStoredOpenAIKey();
 
 export const hasValidOpenAIKey = async () => {
-  if (!hasOpenAIKey()) return false;
+  if (!hasStoredOpenAIKey()) return false;
   try {
+    const apiKey = ensureStoredOpenAIKey();
     const res = await fetch("https://api.openai.com/v1/models", {
       headers: { Authorization: `Bearer ${apiKey}` },
     });
@@ -43,7 +37,7 @@ export const hasValidOpenAIKey = async () => {
   }
 };
 
-const requestCompletion = async (systemMessage: string) => {
+const requestCompletion = async (apiKey: string, systemMessage: string) => {
   const response = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",
     headers: {
@@ -108,6 +102,7 @@ export const askOpenAI = async ({
   onChatHistoryChange?: (chatHistory: (ChatMessage | null)[]) => void;
   onPDFProgressChange?: (progress: number) => void;
 }) => {
+  const apiKey = ensureStoredOpenAIKey();
   const newChatHistory = [
     ...chatHistory,
     logMessagesToChatHistory
@@ -138,7 +133,7 @@ export const askOpenAI = async ({
 
     const systemMessage =
       `Question: ${user}\n\n` + system.replaceAll("{{context}}", context);
-    responseText = await requestCompletion(systemMessage);
+    responseText = await requestCompletion(apiKey, systemMessage);
 
     newChatHistory[newChatIndex] = {
       role: "assistant" as "user" | "assistant",


### PR DESCRIPTION
## Summary
- add an OpenAIKeyContext that tracks the API key, persistence flag, and validity while syncing with storage
- refactor auto-reply utilities and TalentForge helpers to read/write the key through the new context API
- update TalentForge components/layout to consume the provider and adjust tests for session storage mocks

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb8c35be248330ac7afb7e68ffc2ad