### PR TITLE
Refine resume management workflow

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -60,6 +60,7 @@ import {
 import OpenAIKeyModal from "./OpenAiKeyModal";
 import FileUploader from "./FileUploader";
 import ResumeStepperModal from "./ResumeStepperModal";
+import ManageResumesModal from "./ManageResumesModal";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import { STATUSES, getNextStatus } from "@/utils/talentforge/keyboard";
 
@@ -329,6 +330,7 @@ export default function ApplicationBoard() {
   const [liveMessage, setLiveMessage] = useState("");
   const [resumes, setResumes] = useState<ResumeEntry[]>(() => getResumes());
   const [resumeModalOpen, setResumeModalOpen] = useState(false);
+  const [manageResumesOpen, setManageResumesOpen] = useState(false);
   const negotiationRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -809,6 +811,11 @@ export default function ApplicationBoard() {
     handleResumesUpdated(getResumes());
   };
 
+  const handleManageModalClose = () => {
+    setManageResumesOpen(false);
+    handleResumesUpdated(getResumes());
+  };
+
   return (
     <>
       <Box
@@ -831,16 +838,24 @@ export default function ApplicationBoard() {
         <Button variant="contained" onClick={() => setDialogOpen(true)}>
           Add Application
         </Button>
+        <Button variant="outlined" onClick={() => setResumeModalOpen(true)}>
+          Upload Resume
+        </Button>
         <Button
           variant="outlined"
-          onClick={() => setResumeModalOpen(true)}
+          onClick={() => setManageResumesOpen(true)}
         >
-          Upload Resume
+          Manage Resumes
         </Button>
       </Stack>
       <ResumeStepperModal
         open={resumeModalOpen}
         onClose={handleResumeModalClose}
+        onResumesUpdated={handleResumesUpdated}
+      />
+      <ManageResumesModal
+        open={manageResumesOpen}
+        onClose={handleManageModalClose}
         onResumesUpdated={handleResumesUpdated}
       />
       <DndContext onDragEnd={handleDragEnd}>

--- a/src/components/talentforge/ManageResumesModal.tsx
+++ b/src/components/talentforge/ManageResumesModal.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Skeleton,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type { ResumeEntry } from "@/types";
+import { filterByTag, filterByText } from "@/utils/search";
+import { getResumes } from "@/utils/talentforge/dataStore";
+import ResumeVariantList from "./ResumeVariants/List";
+
+interface ManageResumesModalProps {
+  open: boolean;
+  onClose: () => void;
+  onResumesUpdated?: (resumes: ResumeEntry[]) => void;
+}
+
+export default function ManageResumesModal({
+  open,
+  onClose,
+  onResumesUpdated,
+}: ManageResumesModalProps) {
+  const [resumes, setResumes] = useState<ResumeEntry[]>([]);
+  const [searchText, setSearchText] = useState("");
+  const [searchTag, setSearchTag] = useState("");
+  const [loadingResumes, setLoadingResumes] = useState(true);
+
+  useEffect(() => {
+    if (!open) {
+      setSearchText("");
+      setSearchTag("");
+      setLoadingResumes(true);
+      return;
+    }
+
+    const id = window.setTimeout(() => {
+      const existing = getResumes();
+      setResumes(existing);
+      onResumesUpdated?.(existing);
+      setLoadingResumes(false);
+    }, 0);
+
+    return () => window.clearTimeout(id);
+  }, [open, onResumesUpdated]);
+
+  const filteredResumes = useMemo(
+    () => filterByTag(filterByText(resumes, searchText, ["content"]), searchTag),
+    [resumes, searchText, searchTag],
+  );
+
+  const handleResumesChange = (updated: ResumeEntry[]) => {
+    setResumes(updated);
+    onResumesUpdated?.(updated);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Manage Resumes</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={3} aria-busy={loadingResumes}>
+          <Typography variant="body1">
+            Filter, organize, and compare the resumes saved in your library.
+          </Typography>
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField
+              label="Filter by text"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Filter by tag"
+              value={searchTag}
+              onChange={(e) => setSearchTag(e.target.value)}
+              fullWidth
+            />
+          </Stack>
+          {loadingResumes ? (
+            <Stack spacing={1}>
+              {Array.from({ length: 3 }).map((_, idx) => (
+                <Skeleton key={idx} variant="rectangular" height={60} />
+              ))}
+            </Stack>
+          ) : (
+            <Box>
+              <ResumeVariantList resumes={filteredResumes} setResumes={handleResumesChange} />
+            </Box>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/talentforge/ResumeStepperModal.tsx
+++ b/src/components/talentforge/ResumeStepperModal.tsx
@@ -1,27 +1,30 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { v4 as uuid } from "uuid";
 import {
   Alert,
   Box,
   Button,
+  Chip,
   CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  Skeleton,
   Snackbar,
   Stack,
   Step,
   StepLabel,
   Stepper,
+  MenuItem,
   TextField,
   Typography,
 } from "@mui/material";
-import { filterByTag, filterByText } from "@/utils/search";
-import { getResumes, addResume } from "@/utils/talentforge/dataStore";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import DescriptionIcon from "@mui/icons-material/Description";
+import { getResumes, addResume, updateResume } from "@/utils/talentforge/dataStore";
 import type { ResumeEntry } from "@/types";
 import { askOpenAI, hasOpenAIKey } from "@/utils/talentforge/utils";
 import { fileToText, parseResumeText } from "@/utils/talentforge/resumeIngest";
@@ -30,7 +33,13 @@ import { tagResume } from "@/utils/talentforge/tagging";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
 import OpenAIKeyModal from "./OpenAiKeyModal";
 import FileUploader from "./FileUploader";
-import ResumeVariantList from "./ResumeVariants/List";
+import {
+  INPUT_DELIMITERS,
+  MAX_TAG_LENGTH,
+  normalizeTags,
+  tagsEqual,
+  validateTag,
+} from "@/utils/talentforge/tagUtils";
 
 interface ResumeStepperModalProps {
   open: boolean;
@@ -38,7 +47,7 @@ interface ResumeStepperModalProps {
   onResumesUpdated?: (resumes: ResumeEntry[]) => void;
 }
 
-const STEPS = ["Upload", "Compare", "Manage"] as const;
+const STEPS = ["Upload", "Compare", "Enhance"] as const;
 
 export default function ResumeStepperModal({
   open,
@@ -51,8 +60,6 @@ export default function ResumeStepperModal({
   const [comparison, setComparison] = useState("");
   const [loadingCompare, setLoadingCompare] = useState(false);
   const [openKeyModal, setOpenKeyModal] = useState(false);
-  const [searchText, setSearchText] = useState("");
-  const [searchTag, setSearchTag] = useState("");
   const [loadingResumes, setLoadingResumes] = useState(true);
   const [toastOpen, setToastOpen] = useState(false);
   const [activeStep, setActiveStep] = useState<number>(0);
@@ -60,6 +67,24 @@ export default function ResumeStepperModal({
   const [fileImportError, setFileImportError] = useState<string | null>(null);
   const [textImportLoading, setTextImportLoading] = useState(false);
   const [textImportError, setTextImportError] = useState<string | null>(null);
+  const [selectedResumeId, setSelectedResumeId] = useState<string>("");
+  const [tagDraft, setTagDraft] = useState<string[]>([]);
+  const [newTag, setNewTag] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [editingIdx, setEditingIdx] = useState<number | null>(null);
+  const [editingValue, setEditingValue] = useState("");
+  const [editingError, setEditingError] = useState<string | null>(null);
+  const editingInputRef = useRef<HTMLInputElement | null>(null);
+  const [tagging, setTagging] = useState(false);
+  const [enhanceFeedback, setEnhanceFeedback] = useState<
+    { type: "success" | "error"; message: string } | null
+  >(null);
+  const [copyTagsFeedback, setCopyTagsFeedback] = useState<
+    { type: "success" | "error"; message: string } | null
+  >(null);
+  const [copyResumeFeedback, setCopyResumeFeedback] = useState<
+    { type: "success" | "error"; message: string } | null
+  >(null);
 
   useEffect(() => {
     if (!open) {
@@ -67,13 +92,22 @@ export default function ResumeStepperModal({
       setText("");
       setJobDescription("");
       setComparison("");
-      setSearchText("");
-      setSearchTag("");
       setToastOpen(false);
       setFileImportLoading(false);
       setTextImportLoading(false);
       setFileImportError(null);
       setTextImportError(null);
+      setSelectedResumeId("");
+      setTagDraft([]);
+      setNewTag("");
+      setInputError(null);
+      setEditingIdx(null);
+      setEditingValue("");
+      setEditingError(null);
+      setEnhanceFeedback(null);
+      setCopyTagsFeedback(null);
+      setCopyResumeFeedback(null);
+      setTagging(false);
       return;
     }
 
@@ -83,19 +117,229 @@ export default function ResumeStepperModal({
       setResumes(existing);
       onResumesUpdated?.(existing);
       setLoadingResumes(false);
+      setSelectedResumeId((prev) => {
+        if (prev && existing.some((resume) => resume.id === prev)) {
+          return prev;
+        }
+        return existing.length ? existing[existing.length - 1].id : "";
+      });
     }, 0);
 
     return () => window.clearTimeout(id);
   }, [open, onResumesUpdated]);
 
-  const filteredResumes = useMemo(
-    () => filterByTag(filterByText(resumes, searchText, ["content"]), searchTag),
-    [resumes, searchText, searchTag],
-  );
-
   const handleResumesChange = (updated: ResumeEntry[]) => {
     setResumes(updated);
     onResumesUpdated?.(updated);
+  };
+
+  const selectedResume =
+    resumes.find((resume) => resume.id === selectedResumeId) ?? null;
+
+  useEffect(() => {
+    if (editingIdx !== null) {
+      editingInputRef.current?.focus();
+      editingInputRef.current?.select();
+    }
+  }, [editingIdx]);
+
+  useEffect(() => {
+    if (!selectedResume) {
+      setTagDraft([]);
+      setNewTag("");
+      setInputError(null);
+      setEditingIdx(null);
+      setEditingValue("");
+      setEditingError(null);
+      setEnhanceFeedback(null);
+      setCopyTagsFeedback(null);
+      setCopyResumeFeedback(null);
+      setTagging(false);
+      return;
+    }
+    setTagDraft(selectedResume.tags);
+    setNewTag("");
+    setInputError(null);
+    setEditingIdx(null);
+    setEditingValue("");
+    setEditingError(null);
+    setEnhanceFeedback(null);
+    setCopyTagsFeedback(null);
+    setCopyResumeFeedback(null);
+  }, [selectedResume]);
+
+  const applyTags = (values: string[], options?: { fromAi?: boolean }) => {
+    const normalized = normalizeTags(values);
+    setTagDraft(normalized);
+    setCopyTagsFeedback(null);
+    if (!selectedResume) {
+      return false;
+    }
+    const changed = !tagsEqual(normalized, selectedResume.tags);
+    if (changed) {
+      const updatedResume = { ...selectedResume, tags: normalized };
+      const updated = updateResume(updatedResume);
+      handleResumesChange(updated);
+      setSelectedResumeId(updatedResume.id);
+    }
+    if (!options?.fromAi) {
+      setEnhanceFeedback(null);
+    }
+    return changed;
+  };
+
+  const handleDeleteTag = (idx: number) => {
+    if (editingIdx !== null) {
+      if (editingIdx === idx) {
+        setEditingIdx(null);
+        setEditingValue("");
+        setEditingError(null);
+      } else if (editingIdx > idx) {
+        setEditingIdx(editingIdx - 1);
+      }
+    }
+    applyTags(tagDraft.filter((_, i) => i !== idx));
+  };
+
+  const handleEditStart = (idx: number) => {
+    setEditingIdx(idx);
+    setEditingValue(tagDraft[idx]);
+    setEditingError(null);
+  };
+
+  const handleEditCommit = (): boolean => {
+    if (editingIdx === null) return true;
+    const error = validateTag(editingValue, tagDraft, { ignoreIndex: editingIdx });
+    if (error) {
+      setEditingError(error);
+      return false;
+    }
+    const updated = [...tagDraft];
+    updated[editingIdx] = editingValue.trim();
+    setEditingIdx(null);
+    setEditingValue("");
+    setEditingError(null);
+    applyTags(updated);
+    return true;
+  };
+
+  const handleEditCancel = () => {
+    setEditingIdx(null);
+    setEditingValue("");
+    setEditingError(null);
+  };
+
+  const handleAddTag = () => {
+    const error = validateTag(newTag, tagDraft);
+    if (error) {
+      setInputError(error);
+      return;
+    }
+    const trimmed = newTag.trim();
+    applyTags([...tagDraft, trimmed]);
+    setNewTag("");
+    setInputError(null);
+  };
+
+  const handleGenerateTags = async () => {
+    if (!selectedResume) return;
+    if (!selectedResume.content.trim()) {
+      setEnhanceFeedback({
+        type: "error",
+        message: "Resume content is empty, so no tags can be generated.",
+      });
+      return;
+    }
+    setTagging(true);
+    setEnhanceFeedback(null);
+    try {
+      const aiTags = await tagResume(selectedResume.content);
+      const normalized = normalizeTags(
+        aiTags.filter((tag) => tag.trim().length <= MAX_TAG_LENGTH),
+      );
+      if (!normalized.length) {
+        setEnhanceFeedback({
+          type: "error",
+          message: "AI couldn't suggest any tags.",
+        });
+        return;
+      }
+      const changed = applyTags(normalized, { fromAi: true });
+      setEnhanceFeedback({
+        type: "success",
+        message: changed
+          ? "Tags updated from AI suggestions."
+          : "Tags already match the AI suggestions.",
+      });
+    } catch (error) {
+      setEnhanceFeedback({
+        type: "error",
+        message:
+          error instanceof Error && error.message
+            ? error.message
+            : "Unable to refresh tags right now.",
+      });
+    } finally {
+      setTagging(false);
+    }
+  };
+
+  const handleCopyTags = async () => {
+    if (!tagDraft.length) {
+      setCopyTagsFeedback({
+        type: "error",
+        message: "Add tags before copying them.",
+      });
+      return;
+    }
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      setCopyTagsFeedback({
+        type: "error",
+        message: "Clipboard access isn't available in this browser.",
+      });
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(tagDraft.join(", "));
+      setCopyTagsFeedback({
+        type: "success",
+        message: "Tags copied to clipboard.",
+      });
+    } catch {
+      setCopyTagsFeedback({
+        type: "error",
+        message: "Unable to copy tags right now.",
+      });
+    }
+  };
+
+  const handleCopyResume = async () => {
+    if (!selectedResume || !selectedResume.content.trim()) {
+      setCopyResumeFeedback({
+        type: "error",
+        message: "No resume content available to copy.",
+      });
+      return;
+    }
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      setCopyResumeFeedback({
+        type: "error",
+        message: "Clipboard access isn't available in this browser.",
+      });
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(selectedResume.content);
+      setCopyResumeFeedback({
+        type: "success",
+        message: "Resume content copied to clipboard.",
+      });
+    } catch {
+      setCopyResumeFeedback({
+        type: "error",
+        message: "Unable to copy the resume right now.",
+      });
+    }
   };
 
   const handleSave = async () => {
@@ -124,6 +368,7 @@ export default function ResumeStepperModal({
       };
       const updated = addResume(newResume);
       handleResumesChange(updated);
+      setSelectedResumeId(newResume.id);
       setText(sanitized);
       setComparison("");
       setToastOpen(true);
@@ -179,7 +424,7 @@ export default function ResumeStepperModal({
         fullWidth
         aria-labelledby="resume-stepper-title"
       >
-        <DialogTitle id="resume-stepper-title">Manage Resumes</DialogTitle>
+        <DialogTitle id="resume-stepper-title">Upload Resume</DialogTitle>
         <DialogContent dividers>
           <Stepper activeStep={activeStep} alternativeLabel>
             {STEPS.map((label) => (
@@ -219,6 +464,7 @@ export default function ResumeStepperModal({
                       try {
                         let latest = resumes;
                         let lastContent = "";
+                        let lastAddedId = "";
                         for (const file of files) {
                           const content = await fileToText(file);
                           const tags = await tagResume(content);
@@ -229,8 +475,9 @@ export default function ResumeStepperModal({
                             console.error("Failed to parse resume text", parseError);
                             throw parseError;
                           }
+                          const generatedId = uuid();
                           latest = addResume({
-                            id: uuid(),
+                            id: generatedId,
                             userId: "",
                             label: "",
                             title: "",
@@ -240,8 +487,12 @@ export default function ResumeStepperModal({
                             tags,
                           });
                           lastContent = content;
+                          lastAddedId = generatedId;
                         }
                         handleResumesChange(latest);
+                        if (lastAddedId) {
+                          setSelectedResumeId(lastAddedId);
+                        }
                         if (files.length === 1 && lastContent) {
                           setText(parsePastedHtml(lastContent));
                           setComparison("");
@@ -371,33 +622,308 @@ export default function ResumeStepperModal({
               </Stack>
             )}
             {activeStep === 2 && (
-              <Stack
-                spacing={2}
-                aria-busy={loadingResumes}
-                aria-label={loadingResumes ? "Loading resumes" : undefined}
-              >
+              <Stack spacing={3}>
                 <Typography variant="body1">
-                  Filter and manage your saved resumes.
+                  Generate intelligent tags and review structured details for a
+                  specific resume.
                 </Typography>
-                <TextField
-                  label="Filter by text"
-                  value={searchText}
-                  onChange={(e) => setSearchText(e.target.value)}
-                />
-                <TextField
-                  label="Filter by tag"
-                  value={searchTag}
-                  onChange={(e) => setSearchTag(e.target.value)}
-                />
                 {loadingResumes ? (
-                  Array.from({ length: 3 }).map((_, idx) => (
-                    <Skeleton key={idx} variant="rectangular" height={60} />
-                  ))
+                  <Box
+                    sx={{ display: "flex", justifyContent: "center" }}
+                    aria-busy="true"
+                    aria-label="Loading resumes"
+                  >
+                    <CircularProgress size={24} />
+                  </Box>
+                ) : resumes.length === 0 ? (
+                  <Alert severity="info">
+                    Upload a resume in the first step to start enhancing it.
+                  </Alert>
                 ) : (
-                  <ResumeVariantList
-                    resumes={filteredResumes}
-                    setResumes={handleResumesChange}
-                  />
+                  <Stack spacing={3}>
+                    <TextField
+                      select
+                      label="Select resume"
+                      value={selectedResumeId}
+                      onChange={(e) => setSelectedResumeId(e.target.value)}
+                      fullWidth
+                    >
+                      {resumes.map((resume) => (
+                        <MenuItem key={resume.id} value={resume.id}>
+                          {resume.title}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                    {selectedResume ? (
+                      <Stack spacing={3}>
+                        <Stack spacing={1}>
+                          <Typography variant="subtitle1">Tags</Typography>
+                          <Stack
+                            direction="row"
+                            spacing={1}
+                            flexWrap="wrap"
+                            alignItems="center"
+                          >
+                            {tagDraft.map((tag, idx) =>
+                              editingIdx === idx ? (
+                                <TextField
+                                  key={`edit-${idx}`}
+                                  size="small"
+                                  value={editingValue}
+                                  inputRef={editingInputRef}
+                                  onChange={(e) => {
+                                    setEditingValue(e.target.value);
+                                    if (editingError) setEditingError(null);
+                                  }}
+                                  onBlur={() => {
+                                    const committed = handleEditCommit();
+                                    if (!committed) {
+                                      window.setTimeout(
+                                        () => editingInputRef.current?.focus(),
+                                        0,
+                                      );
+                                    }
+                                  }}
+                                  onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                      e.preventDefault();
+                                      handleEditCommit();
+                                    } else if (e.key === "Escape") {
+                                      e.preventDefault();
+                                      handleEditCancel();
+                                    } else if (e.key === "Tab") {
+                                      const committed = handleEditCommit();
+                                      if (!committed) {
+                                        e.preventDefault();
+                                      }
+                                    }
+                                  }}
+                                  error={Boolean(editingError)}
+                                  helperText={
+                                    editingError
+                                      ?? "Press Enter to save or Esc to cancel."
+                                  }
+                                  FormHelperTextProps={{ sx: { ml: 0 } }}
+                                  inputProps={{
+                                    "aria-label": `Edit tag ${tag}`,
+                                  }}
+                                  sx={{ mb: 1, minWidth: 160 }}
+                                />
+                              ) : (
+                                <Chip
+                                  key={`${tag}-${idx}`}
+                                  label={tag}
+                                  onDelete={() => handleDeleteTag(idx)}
+                                  onClick={() => handleEditStart(idx)}
+                                  onKeyDown={(e) => {
+                                    if (e.key === "Enter" || e.key === " ") {
+                                      e.preventDefault();
+                                      handleEditStart(idx);
+                                    } else if (
+                                      e.key === "Backspace" ||
+                                      e.key === "Delete"
+                                    ) {
+                                      e.preventDefault();
+                                      handleDeleteTag(idx);
+                                    }
+                                  }}
+                                  tabIndex={0}
+                                  role="button"
+                                  aria-label={`Edit tag ${tag}`}
+                                  sx={{ mb: 1 }}
+                                />
+                              ),
+                            )}
+                          </Stack>
+                          <Stack
+                            direction={{ xs: "column", sm: "row" }}
+                            spacing={1}
+                            alignItems={{ sm: "flex-start" }}
+                          >
+                            <TextField
+                              size="small"
+                              label="Add tag"
+                              value={newTag}
+                              onChange={(e) => {
+                                setNewTag(e.target.value);
+                                if (inputError) setInputError(null);
+                              }}
+                              onKeyDown={(e) => {
+                                if (INPUT_DELIMITERS.has(e.key)) {
+                                  if (newTag.trim()) {
+                                    e.preventDefault();
+                                    handleAddTag();
+                                  }
+                                } else if (e.key === "Backspace" && !newTag) {
+                                  if (tagDraft.length) {
+                                    e.preventDefault();
+                                    handleDeleteTag(tagDraft.length - 1);
+                                  }
+                                } else if (e.key === "Escape" && newTag) {
+                                  e.preventDefault();
+                                  setNewTag("");
+                                  setInputError(null);
+                                }
+                              }}
+                              helperText={
+                                inputError
+                                  ?? "Press Enter, Tab, or comma to add a tag. Backspace removes the last tag."
+                              }
+                              error={Boolean(inputError)}
+                              FormHelperTextProps={{ sx: { ml: 0 } }}
+                              inputProps={{ "aria-label": "Add new tag" }}
+                              sx={{ mb: { xs: 1, sm: 0 }, flexGrow: 1, minWidth: 200 }}
+                            />
+                            <Button
+                              variant="contained"
+                              onClick={handleAddTag}
+                              disabled={!newTag.trim()}
+                            >
+                              Add tag
+                            </Button>
+                          </Stack>
+                        </Stack>
+                        <Stack
+                          direction={{ xs: "column", sm: "row" }}
+                          spacing={1}
+                          alignItems={{ sm: "center" }}
+                        >
+                          <Button
+                            variant="outlined"
+                            onClick={handleGenerateTags}
+                            disabled={
+                              tagging || !selectedResume.content.trim()
+                            }
+                            startIcon={
+                              tagging ? (
+                                <CircularProgress size={18} />
+                              ) : (
+                                <AutoAwesomeIcon fontSize="small" />
+                              )
+                            }
+                          >
+                            {tagging ? "Generating tags..." : "Generate tags with AI"}
+                          </Button>
+                          <Button
+                            variant="outlined"
+                            onClick={handleCopyTags}
+                            disabled={!tagDraft.length}
+                            startIcon={<ContentCopyIcon fontSize="small" />}
+                          >
+                            Copy tags
+                          </Button>
+                          <Button
+                            variant="outlined"
+                            onClick={handleCopyResume}
+                            disabled={!selectedResume.content.trim()}
+                            startIcon={<DescriptionIcon fontSize="small" />}
+                          >
+                            Copy resume text
+                          </Button>
+                        </Stack>
+                        {enhanceFeedback && (
+                          <Typography
+                            variant="body2"
+                            color={
+                              enhanceFeedback.type === "success"
+                                ? "success.main"
+                                : "error"
+                            }
+                          >
+                            {enhanceFeedback.message}
+                          </Typography>
+                        )}
+                        {copyTagsFeedback && (
+                          <Typography
+                            variant="body2"
+                            color={
+                              copyTagsFeedback.type === "success"
+                                ? "success.main"
+                                : "error"
+                            }
+                          >
+                            {copyTagsFeedback.message}
+                          </Typography>
+                        )}
+                        {copyResumeFeedback && (
+                          <Typography
+                            variant="body2"
+                            color={
+                              copyResumeFeedback.type === "success"
+                                ? "success.main"
+                                : "error"
+                            }
+                          >
+                            {copyResumeFeedback.message}
+                          </Typography>
+                        )}
+                        <Stack spacing={2}>
+                          <Typography variant="subtitle1">
+                            Structured overview
+                          </Typography>
+                          <Stack spacing={1}>
+                            <Typography variant="subtitle2">Contact</Typography>
+                            {selectedResume.parsed.contact ? (
+                              <Typography
+                                variant="body2"
+                                sx={{ whiteSpace: "pre-wrap" }}
+                              >
+                                {selectedResume.parsed.contact}
+                              </Typography>
+                            ) : (
+                              <Typography variant="body2" color="text.secondary">
+                                No contact information detected.
+                              </Typography>
+                            )}
+                          </Stack>
+                          <Stack spacing={1}>
+                            <Typography variant="subtitle2">Experience</Typography>
+                            {selectedResume.parsed.experience.length ? (
+                              selectedResume.parsed.experience.map((line, idx) => (
+                                <Typography key={idx} variant="body2">
+                                  {line}
+                                </Typography>
+                              ))
+                            ) : (
+                              <Typography variant="body2" color="text.secondary">
+                                No experience entries detected.
+                              </Typography>
+                            )}
+                          </Stack>
+                          <Stack spacing={1}>
+                            <Typography variant="subtitle2">Education</Typography>
+                            {selectedResume.parsed.education.length ? (
+                              selectedResume.parsed.education.map((line, idx) => (
+                                <Typography key={idx} variant="body2">
+                                  {line}
+                                </Typography>
+                              ))
+                            ) : (
+                              <Typography variant="body2" color="text.secondary">
+                                No education entries detected.
+                              </Typography>
+                            )}
+                          </Stack>
+                          <Stack spacing={1}>
+                            <Typography variant="subtitle2">Skills</Typography>
+                            {selectedResume.parsed.skills.length ? (
+                              selectedResume.parsed.skills.map((line, idx) => (
+                                <Typography key={idx} variant="body2">
+                                  {line}
+                                </Typography>
+                              ))
+                            ) : (
+                              <Typography variant="body2" color="text.secondary">
+                                No skills detected.
+                              </Typography>
+                            )}
+                          </Stack>
+                        </Stack>
+                      </Stack>
+                    ) : (
+                      <Alert severity="info">Select a resume to enhance.</Alert>
+                    )}
+                  </Stack>
                 )}
               </Stack>
             )}

--- a/src/components/talentforge/ResumeVariants/Detail.tsx
+++ b/src/components/talentforge/ResumeVariants/Detail.tsx
@@ -17,33 +17,13 @@ import {
 import type { ResumeEntry } from "@/types";
 import { updateResume } from "@/utils/talentforge/dataStore";
 import { tagResume } from "@/utils/talentforge/tagging";
-
-const MAX_TAG_LENGTH = 40;
-const INPUT_DELIMITERS = new Set(["Enter", ",", ";", "Tab"]);
-
-const normalizeTags = (values: string[]): string[] => {
-  const seen = new Set<string>();
-  const normalized: string[] = [];
-  for (const raw of values) {
-    const trimmed = raw.trim();
-    if (!trimmed) {
-      continue;
-    }
-    const key = trimmed.toLowerCase();
-    if (seen.has(key)) {
-      continue;
-    }
-    normalized.push(trimmed);
-    seen.add(key);
-  }
-  return normalized;
-};
-
-const tagsEqual = (a: string[], b: string[]): boolean => {
-  if (a === b) return true;
-  if (a.length !== b.length) return false;
-  return a.every((tag, idx) => tag === b[idx]);
-};
+import {
+  INPUT_DELIMITERS,
+  MAX_TAG_LENGTH,
+  normalizeTags,
+  tagsEqual,
+  validateTag as validateTagValue,
+} from "@/utils/talentforge/tagUtils";
 
 interface Props {
   resume: ResumeEntry;
@@ -117,22 +97,8 @@ export default function Detail({ resume, onClose, onSave }: Props) {
     setRetagError(null);
   };
 
-  const validateTag = (value: string, idx?: number): string | null => {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return "Tag cannot be empty.";
-    }
-    if (trimmed.length > MAX_TAG_LENGTH) {
-      return `Tag must be ${MAX_TAG_LENGTH} characters or fewer.`;
-    }
-    const duplicateIndex = tags.findIndex(
-      (tag, i) => tag.toLowerCase() === trimmed.toLowerCase() && i !== idx,
-    );
-    if (duplicateIndex !== -1) {
-      return "Tag already exists.";
-    }
-    return null;
-  };
+  const validateTag = (value: string, idx?: number): string | null =>
+    validateTagValue(value, tags, { ignoreIndex: idx });
 
   const handleDelete = (idx: number) => {
     if (editingIdx !== null) {

--- a/src/utils/talentforge/tagUtils.ts
+++ b/src/utils/talentforge/tagUtils.ts
@@ -1,0 +1,50 @@
+export const MAX_TAG_LENGTH = 40;
+
+export const INPUT_DELIMITERS = new Set(["Enter", ",", ";", "Tab"]);
+
+export function normalizeTags(values: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const raw of values) {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    normalized.push(trimmed);
+    seen.add(key);
+  }
+  return normalized;
+}
+
+export function tagsEqual(a: string[], b: string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((tag, idx) => tag === b[idx]);
+}
+
+export function validateTag(
+  value: string,
+  existing: string[],
+  options: { ignoreIndex?: number; maxLength?: number } = {},
+): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "Tag cannot be empty.";
+  }
+  const maxLength = options.maxLength ?? MAX_TAG_LENGTH;
+  if (trimmed.length > maxLength) {
+    return `Tag must be ${maxLength} characters or fewer.`;
+  }
+  const duplicateIndex = existing.findIndex(
+    (tag, idx) =>
+      tag.toLowerCase() === trimmed.toLowerCase() && idx !== options.ignoreIndex,
+  );
+  if (duplicateIndex !== -1) {
+    return "Tag already exists.";
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a dedicated Manage Resumes modal accessible from the application board
- enhance the upload workflow with AI-powered tagging tools and resume actions
- centralize resume tag helpers for reuse across components

## Testing
- npm run lint
- npm test -- --runTestsByPath src/tests/talentforge/loaders.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb91f79e7483309d6a1b768be6bab4