### PR TITLE
feat: add TalentForge data store subscriptions

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -42,13 +42,9 @@ import type {
   OfferComp,
 } from "@/types";
 import {
-  addJobApplication,
-  getJobApplications,
-  updateJobApplicationStatus,
-  updateJobApplication,
-  getResumes,
-  getCurrentCompensation,
-} from "@/utils/talentforge/dataStore";
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
 import EmptyState from "./EmptyState";
 import { PROMPT_TILES } from "@/consts/promptTiles";
@@ -295,7 +291,19 @@ function Card({
 }
 
 export default function ApplicationBoard() {
-  const [applications, setApplications] = useState<JobApplication[]>([]);
+  const dataStore = useTalentForgeData();
+  const applications = useTalentForgeSelector(
+    (store) => store.getJobApplications(),
+    { keys: ["applications"] },
+  );
+  const resumes = useTalentForgeSelector(
+    (store) => store.getResumes(),
+    { keys: ["resumes"] },
+  );
+  const currentCompensation = useTalentForgeSelector(
+    (store) => store.getCurrentCompensation(),
+    { keys: ["currentCompensation"] },
+  );
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [title, setTitle] = useState("");
@@ -327,34 +335,51 @@ export default function ApplicationBoard() {
   const [openKeyModal, setOpenKeyModal] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [liveMessage, setLiveMessage] = useState("");
-  const [resumes, setResumes] = useState<ResumeEntry[]>(() => getResumes());
   const [resumeModalOpen, setResumeModalOpen] = useState(false);
   const negotiationRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const existing = getJobApplications();
-    if (existing.length === 0) {
-      fetchAllListings("").then((listings) => {
-        let apps = existing;
-        listings.forEach((listing) => {
-          apps = addJobApplication({
-            id: uuid(),
-            applicant: { id: "", name: "", email: "" },
-            role: { ...listing, id: uuid() },
-            status: "applied",
-            history: [
-              { status: "applied", changedAt: new Date().toISOString() },
-            ],
-          });
-        });
-        setApplications(apps);
-        setLoading(false);
-      });
-    } else {
-      setApplications(existing);
+    if (!loading) return;
+
+    const existing = dataStore.getJobApplications();
+    if (existing.length > 0) {
       setLoading(false);
+      return;
     }
-  }, []);
+
+    let cancelled = false;
+
+    fetchAllListings("").then((listings) => {
+      if (cancelled) return;
+      let apps = dataStore.getJobApplications();
+      if (apps.length > 0) {
+        setLoading(false);
+        return;
+      }
+      listings.forEach((listing) => {
+        apps = dataStore.addJobApplication({
+          id: uuid(),
+          applicant: { id: "", name: "", email: "" },
+          role: { ...listing, id: uuid() },
+          status: "applied",
+          history: [{ status: "applied", changedAt: new Date().toISOString() }],
+        });
+      });
+      if (!cancelled) {
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dataStore, loading]);
+
+  useEffect(() => {
+    if (resumeId && !resumes.some((r) => r.id === resumeId)) {
+      setResumeId("");
+    }
+  }, [resumeId, resumes]);
 
   if (loading) {
     return (
@@ -373,8 +398,10 @@ export default function ApplicationBoard() {
     const { active, over } = event;
     if (!over) return;
     const newStatus = over.id as ApplicationStatus;
-    const updated = updateJobApplicationStatus(active.id as string, newStatus);
-    setApplications(updated);
+    const updated = dataStore.updateJobApplicationStatus(
+      active.id as string,
+      newStatus,
+    );
     const movedApp = updated.find((a) => a.id === active.id);
     if (movedApp) {
       setLiveMessage(`${movedApp.role.title} moved to ${newStatus}`);
@@ -386,8 +413,7 @@ export default function ApplicationBoard() {
     if (!app) return;
     const newStatus = getNextStatus(app.status, key);
     if (newStatus !== app.status) {
-      const updated = updateJobApplicationStatus(appId, newStatus);
-      setApplications(updated);
+      const updated = dataStore.updateJobApplicationStatus(appId, newStatus);
       const movedApp = updated.find((a) => a.id === appId);
       if (movedApp) {
         setLiveMessage(`${movedApp.role.title} moved to ${newStatus}`);
@@ -429,8 +455,7 @@ export default function ApplicationBoard() {
       status: "applied",
       history: [{ status: "applied", changedAt: new Date().toISOString() }],
     };
-    const updated = addJobApplication(newApp);
-    setApplications(updated);
+    dataStore.addJobApplication(newApp);
     setDialogOpen(false);
     setTitle("");
     setCompany("");
@@ -556,11 +581,13 @@ export default function ApplicationBoard() {
       );
       app.offer?.summary?.forEach((s) => offerLines.push(s));
       const offerText = offerLines.join("\n");
-      const current = getCurrentCompensation();
       const currentLines: string[] = [];
-      if (current.salary) currentLines.push(`Salary: ${current.salary}`);
-      if (current.benefits) currentLines.push(`Benefits: ${current.benefits}`);
-      if (current.stock) currentLines.push(`Stock: ${current.stock}`);
+      if (currentCompensation.salary)
+        currentLines.push(`Salary: ${currentCompensation.salary}`);
+      if (currentCompensation.benefits)
+        currentLines.push(`Benefits: ${currentCompensation.benefits}`);
+      if (currentCompensation.stock)
+        currentLines.push(`Stock: ${currentCompensation.stock}`);
       const currentComp = currentLines.join("\n");
       const prompt = tile.fullPrompt
         .replaceAll("{{offer}}", offerText)
@@ -650,18 +677,15 @@ export default function ApplicationBoard() {
   const handleAssignResume = (appId: string, resId: string) => {
     const resume = resumes.find((r) => r.id === resId);
     if (!resume) return;
-    const updated = updateJobApplication(appId, { resumeVariant: resume });
-    setApplications(updated);
+    dataStore.updateJobApplication(appId, { resumeVariant: resume });
   };
 
   const handleInterviewDate = (appId: string, value: string) => {
-    const updated = updateJobApplication(appId, { interviewDateTime: value });
-    setApplications(updated);
+    dataStore.updateJobApplication(appId, { interviewDateTime: value });
   };
 
   const handleInterviewLocation = (appId: string, value: string) => {
-    const updated = updateJobApplication(appId, { interviewLocation: value });
-    setApplications(updated);
+    dataStore.updateJobApplication(appId, { interviewLocation: value });
   };
 
   const handleOfferUpload = async (file: File) => {
@@ -710,14 +734,14 @@ export default function ApplicationBoard() {
         compensation: parsed.compensation || [],
         summary: summaryLines,
       };
-      const updated = updateJobApplication(drawerApp.id, { offer });
-      setApplications(updated);
+      const updated = dataStore.updateJobApplication(drawerApp.id, { offer });
       setDrawerMessages([
         {
           role: "assistant",
           data: { compensation: offer.compensation, summary: offer.summary },
         },
       ]);
+      setDrawerApp(updated.find((a) => a.id === drawerApp.id) || null);
     } finally {
       setDrawerLoading(false);
     }
@@ -756,12 +780,11 @@ export default function ApplicationBoard() {
 
   const handleReject = () => {
     if (!drawerApp) return;
-    const updated = updateJobApplicationStatus(
+    dataStore.updateJobApplicationStatus(
       drawerApp.id,
       "rejected",
       rejectReason || undefined
     );
-    setApplications(updated);
     setRejectReason("");
     setDrawerOpen(false);
     setDrawerApp(null);
@@ -792,21 +815,14 @@ export default function ApplicationBoard() {
     if (!drawerApp) return;
     const text = negotiationRef.current?.innerText || "";
     const history = [...(drawerApp.offerHistory || []), text];
-    const updated = updateJobApplication(drawerApp.id, { offerHistory: history });
-    setApplications(updated);
+    const updated = dataStore.updateJobApplication(drawerApp.id, {
+      offerHistory: history,
+    });
     setDrawerApp(updated.find((a) => a.id === drawerApp.id) || null);
-  };
-
-  const handleResumesUpdated = (updated: ResumeEntry[]) => {
-    setResumes(updated);
-    if (resumeId && !updated.some((r) => r.id === resumeId)) {
-      setResumeId("");
-    }
   };
 
   const handleResumeModalClose = () => {
     setResumeModalOpen(false);
-    handleResumesUpdated(getResumes());
   };
 
   return (
@@ -841,7 +857,6 @@ export default function ApplicationBoard() {
       <ResumeStepperModal
         open={resumeModalOpen}
         onClose={handleResumeModalClose}
-        onResumesUpdated={handleResumesUpdated}
       />
       <DndContext onDragEnd={handleDragEnd}>
         {applications.length === 0 ? (

--- a/src/components/talentforge/Dashboard.tsx
+++ b/src/components/talentforge/Dashboard.tsx
@@ -2,40 +2,36 @@
 
 import { useEffect, useState } from "react";
 import { Box, Card, CardContent, Grid, Typography, Skeleton } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-
-interface Counts {
-  resumes: number;
-  applications: number;
-  offers: number;
-  messages: number;
-}
+import { useTalentForgeSelector } from "@/contexts/TalentForgeDataContext";
 
 export default function Dashboard() {
-  const data = useTalentForgeData();
-  const [counts, setCounts] = useState<Counts>({
-    resumes: 0,
-    applications: 0,
-    offers: 0,
-    messages: 0,
-  });
+  const resumes = useTalentForgeSelector(
+    (store) => store.getResumes(),
+    { keys: ["resumes"] },
+  );
+  const applications = useTalentForgeSelector(
+    (store) => store.getJobApplications(),
+    { keys: ["applications"] },
+  );
+  const offers = useTalentForgeSelector(
+    (store) => store.getOffers(),
+    { keys: ["offers"] },
+  );
+  const messages = useTalentForgeSelector(
+    (store) => store.getMessages(),
+    { keys: ["messages"] },
+  );
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setCounts({
-      resumes: data.getResumes().length,
-      applications: data.getJobApplications().length,
-      offers: data.getOffers().length,
-      messages: data.getMessages().length,
-    });
     setLoading(false);
-  }, [data]);
+  }, [resumes, applications, offers, messages]);
 
   const items = [
-    { label: "Resumes", value: counts.resumes },
-    { label: "Applications", value: counts.applications },
-    { label: "Offers", value: counts.offers },
-    { label: "Messages", value: counts.messages },
+    { label: "Resumes", value: resumes.length },
+    { label: "Applications", value: applications.length },
+    { label: "Offers", value: offers.length },
+    { label: "Messages", value: messages.length },
   ];
 
   return (

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -27,8 +27,11 @@ import {
   AutoReplyTemplate,
 } from "@/utils/autoReply";
 
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-import type { Message, RecruiterEntry } from "@/types";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
+import type { Message } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 import PromptSelector from "./PromptSelector";
 import Tile from "./promptTiles/Tile";
@@ -37,33 +40,36 @@ import EmptyState from "./EmptyState";
 
 export default function Inbox() {
   const data = useTalentForgeData();
-  const [threads, setThreads] = useState<Message[]>([]);
+  const threads = useTalentForgeSelector(
+    (store) => store.getThreads(),
+    { keys: ["messages"] },
+  );
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [templateSelections, setTemplateSelections] =
     useState<Record<string, AutoReplyTemplate>>({});
   const [quickTones, setQuickTones] = useState<Record<string, AutoReplyTemplate>>({});
-  const [templateDefs, setTemplateDefs] = useState<Record<string, string>>({});
+  const templateDefs = useTalentForgeSelector(
+    (store) => store.getAutoReplyTemplates(),
+    { keys: ["autoReplyTemplates"] },
+  );
   const [editorOpen, setEditorOpen] = useState(false);
   const [editorTemplates, setEditorTemplates] = useState<
     Array<{ name: string; prompt: string }>
   >([]);
   const [search, setSearch] = useState("");
-  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
+  const recruiters = useTalentForgeSelector(
+    (store) => store.getRecruiters(),
+    { keys: ["recruiters"] },
+  );
   const [aiThread, setAiThread] = useState<string | null>(null);
   const [promptKey, setPromptKey] = useState<string>("");
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const id = setTimeout(() => {
-      setThreads(data.getThreads());
-      setRecruiters(data.getRecruiters());
-      setTemplateDefs(data.getAutoReplyTemplates());
-      setLoading(false);
-    }, 0);
-    return () => clearTimeout(id);
-  }, [data]);
+    setLoading(false);
+  }, [threads]);
 
   const handleFilterChange = (event: SelectChangeEvent) => {
     setFilter(event.target.value as "all" | "unread" | "read");
@@ -87,8 +93,7 @@ export default function Inbox() {
     setSelectedId(message.id);
     if (!drafts[message.id]) void handleAutoReply(message);
     if (message.status === "unread") {
-      const updated = data.updateThreadStatus(message.id, "read");
-      setThreads(updated);
+      data.updateThreadStatus(message.id, "read");
     }
   };
 
@@ -111,8 +116,7 @@ export default function Inbox() {
       sentAt: new Date().toISOString(),
       connector: message.connector,
     };
-    const updated = data.addThreadReply(message.id, reply);
-    setThreads(updated);
+    data.addThreadReply(message.id, reply);
   };
 
   const handleSendReply = (message: Message) => {
@@ -124,32 +128,27 @@ export default function Inbox() {
       sentAt: new Date().toISOString(),
       connector: message.connector,
     };
-    let updated = data.addThreadReply(message.id, reply);
+    data.addThreadReply(message.id, reply);
 
     const matchedRecruiter = recruiters.find(
       (r) => r.connector.toLowerCase() === message.connector.toLowerCase(),
     );
     if (matchedRecruiter) {
-      updated = data.linkThreadToRecruiter(message.id, matchedRecruiter.id);
-      setRecruiters(data.getRecruiters());
+      data.linkThreadToRecruiter(message.id, matchedRecruiter.id);
     }
 
-    setThreads(updated);
     setDrafts((d) => ({ ...d, [message.id]: "" }));
   };
 
   const handleToggleStatus = (message: Message) => {
-    const updated = data.updateThreadStatus(
+    data.updateThreadStatus(
       message.id,
       message.status === "unread" ? "read" : "unread",
     );
-    setThreads(updated);
   };
 
   const handleLinkRecruiter = (threadId: string, recruiterId: string) => {
-    const updated = data.linkThreadToRecruiter(threadId, recruiterId);
-    setThreads(updated);
-    setRecruiters(data.getRecruiters());
+    data.linkThreadToRecruiter(threadId, recruiterId);
   };
 
   const handleDraftWithAI = (threadId: string) => {
@@ -196,7 +195,6 @@ export default function Inbox() {
     for (const { name, prompt } of editorTemplates) {
       if (name.trim()) defs[name.trim()] = prompt;
     }
-    setTemplateDefs(defs);
     data.saveAutoReplyTemplates(defs);
     setEditorOpen(false);
   };

--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -20,7 +20,6 @@ import {
   hasOpenAIKey,
 } from "@/utils/talentforge/utils";
 import OpenAIKeyModal from "./OpenAiKeyModal";
-import { addOffer } from "@/utils/talentforge/dataStore";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import type { Offer, Message, ApplicationRecord } from "@/types";
 
@@ -99,7 +98,7 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
           `Indeed Draft: ${parsed.indeed || ""}`,
         ],
       };
-      addOffer(offer);
+      data.addOffer(offer);
     } catch {
       setAnalysis(message);
       setDrafts({ email: "", linkedin: "", indeed: "" });
@@ -109,7 +108,7 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
         compensation: [{ type: "note", amount: 0, notes: compensation }],
         summary: [message],
       };
-      addOffer(offer);
+      data.addOffer(offer);
     }
     setLoading(false);
     onSave?.();

--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -4,10 +4,9 @@ import { useEffect, useState } from "react";
 import { Box, Button, Step, StepLabel, Stepper, Typography } from "@mui/material";
 
 import {
-  getOnboardingStep,
-  setOnboardingStep,
-  clearOnboardingStep,
-} from "@/utils/talentforge/dataStore";
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 
 import KeyEntryStep from "./onboarding/KeyEntryStep";
 import ResumeImportStep from "./onboarding/ResumeImportStep";
@@ -30,18 +29,21 @@ export default function OnboardingStepper({
 }: {
   onComplete?: () => void;
 }) {
-  const [activeStep, setActiveStep] = useState(0);
+  const dataStore = useTalentForgeData();
+  const storedStep = useTalentForgeSelector(
+    (store) => store.getOnboardingStep(),
+    { keys: ["onboarding"] },
+  );
+  const [activeStep, setActiveStep] = useState(storedStep);
 
   useEffect(() => {
-    const step = getOnboardingStep();
-    setActiveStep(step);
-    setOnboardingStep(step);
-  }, []);
+    setActiveStep(storedStep);
+  }, [storedStep]);
 
   const handleNext = () => {
     setActiveStep((prevActiveStep) => {
       const next = prevActiveStep + 1;
-      setOnboardingStep(next);
+      dataStore.setOnboardingStep(next);
       if (next === TOTAL_ONBOARDING_STEPS) onComplete?.();
       return next;
     });
@@ -50,13 +52,13 @@ export default function OnboardingStepper({
   const handleBack = () => {
     setActiveStep((prevActiveStep) => {
       const next = prevActiveStep - 1;
-      setOnboardingStep(next);
+      dataStore.setOnboardingStep(next);
       return next;
     });
   };
 
   const handleReset = () => {
-    clearOnboardingStep();
+    dataStore.clearOnboardingStep();
     setActiveStep(0);
   };
 

--- a/src/components/talentforge/Recruiters/List.tsx
+++ b/src/components/talentforge/Recruiters/List.tsx
@@ -9,18 +9,27 @@ import {
   TextField,
   Button,
 } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-import type { RecruiterEntry, Message } from "@/types";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
+import type { RecruiterEntry } from "@/types";
 
 export default function RecruiterList() {
   const data = useTalentForgeData();
-  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
-  const [messages, setMessages] = useState<Message[]>([]);
+  const storeRecruiters = useTalentForgeSelector(
+    (store) => store.getRecruiters(),
+    { keys: ["recruiters"] },
+  );
+  const messages = useTalentForgeSelector(
+    (store) => store.getMessages(),
+    { keys: ["messages"] },
+  );
+  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>(storeRecruiters);
 
   useEffect(() => {
-    setRecruiters(data.getRecruiters());
-    setMessages(data.getMessages());
-  }, [data]);
+    setRecruiters(storeRecruiters);
+  }, [storeRecruiters]);
 
   const handleSave = (recruiter: RecruiterEntry) => {
     const updated = data.updateRecruiter(recruiter);

--- a/src/components/talentforge/Settings.tsx
+++ b/src/components/talentforge/Settings.tsx
@@ -18,26 +18,32 @@ import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 import OpenAIKeyModal from "@/components/talentforge/OpenAiKeyModal";
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/talentforge/utils";
 import { loadDemoData, clearDemoData } from "@/utils/talentforge/demoData";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import { exportSnapshot, importSnapshot } from "@/utils/talentforge/snapshot";
 import { SNAPSHOT_VERSION } from "@/utils/talentforge/dataStore";
 
 export default function Settings() {
   const dataStore = useTalentForgeData();
+  const storedComp = useTalentForgeSelector(
+    (store) => store.getCurrentCompensation(),
+    { keys: ["currentCompensation"] },
+  );
   const [openKeyModal, setOpenKeyModal] = React.useState(false);
   const [openAiKeySet, setOpenAiKeySet] = React.useState(false);
-  const [comp, setComp] = React.useState({
-    salary: "",
-    benefits: "",
-    stock: "",
-  });
+  const [comp, setComp] = React.useState(storedComp);
   const [toastOpen, setToastOpen] = React.useState(false);
   const [toastMessage, setToastMessage] = React.useState("");
 
   React.useEffect(() => {
     setOpenAiKeySet(hasOpenAIKey());
-    setComp(dataStore.getCurrentCompensation());
-  }, [dataStore]);
+  }, []);
+
+  React.useEffect(() => {
+    setComp(storedComp);
+  }, [storedComp]);
 
   const handleRemoveKey = () => {
     setOpenAIKey("");

--- a/src/components/talentforge/onboarding/CompensationStep.tsx
+++ b/src/components/talentforge/onboarding/CompensationStep.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useEffect } from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 
 interface StepProps {
   onNext: () => void;
@@ -11,16 +14,15 @@ interface StepProps {
 
 export default function CompensationStep({ onNext, onBack }: StepProps) {
   const dataStore = useTalentForgeData();
-  const [comp, setComp] = useState({
-    salary: "",
-    benefits: "",
-    stock: "",
-  });
+  const storedComp = useTalentForgeSelector(
+    (store) => store.getCurrentCompensation(),
+    { keys: ["currentCompensation"] },
+  );
+  const [comp, setComp] = useState(storedComp);
 
   useEffect(() => {
-    const existing = dataStore.getCurrentCompensation();
-    setComp(existing);
-  }, [dataStore]);
+    setComp(storedComp);
+  }, [storedComp]);
 
   const handleChange = (field: "salary" | "benefits" | "stock") => (
     event: React.ChangeEvent<HTMLInputElement>

--- a/src/components/talentforge/onboarding/ConnectorMockStep.tsx
+++ b/src/components/talentforge/onboarding/ConnectorMockStep.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Stack, Typography } from "@mui/material";
 import { v4 as uuid } from "uuid";
 
 import { ConnectorToken } from "@/types/connector";
 import {
-  deleteConnectorToken,
-  getConnectorToken,
-  saveConnectorToken,
-} from "@/utils/talentforge/dataStore";
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 
 interface StepProps {
   onNext: () => void;
@@ -17,18 +16,27 @@ interface StepProps {
 }
 
 export default function ConnectorMockStep({ onNext, onBack }: StepProps) {
-  const [token, setToken] = useState<ConnectorToken | null>(() =>
-    getConnectorToken("mock") ?? null,
+  const dataStore = useTalentForgeData();
+  const storedToken = useTalentForgeSelector(
+    (store) => store.getConnectorToken("mock"),
+    { keys: ["connectorTokens"] },
   );
+  const [token, setToken] = useState<ConnectorToken | null>(
+    storedToken ?? null,
+  );
+
+  useEffect(() => {
+    setToken(storedToken ?? null);
+  }, [storedToken]);
 
   const handleConnect = () => {
     const newToken: ConnectorToken = { accessToken: uuid() };
-    saveConnectorToken("mock", newToken);
+    dataStore.saveConnectorToken("mock", newToken);
     setToken(newToken);
   };
 
   const handleDisconnect = () => {
-    deleteConnectorToken("mock");
+    dataStore.deleteConnectorToken("mock");
     setToken(null);
   };
 

--- a/src/contexts/TalentForgeDataContext.tsx
+++ b/src/contexts/TalentForgeDataContext.tsx
@@ -21,4 +21,58 @@ export function useTalentForgeData() {
   return context;
 }
 
+type Selector<T> = (store: typeof dataStore) => T;
+
+interface UseTalentForgeSelectorOptions<T> {
+  keys?: dataStore.TalentForgeStoreKey[];
+  equalityFn?: (a: T, b: T) => boolean;
+}
+
+export function useTalentForgeSelector<T>(
+  selector: Selector<T>,
+  options: UseTalentForgeSelectorOptions<T> = {},
+): T {
+  const store = useTalentForgeData();
+  const { keys, equalityFn = Object.is } = options;
+
+  const selectorRef = React.useRef(selector);
+  const equalityRef = React.useRef(equalityFn);
+
+  React.useEffect(() => {
+    selectorRef.current = selector;
+  }, [selector]);
+
+  React.useEffect(() => {
+    equalityRef.current = equalityFn;
+  }, [equalityFn]);
+
+  const [value, setValue] = React.useState(() => selector(store));
+
+  React.useEffect(() => {
+    const nextValue = selector(store);
+    setValue((prev) => (equalityFn(prev, nextValue) ? prev : nextValue));
+  }, [store, selector, equalityFn]);
+
+  React.useEffect(() => {
+    const checkForUpdates = () => {
+      const nextValue = selectorRef.current(store);
+      setValue((prev) =>
+        equalityRef.current(prev, nextValue) ? prev : nextValue,
+      );
+    };
+
+    const unsubscribe = store.subscribe((changedKey) => {
+      if (!keys || keys.includes(changedKey)) {
+        checkForUpdates();
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [store, keys]);
+
+  return value;
+}
+
 export default TalentForgeDataContext;

--- a/src/tests/talentforge/loaders.test.tsx
+++ b/src/tests/talentforge/loaders.test.tsx
@@ -18,8 +18,8 @@ jest.mock('@/utils/talentforge/dataStore', () => ({
   getCurrentCompensation: jest.fn(),
 }));
 
-jest.mock('@/contexts/TalentForgeDataContext', () => ({
-  useTalentForgeData: () => ({
+jest.mock('@/contexts/TalentForgeDataContext', () => {
+  const store = {
     getThreads: () => [],
     getRecruiters: () => [],
     getAutoReplyTemplates: () => ({}),
@@ -27,8 +27,17 @@ jest.mock('@/contexts/TalentForgeDataContext', () => ({
     addThreadReply: jest.fn(),
     linkThreadToRecruiter: jest.fn(),
     saveAutoReplyTemplates: jest.fn(),
-  }),
-}));
+    getJobApplications: () => [],
+    getResumes: () => [],
+    getCurrentCompensation: () => ({ salary: '', benefits: '', stock: '' }),
+    subscribe: () => () => undefined,
+  };
+
+  return {
+    useTalentForgeData: () => store,
+    useTalentForgeSelector: (selector: (s: typeof store) => unknown) => selector(store),
+  };
+});
 
 jest.mock('@/utils/talentforge/jobAggregator', () => ({
   fetchAllListings: jest.fn(() => Promise.resolve([])),

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -46,6 +46,43 @@ interface StoreSchema {
   currentCompensation: CurrentCompensation;
 }
 
+export type TalentForgeStoreKey = keyof StoreSchema;
+export type TalentForgeSubscriber = (key: TalentForgeStoreKey) => void;
+
+const memoryStore: Partial<
+  Record<TalentForgeStoreKey, StoreSchema[TalentForgeStoreKey]>
+> = {};
+
+const subscribers = new Set<TalentForgeSubscriber>();
+
+function clearCache(key?: TalentForgeStoreKey): void {
+  if (key) {
+    delete memoryStore[key];
+    return;
+  }
+
+  for (const storeKey of Object.keys(KEYS) as TalentForgeStoreKey[]) {
+    delete memoryStore[storeKey];
+  }
+}
+
+function notifySubscribers(key: TalentForgeStoreKey): void {
+  for (const listener of subscribers) {
+    try {
+      listener(key);
+    } catch (error) {
+      console.error("TalentForge dataStore subscriber error", error);
+    }
+  }
+}
+
+export function subscribe(listener: TalentForgeSubscriber): () => void {
+  subscribers.add(listener);
+  return () => {
+    subscribers.delete(listener);
+  };
+}
+
 // Storage keys for each entity
 const KEYS: { [K in keyof StoreSchema]: string } = {
   user: "userProfile",
@@ -247,21 +284,29 @@ function load<K extends keyof StoreSchema>(
   key: K,
   fallback: StoreSchema[K],
 ): StoreSchema[K] {
+  if (Object.prototype.hasOwnProperty.call(memoryStore, key)) {
+    return memoryStore[key as TalentForgeStoreKey] as StoreSchema[K];
+  }
   const value = loadItem<StoreSchema[K]>(
     KEYS[key],
     VERSION[key],
     MIGRATORS[key],
   );
-  if (value !== undefined) return value;
-  return fallback;
+  const resolved = value !== undefined ? value : fallback;
+  memoryStore[key as TalentForgeStoreKey] = resolved;
+  return resolved;
 }
 
 function save<K extends keyof StoreSchema>(key: K, value: StoreSchema[K]): void {
+  memoryStore[key as TalentForgeStoreKey] = value;
   saveItem(KEYS[key], value, VERSION[key]);
+  notifySubscribers(key);
 }
 
 function remove<K extends keyof StoreSchema>(key: K): void {
+  clearCache(key as TalentForgeStoreKey);
   deleteItem(KEYS[key]);
+  notifySubscribers(key);
 }
 
 // Migrations
@@ -755,9 +800,11 @@ export function importFromJson(json: string): void {
         }
       }
     }
+    clearCache();
     // Trigger migrations for all known keys after importing
     for (const key of Object.keys(KEYS) as (keyof StoreSchema)[]) {
       load(key, DEFAULTS[key]);
+      notifySubscribers(key);
     }
   } catch {
     // ignore parse errors
@@ -811,6 +858,7 @@ const dataStore = {
   deleteConnectorToken,
   exportToJson,
   importFromJson,
+  subscribe,
 };
 
 export default dataStore;


### PR DESCRIPTION
## Summary
- add an in-memory cache with pub/sub notifications to the talentforge data store and clear the cache when reloading snapshots
- add a `useTalentForgeSelector` hook so components can subscribe to store slices
- refactor talentforge UI components and tests to consume the selector-based API

## Testing
- npm run lint
- CI=1 npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb8c92007883308f5f74265cb3f761