### PR TITLE
Refine AI key gating and centralize CTA

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -52,12 +52,8 @@ import {
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
 import EmptyState from "./EmptyState";
 import { PROMPT_TILES } from "@/consts/promptTiles";
-import {
-  askOpenAI,
-  hasValidOpenAIKey,
-  pdfToMarkdown,
-} from "@/utils/talentforge/utils";
-import OpenAIKeyModal from "./OpenAiKeyModal";
+import { askOpenAI, pdfToMarkdown } from "@/utils/talentforge/utils";
+import RequireAIKey from "./RequireAIKey";
 import FileUploader from "./FileUploader";
 import ResumeStepperModal from "./ResumeStepperModal";
 import { exportElementToPdf } from "@/utils/pdfExport";
@@ -324,7 +320,6 @@ export default function ApplicationBoard() {
     useState<JobApplication | null>(null);
   const [drawerApp, setDrawerApp] = useState<JobApplication | null>(null);
   const [rejectReason, setRejectReason] = useState("");
-  const [openKeyModal, setOpenKeyModal] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [liveMessage, setLiveMessage] = useState("");
   const [resumes, setResumes] = useState<ResumeEntry[]>(() => getResumes());
@@ -443,11 +438,6 @@ export default function ApplicationBoard() {
   const runTile = async (tileId: string, app: JobApplication) => {
     const tile = PROMPT_TILES[tileId];
     if (!tile) return;
-    const valid = await hasValidOpenAIKey();
-    if (!valid) {
-      setOpenKeyModal(true);
-      return;
-    }
     if (tileId === "resumeCompare") {
       if (resumes.length === 0) {
         setDrawerTitle(tile.display);
@@ -810,7 +800,8 @@ export default function ApplicationBoard() {
   };
 
   return (
-    <>
+    <RequireAIKey>
+      <>
       <Box
         sx={{
           position: "absolute",
@@ -1151,10 +1142,7 @@ export default function ApplicationBoard() {
           </Box>
         </Drawer>
       )}
-      <OpenAIKeyModal
-        open={openKeyModal}
-        onClose={() => setOpenKeyModal(false)}
-      />
     </>
+    </RequireAIKey>
   );
 }

--- a/src/components/talentforge/ChatAssistant.tsx
+++ b/src/components/talentforge/ChatAssistant.tsx
@@ -12,12 +12,8 @@ import {
 } from "@mui/material";
 
 import { PROMPT_TILES } from "@/consts/promptTiles";
-import {
-  askOpenAI,
-  hasValidOpenAIKey,
-} from "@/utils/talentforge/utils";
+import { askOpenAI } from "@/utils/talentforge/utils";
 import { exportElementToPdf } from "@/utils/pdfExport";
-import OpenAIKeyModal from "./OpenAiKeyModal";
 import RequireAIKey from "./RequireAIKey";
 import { ChatMessage } from "@/types";
 export default function ChatAssistant() {
@@ -40,7 +36,6 @@ export default function ChatAssistant() {
   useEffect(() => {
     localStorage.setItem("chatHistory", JSON.stringify(chatHistory));
   }, [chatHistory]);
-  const [openKeyModal, setOpenKeyModal] = useState(false);
   const chatRef = useRef<HTMLDivElement>(null);
 
   const handleSubmit = async () => {
@@ -48,11 +43,6 @@ export default function ChatAssistant() {
     const tile = PROMPT_TILES[selectedTile];
     const fullText = tile?.fullPrompt;
     if (!fullText) return;
-    const valid = await hasValidOpenAIKey();
-    if (!valid) {
-      setOpenKeyModal(true);
-      return;
-    }
 
     askOpenAI({
       context: "",
@@ -67,10 +57,6 @@ export default function ChatAssistant() {
   return (
     <RequireAIKey>
       <Box>
-        <OpenAIKeyModal
-          open={openKeyModal}
-          onClose={() => setOpenKeyModal(false)}
-        />
         <Stack spacing={2}>
           <Select
             value={selectedTile}

--- a/src/components/talentforge/CoverLetter.tsx
+++ b/src/components/talentforge/CoverLetter.tsx
@@ -10,28 +10,23 @@ import {
   Typography,
 } from "@mui/material";
 
-import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { askOpenAI } from "@/utils/talentforge/utils";
 import { getResumes } from "@/utils/talentforge/dataStore";
 import { exportElementToPdf } from "@/utils/pdfExport";
-import OpenAIKeyModal from "./OpenAiKeyModal";
 import EmptyState from "./EmptyState";
+import RequireAIKey from "./RequireAIKey";
 
 export default function CoverLetter() {
   const [resumeVariantId, setResumeVariantId] = useState("");
   const [jobDescription, setJobDescription] = useState("");
   const [coverLetter, setCoverLetter] = useState("");
   const [loading, setLoading] = useState(false);
-  const [openKeyModal, setOpenKeyModal] = useState(false);
   const coverRef = useRef<HTMLDivElement>(null);
 
   const resumes = getResumes();
 
   const handleGenerate = async () => {
     if (!resumeVariantId || !jobDescription) return;
-    if (!hasOpenAIKey()) {
-      setOpenKeyModal(true);
-      return;
-    }
     const resume = resumes.find((r) => r.id === resumeVariantId);
     if (!resume) return;
     setLoading(true);
@@ -50,66 +45,67 @@ export default function CoverLetter() {
     setLoading(false);
   };
 
-  if (resumes.length === 0) {
-    return (
-      <EmptyState
-        message="No resumes available"
-        helperText="Add a resume before generating a cover letter."
-      />
-    );
-  }
-
   return (
-    <Box>
-      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
-      <Stack spacing={2}>
-        <TextField
-          select
-          label="Resume Variant"
-          value={resumeVariantId}
-          onChange={(e) => setResumeVariantId(e.target.value)}
-        >
-          {resumes.map((r) => (
-            <MenuItem key={r.id} value={r.id}>
-              {r.title}
-            </MenuItem>
-          ))}
-        </TextField>
-        <TextField
-          label="Job Description"
-          multiline
-          minRows={6}
-          value={jobDescription}
-          onChange={(e) => setJobDescription(e.target.value)}
+    <RequireAIKey>
+      {resumes.length === 0 ? (
+        <EmptyState
+          message="No resumes available"
+          helperText="Add a resume before generating a cover letter."
         />
-        <Stack direction="row" spacing={2}>
-          <Button
-            variant="contained"
-            onClick={handleGenerate}
-            disabled={!resumeVariantId || !jobDescription || loading}
-            aria-label="Generate cover letter"
-          >
-            Generate
-          </Button>
-          <Button
-            variant="outlined"
-            disabled={!coverLetter}
-            onClick={() =>
-              coverRef.current &&
-              exportElementToPdf(coverRef.current, "cover-letter.pdf")
-            }
-            aria-label="Export cover letter"
-          >
-            Export
-          </Button>
-        </Stack>
-        {coverLetter && (
-          <Box ref={coverRef}>
-            <Typography sx={{ whiteSpace: "pre-wrap" }}>{coverLetter}</Typography>
-          </Box>
-        )}
-      </Stack>
-    </Box>
+      ) : (
+        <Box>
+          <Stack spacing={2}>
+            <TextField
+              select
+              label="Resume Variant"
+              value={resumeVariantId}
+              onChange={(e) => setResumeVariantId(e.target.value)}
+            >
+              {resumes.map((r) => (
+                <MenuItem key={r.id} value={r.id}>
+                  {r.title}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Job Description"
+              multiline
+              minRows={6}
+              value={jobDescription}
+              onChange={(e) => setJobDescription(e.target.value)}
+            />
+            <Stack direction="row" spacing={2}>
+              <Button
+                variant="contained"
+                onClick={handleGenerate}
+                disabled={!resumeVariantId || !jobDescription || loading}
+                aria-label="Generate cover letter"
+              >
+                Generate
+              </Button>
+              <Button
+                variant="outlined"
+                disabled={!coverLetter}
+                onClick={() =>
+                  coverRef.current &&
+                  exportElementToPdf(coverRef.current, "cover-letter.pdf")
+                }
+                aria-label="Export cover letter"
+              >
+                Export
+              </Button>
+            </Stack>
+            {coverLetter && (
+              <Box ref={coverRef}>
+                <Typography sx={{ whiteSpace: "pre-wrap" }}>
+                  {coverLetter}
+                </Typography>
+              </Box>
+            )}
+          </Stack>
+        </Box>
+      )}
+    </RequireAIKey>
   );
 }
 

--- a/src/components/talentforge/Hero.tsx
+++ b/src/components/talentforge/Hero.tsx
@@ -23,12 +23,8 @@ import {
   userQuestionPrompt,
 } from "@/consts/talentforge/consts";
 import { ChatMessage } from "@/types";
-import {
-  askOpenAI,
-  pdfToMarkdown,
-  hasOpenAIKey,
-} from "@/utils/talentforge/utils";
-import OpenAIKeyModal from "./OpenAiKeyModal";
+import { askOpenAI, pdfToMarkdown } from "@/utils/talentforge/utils";
+import RequireAIKey from "./RequireAIKey";
 
 import CircularProgressWithLabel from "./CircularProgressWithLabel";
 import FileUploader from "./FileUploader";
@@ -46,7 +42,6 @@ export default function Hero() {
   >(0);
   const [pdfProgress, setPdfProgress] = React.useState<number | null>(null);
   const [openTerms, setOpenTerms] = React.useState<boolean>(false);
-  const [openKeyModal, setOpenKeyModal] = React.useState(false);
   const setChatHistory = (newChatHistory: typeof chatHistory) => {
     setChatHistoryState(newChatHistory);
     setActiveQuestionIndex(null);
@@ -56,10 +51,6 @@ export default function Hero() {
   const userQuestionInputRef = React.useRef<HTMLInputElement>(null);
 
   const askUserQuestion = async () => {
-    if (!hasOpenAIKey()) {
-      setOpenKeyModal(true);
-      return;
-    }
     const context =
       pdfAsMarkdown?.length > aiBufferSize ? pdfSummary : pdfAsMarkdown;
 
@@ -122,23 +113,20 @@ export default function Hero() {
   });
 
   return (
-    <Box
-      id="hero"
-      sx={(theme) => ({
-        width: "100%",
-        backgroundImage:
-          theme.palette.mode === "light"
-            ? "linear-gradient(180deg, #CEE5FD, #FFF)"
-            : `linear-gradient(#02294F, ${alpha("#090E10", 0.0)})`,
-        backgroundSize: "100% 20%",
-        backgroundRepeat: "no-repeat",
-      })}
-    >
-      <TermsDialog open={openTerms} onClose={() => setOpenTerms(false)} />
-      <OpenAIKeyModal
-        open={openKeyModal}
-        onClose={() => setOpenKeyModal(false)}
-      />
+    <RequireAIKey>
+      <Box
+        id="hero"
+        sx={(theme) => ({
+          width: "100%",
+          backgroundImage:
+            theme.palette.mode === "light"
+              ? "linear-gradient(180deg, #CEE5FD, #FFF)"
+              : `linear-gradient(#02294F, ${alpha("#090E10", 0.0)})`,
+          backgroundSize: "100% 20%",
+          backgroundRepeat: "no-repeat",
+        })}
+      >
+        <TermsDialog open={openTerms} onClose={() => setOpenTerms(false)} />
       <Container
         sx={{
           display: "flex",
@@ -195,10 +183,6 @@ export default function Hero() {
               outputType="files"
               sx={{ width: { xs: "100%" } }}
               onChange={async (filesFromParam) => {
-                if (!hasOpenAIKey()) {
-                  setOpenKeyModal(true);
-                  return;
-                }
                 const files = filesFromParam as File[];
                 if (files && files.length > 0) {
                   const markdown = await pdfToMarkdown(files[0]);
@@ -399,6 +383,7 @@ export default function Hero() {
           }
         />
       </Container>
-    </Box>
+      </Box>
+    </RequireAIKey>
   );
 }

--- a/src/components/talentforge/JobDescriptionRisk.tsx
+++ b/src/components/talentforge/JobDescriptionRisk.tsx
@@ -9,10 +9,10 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import OpenAIKeyModal from "./OpenAiKeyModal";
-import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { askOpenAI } from "@/utils/talentforge/utils";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import EmptyState from "./EmptyState";
+import RequireAIKey from "./RequireAIKey";
 
 interface Issue {
   severity: "red" | "yellow";
@@ -28,13 +28,8 @@ export default function JobDescriptionRisk() {
   const [jobDescription, setJobDescription] = useState("");
   const [analysis, setAnalysis] = useState<Analysis | null>(null);
   const [loading, setLoading] = useState(false);
-  const [openKeyModal, setOpenKeyModal] = useState(false);
 
   const analyze = async () => {
-    if (!hasOpenAIKey()) {
-      setOpenKeyModal(true);
-      return;
-    }
     if (!jobDescription.trim()) return;
     const context = `Job Description:\n${jobDescription}`;
     const prompt = PROMPT_TEMPLATES.jobDescriptionRisk?.fullText || "";
@@ -61,8 +56,8 @@ export default function JobDescriptionRisk() {
   };
 
   return (
-    <Box>
-      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+    <RequireAIKey>
+      <Box>
       <TextField
         label="Paste job description"
         multiline
@@ -112,7 +107,8 @@ export default function JobDescriptionRisk() {
           />
         )
       )}
-    </Box>
+      </Box>
+    </RequireAIKey>
   );
 }
 

--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -14,12 +14,8 @@ import {
 } from "@mui/material";
 
 import FileUploader from "./FileUploader";
-import {
-  askOpenAI,
-  pdfToMarkdown,
-  hasOpenAIKey,
-} from "@/utils/talentforge/utils";
-import OpenAIKeyModal from "./OpenAiKeyModal";
+import { askOpenAI, pdfToMarkdown } from "@/utils/talentforge/utils";
+import RequireAIKey from "./RequireAIKey";
 import { addOffer } from "@/utils/talentforge/dataStore";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import type { Offer, Message, ApplicationRecord } from "@/types";
@@ -39,7 +35,6 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
     indeed: "",
   });
   const [loading, setLoading] = useState(false);
-  const [openKeyModal, setOpenKeyModal] = useState(false);
 
   const handleFileChange = (
     filesFromParam: File[] | string | { filename: string; type: string; content: string } | undefined
@@ -56,10 +51,6 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
   };
 
   const analyzeOffer = async () => {
-    if (!hasOpenAIKey()) {
-      setOpenKeyModal(true);
-      return;
-    }
     const context = `Offer Letter:\n${offerText}\n\nCurrent Compensation:\n${compensation}`;
     const prompt =
       "Compare the offer letter to the current compensation and summarize key differences. " +
@@ -131,11 +122,8 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
   };
 
   return (
-    <Box>
-      <OpenAIKeyModal
-        open={openKeyModal}
-        onClose={() => setOpenKeyModal(false)}
-      />
+    <RequireAIKey>
+      <Box>
       <Stack spacing={2}>
         <FileUploader
           accept=".pdf,.txt"
@@ -226,7 +214,8 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
           </Box>
         )}
       </Stack>
-    </Box>
+      </Box>
+    </RequireAIKey>
   );
 }
 

--- a/src/components/talentforge/RequireAIKey.tsx
+++ b/src/components/talentforge/RequireAIKey.tsx
@@ -1,35 +1,51 @@
 "use client";
 
-import { ReactNode, useEffect, useState } from "react";
-import { Alert, Box } from "@mui/material";
+import { ReactNode, useRef } from "react";
+import { Alert, Box, Button, Stack } from "@mui/material";
 
-import { hasValidOpenAIKey } from "@/utils/talentforge/utils";
+import OpenAiKeyModal from "./OpenAiKeyModal";
+import useOpenAIKey from "@/hooks/talentforge/useOpenAIKey";
 
 interface RequireAIKeyProps {
   children: ReactNode;
 }
 
 export default function RequireAIKey({ children }: RequireAIKeyProps) {
-  const [hasKey, setHasKey] = useState<boolean | null>(null);
+  const { hasKey, isChecking, modalOpen, openModal, closeModal } =
+    useOpenAIKey();
+  const ctaRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    const checkKey = async () => {
-      const valid = await hasValidOpenAIKey();
-      setHasKey(valid);
-    };
-    checkKey();
-  }, []);
+  const handleClose = () => {
+    closeModal();
+    ctaRef.current?.focus();
+  };
 
-  if (hasKey === null) return null;
-  if (!hasKey) {
-    return (
-      <Box>
-        <Alert severity="warning">
-          OpenAI API key not found. Please add your key to use this feature.
-        </Alert>
-      </Box>
-    );
+  if (isChecking) {
+    return null;
   }
 
-  return <>{children}</>;
+  return (
+    <>
+      <OpenAiKeyModal open={modalOpen} onClose={handleClose} />
+      {hasKey ? (
+        <>{children}</>
+      ) : (
+        <Box role="region" aria-live="polite">
+          <Stack spacing={2} alignItems="flex-start">
+            <Alert severity="warning" sx={{ width: "100%" }}>
+              OpenAI API key not found. Please add your key to use this feature.
+            </Alert>
+            <Button
+              variant="contained"
+              onClick={openModal}
+              ref={ctaRef}
+              autoFocus
+            >
+              Add your OpenAI key
+            </Button>
+          </Stack>
+        </Box>
+      )}
+    </>
+  );
 }

--- a/src/components/talentforge/ResumeStepperModal.tsx
+++ b/src/components/talentforge/ResumeStepperModal.tsx
@@ -23,12 +23,11 @@ import {
 import { filterByTag, filterByText } from "@/utils/search";
 import { getResumes, addResume } from "@/utils/talentforge/dataStore";
 import type { ResumeEntry } from "@/types";
-import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { askOpenAI } from "@/utils/talentforge/utils";
 import { fileToText, parseResumeText } from "@/utils/talentforge/resumeIngest";
 import { parsePastedHtml } from "@/utils/talentforge/pasteParser";
 import { tagResume } from "@/utils/talentforge/tagging";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
-import OpenAIKeyModal from "./OpenAiKeyModal";
 import FileUploader from "./FileUploader";
 import ResumeVariantList from "./ResumeVariants/List";
 
@@ -50,7 +49,6 @@ export default function ResumeStepperModal({
   const [jobDescription, setJobDescription] = useState("");
   const [comparison, setComparison] = useState("");
   const [loadingCompare, setLoadingCompare] = useState(false);
-  const [openKeyModal, setOpenKeyModal] = useState(false);
   const [searchText, setSearchText] = useState("");
   const [searchTag, setSearchTag] = useState("");
   const [loadingResumes, setLoadingResumes] = useState(true);
@@ -141,10 +139,6 @@ export default function ResumeStepperModal({
   };
 
   const handleCompare = async () => {
-    if (!hasOpenAIKey()) {
-      setOpenKeyModal(true);
-      return;
-    }
     if (!text.trim() || !jobDescription.trim()) return;
     const context = `Resume:\n${text}\n\nJob Description:\n${jobDescription}`;
     const prompt = PROMPT_TEMPLATES.compareResumeToJob?.fullText || "";
@@ -415,7 +409,6 @@ export default function ResumeStepperModal({
           )}
         </DialogActions>
       </Dialog>
-      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
       <Snackbar
         open={toastOpen}
         autoHideDuration={3000}

--- a/src/components/talentforge/ScreenRole.tsx
+++ b/src/components/talentforge/ScreenRole.tsx
@@ -9,10 +9,10 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import OpenAIKeyModal from "./OpenAiKeyModal";
-import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
+import { askOpenAI } from "@/utils/talentforge/utils";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import EmptyState from "./EmptyState";
+import RequireAIKey from "./RequireAIKey";
 
 interface Issue {
   severity: "red" | "yellow";
@@ -28,13 +28,8 @@ export default function ScreenRole() {
   const [jobDescription, setJobDescription] = useState("");
   const [analysis, setAnalysis] = useState<Analysis | null>(null);
   const [loading, setLoading] = useState(false);
-  const [openKeyModal, setOpenKeyModal] = useState(false);
 
   const analyze = async () => {
-    if (!hasOpenAIKey()) {
-      setOpenKeyModal(true);
-      return;
-    }
     if (!jobDescription.trim()) return;
     const context = `Job Description:\n${jobDescription}`;
     const prompt = PROMPT_TEMPLATES.screenRole?.fullText || "";
@@ -61,8 +56,8 @@ export default function ScreenRole() {
   };
 
   return (
-    <Box>
-      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
+    <RequireAIKey>
+      <Box>
       <TextField
         label="Paste job description"
         multiline
@@ -112,7 +107,8 @@ export default function ScreenRole() {
           />
         )
       )}
-    </Box>
+      </Box>
+    </RequireAIKey>
   );
 }
 

--- a/src/components/talentforge/Workspace.tsx
+++ b/src/components/talentforge/Workspace.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Box, Button, Stack, Typography } from "@mui/material";
 
 import ErrorBoundary from "./ErrorBoundary";
+import RequireAIKey from "./RequireAIKey";
 import { PROMPT_TILES } from "@/consts/promptTiles";
 import Tile from "./promptTiles/Tile";
 
@@ -34,64 +35,66 @@ export default function Workspace({
 
   return (
     <ErrorBoundary>
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: { xs: "column", md: "row" },
-          gap: 2,
-        }}
-      >
+      <RequireAIKey>
         <Box
           sx={{
-            flex: 1,
-            display: "grid",
-            gridTemplateColumns: {
-              xs: "1fr",
-              sm: "repeat(2, 1fr)",
-              md: "repeat(3, 1fr)",
-            },
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
             gap: 2,
           }}
         >
-          {Object.values(PROMPT_TILES).map((tile) => (
-            <Tile key={tile.id} {...tile} onResponse={setOutput} />
-          ))}
+          <Box
+            sx={{
+              flex: 1,
+              display: "grid",
+              gridTemplateColumns: {
+                xs: "1fr",
+                sm: "repeat(2, 1fr)",
+                md: "repeat(3, 1fr)",
+              },
+              gap: 2,
+            }}
+          >
+            {Object.values(PROMPT_TILES).map((tile) => (
+              <Tile key={tile.id} {...tile} onResponse={setOutput} />
+            ))}
+          </Box>
+          <Box
+            sx={{
+              flexBasis: { md: "30%" },
+              border: 1,
+              borderColor: "divider",
+              p: 2,
+              borderRadius: 1,
+              minHeight: 200,
+            }}
+          >
+            <Typography variant="h6" gutterBottom>
+              Output
+            </Typography>
+            <Box sx={{ whiteSpace: "pre-wrap", mb: 2 }}>{output}</Box>
+            <Stack direction="row" spacing={1}>
+              <Button variant="outlined" onClick={handleCopy} disabled={!output}>
+                Copy
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={handleInsert}
+                disabled={!onInsertIntoThread || !output}
+              >
+                Insert into Thread
+              </Button>
+              <Button
+                variant="contained"
+                onClick={handleSave}
+                disabled={!onSaveResumeVariant || !output}
+              >
+                Save as Resume Variant
+              </Button>
+            </Stack>
+          </Box>
         </Box>
-        <Box
-          sx={{
-            flexBasis: { md: "30%" },
-            border: 1,
-            borderColor: "divider",
-            p: 2,
-            borderRadius: 1,
-            minHeight: 200,
-          }}
-        >
-          <Typography variant="h6" gutterBottom>
-            Output
-          </Typography>
-          <Box sx={{ whiteSpace: "pre-wrap", mb: 2 }}>{output}</Box>
-          <Stack direction="row" spacing={1}>
-            <Button variant="outlined" onClick={handleCopy} disabled={!output}>
-              Copy
-            </Button>
-            <Button
-              variant="outlined"
-              onClick={handleInsert}
-              disabled={!onInsertIntoThread || !output}
-            >
-              Insert into Thread
-            </Button>
-            <Button
-              variant="contained"
-              onClick={handleSave}
-              disabled={!onSaveResumeVariant || !output}
-            >
-              Save as Resume Variant
-            </Button>
-          </Stack>
-        </Box>
-      </Box>
+      </RequireAIKey>
     </ErrorBoundary>
   );
 }

--- a/src/components/talentforge/promptTiles/PromptTileGrid.tsx
+++ b/src/components/talentforge/promptTiles/PromptTileGrid.tsx
@@ -11,11 +11,8 @@ import {
   MenuItem,
 } from "@mui/material";
 
-import OpenAiKeyModal from "../OpenAiKeyModal";
-import {
-  askOpenAI,
-  hasValidOpenAIKey,
-} from "@/utils/talentforge/utils";
+import RequireAIKey from "../RequireAIKey";
+import { askOpenAI } from "@/utils/talentforge/utils";
 import { getResumes } from "@/utils/talentforge/dataStore";
 import { PROMPT_TILES, type PromptTileDefinition } from "@/consts/promptTiles";
 
@@ -40,7 +37,6 @@ export default function PromptTileGrid({
   }, [initialValues]);
   const [responses, setResponses] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState<Record<string, boolean>>({});
-  const [openKeyModal, setOpenKeyModal] = useState(false);
 
   const handleChange = (id: string, key: string, value: string) => {
     setValues((prev) => ({
@@ -52,12 +48,6 @@ export default function PromptTileGrid({
   const runTile = async (id: string) => {
     const tile = registry[id];
     if (!tile) return;
-
-    const valid = await hasValidOpenAIKey();
-    if (!valid) {
-      setOpenKeyModal(true);
-      return;
-    }
 
     setLoading((prev) => ({ ...prev, [id]: true }));
     try {
@@ -102,11 +92,7 @@ export default function PromptTileGrid({
     : Object.values(registry);
 
   return (
-    <>
-      <OpenAiKeyModal
-        open={openKeyModal}
-        onClose={() => setOpenKeyModal(false)}
-      />
+    <RequireAIKey>
       <Grid container spacing={2}>
         {tiles.map((tile) => (
           <Grid item xs={12} sm={6} md={4} key={tile.id}>
@@ -163,7 +149,7 @@ export default function PromptTileGrid({
           </Grid>
         ))}
       </Grid>
-    </>
+    </RequireAIKey>
   );
 }
 

--- a/src/components/talentforge/promptTiles/Tile.tsx
+++ b/src/components/talentforge/promptTiles/Tile.tsx
@@ -15,8 +15,7 @@ import {
 import { ContentCopy } from "@mui/icons-material";
 import Markdown from "react-markdown";
 
-import OpenAIKeyModal from "../OpenAiKeyModal";
-import { askOpenAI, hasValidOpenAIKey } from "@/utils/talentforge/utils";
+import { askOpenAI } from "@/utils/talentforge/utils";
 import { getResumes, addResume, addOffer } from "@/utils/talentforge/dataStore";
 import { tagResume } from "@/utils/talentforge/tagging";
 import { parseResumeText } from "@/utils/talentforge/resumeIngest";
@@ -45,7 +44,6 @@ export default function Tile({
   const [values, setValues] = useState<Record<string, string>>(initialValues);
   const [response, setResponse] = useState("");
   const [loading, setLoading] = useState(false);
-  const [openKeyModal, setOpenKeyModal] = useState(false);
   const [saving, setSaving] = useState(false);
   const [offerDrafts, setOfferDrafts] = useState<
     { email: string; linkedin: string; indeed: string } | null
@@ -74,11 +72,6 @@ export default function Tile({
     getResumes().find((r) => r.id === values["resumeVariantId"]);
 
   const handleRun = async () => {
-    const valid = await hasValidOpenAIKey();
-    if (!valid) {
-      setOpenKeyModal(true);
-      return;
-    }
     setLoading(true);
     try {
       setResponse("");
@@ -264,7 +257,6 @@ export default function Tile({
 
   return (
     <Box>
-      <OpenAIKeyModal open={openKeyModal} onClose={() => setOpenKeyModal(false)} />
       <Stack spacing={1}>
         <Typography variant="subtitle1">{display}</Typography>
         {inputs.map((name) =>

--- a/src/hooks/talentforge/useOpenAIKey.ts
+++ b/src/hooks/talentforge/useOpenAIKey.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { hasOpenAIKey } from "@/utils/talentforge/utils";
+
+const STORAGE_KEYS = [
+  "talentforge-openai-key",
+  "talentforge-openai-key-persist",
+];
+
+export function useOpenAIKey() {
+  const [hasKey, setHasKey] = useState<boolean | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const refresh = useCallback(() => {
+    setHasKey(hasOpenAIKey());
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && !STORAGE_KEYS.includes(event.key)) {
+        return;
+      }
+      refresh();
+    };
+
+    const handleFocus = () => {
+      refresh();
+    };
+
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener("focus", handleFocus);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [refresh]);
+
+  const openModal = useCallback(() => {
+    setModalOpen(true);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setModalOpen(false);
+    refresh();
+  }, [refresh]);
+
+  return {
+    hasKey,
+    isChecking: hasKey === null,
+    openModal,
+    closeModal,
+    modalOpen,
+    refresh,
+  };
+}
+
+export default useOpenAIKey;


### PR DESCRIPTION
## Summary
- add a shared `useOpenAIKey` hook and enhance `RequireAIKey` with an accessible CTA that opens `OpenAiKeyModal`
- remove ad-hoc OpenAI key validation across TalentForge AI entry points and wrap experiences with the gate
- rely on the new gate within chat, prompt grids, offer tools, and other AI flows instead of duplicating modal management

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb8c552c848330828167c581d37cc4