### PR TITLE
Add resume metadata support

### DIFF
--- a/src/components/talentforge/ResumePaste.tsx
+++ b/src/components/talentforge/ResumePaste.tsx
@@ -43,7 +43,7 @@ export default function ResumePaste() {
 
   const handleParse = async () => {
     const sanitized = parsePastedHtml(input);
-    const text = await parseResume(sanitized);
+    const { text, metadata } = await parseResume(sanitized);
     setInput(text);
     setFields(extractFields(text));
     const parsed = parseResumeText(text);
@@ -56,6 +56,7 @@ export default function ResumePaste() {
       content: text,
       parsed,
       tags: [],
+      ...metadata,
     });
     setToastOpen(true);
   };

--- a/src/components/talentforge/ResumeStepperModal.tsx
+++ b/src/components/talentforge/ResumeStepperModal.tsx
@@ -24,7 +24,11 @@ import { filterByTag, filterByText } from "@/utils/search";
 import { getResumes, addResume } from "@/utils/talentforge/dataStore";
 import type { ResumeEntry } from "@/types";
 import { askOpenAI } from "@/utils/talentforge/utils";
-import { fileToText, parseResumeText } from "@/utils/talentforge/resumeIngest";
+import {
+  fileToText,
+  parseResumeText,
+  createPastedResumeMetadata,
+} from "@/utils/talentforge/resumeIngest";
 import { parsePastedHtml } from "@/utils/talentforge/pasteParser";
 import { tagResume } from "@/utils/talentforge/tagging";
 import { PROMPT_TEMPLATES } from "@/consts/prompts";
@@ -110,6 +114,7 @@ export default function ResumeStepperModal({
         console.error("Failed to parse resume text", parseError);
         throw parseError;
       }
+      const metadata = createPastedResumeMetadata();
       const newResume: ResumeEntry = {
         id: uuid(),
         userId: "",
@@ -119,6 +124,7 @@ export default function ResumeStepperModal({
         content: sanitized,
         parsed,
         tags,
+        ...metadata,
       };
       const updated = addResume(newResume);
       handleResumesChange(updated);
@@ -214,7 +220,7 @@ export default function ResumeStepperModal({
                         let latest = resumes;
                         let lastContent = "";
                         for (const file of files) {
-                          const content = await fileToText(file);
+                          const { text: content, metadata } = await fileToText(file);
                           const tags = await tagResume(content);
                           let parsed: ResumeEntry["parsed"];
                           try {
@@ -232,6 +238,7 @@ export default function ResumeStepperModal({
                             content,
                             parsed,
                             tags,
+                            ...metadata,
                           });
                           lastContent = content;
                         }

--- a/src/components/talentforge/ResumeVariants/Detail.tsx
+++ b/src/components/talentforge/ResumeVariants/Detail.tsx
@@ -21,6 +21,31 @@ import { tagResume } from "@/utils/talentforge/tagging";
 const MAX_TAG_LENGTH = 40;
 const INPUT_DELIMITERS = new Set(["Enter", ",", ";", "Tab"]);
 
+const importDateFormatter =
+  typeof Intl !== "undefined" && typeof Intl.DateTimeFormat === "function"
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" })
+    : null;
+
+function formatResumeMetadata(resume: ResumeEntry): string | null {
+  const parts: string[] = [];
+  if (resume.sourceFilename) {
+    parts.push(resume.sourceFilename);
+  }
+  if (resume.importedAt) {
+    const date = new Date(resume.importedAt);
+    if (!Number.isNaN(date.getTime())) {
+      const formatted = importDateFormatter
+        ? importDateFormatter.format(date)
+        : date.toLocaleString();
+      parts.push(`Imported ${formatted}`);
+    }
+  }
+  if (!parts.length) {
+    return null;
+  }
+  return parts.join(" • ");
+}
+
 const normalizeTags = (values: string[]): string[] => {
   const seen = new Set<string>();
   const normalized: string[] = [];
@@ -215,12 +240,18 @@ export default function Detail({ resume, onClose, onSave }: Props) {
   };
 
   const { contact, experience, education, skills } = resume.parsed;
+  const metadataLabel = formatResumeMetadata(resume);
 
   return (
     <Dialog open onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>{resume.title}</DialogTitle>
       <DialogContent dividers>
         <Stack spacing={2}>
+          {metadataLabel && (
+            <Typography variant="body2" color="text.secondary">
+              {metadataLabel}
+            </Typography>
+          )}
           <Stack spacing={0.5}>
             <Stack direction="row" spacing={1} flexWrap="wrap" alignItems="center">
               {tags.map((tag, idx) =>

--- a/src/components/talentforge/ResumeVariants/List.tsx
+++ b/src/components/talentforge/ResumeVariants/List.tsx
@@ -12,6 +12,7 @@ import {
   DialogActions,
   Button,
   TextField,
+  Typography,
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
@@ -34,6 +35,31 @@ import Diff from "./Diff";
 interface Props {
   resumes: ResumeEntry[];
   setResumes: (resumes: ResumeEntry[]) => void;
+}
+
+const importDateFormatter =
+  typeof Intl !== "undefined" && typeof Intl.DateTimeFormat === "function"
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" })
+    : null;
+
+function formatResumeMetadata(resume: ResumeEntry): string | null {
+  const parts: string[] = [];
+  if (resume.sourceFilename) {
+    parts.push(resume.sourceFilename);
+  }
+  if (resume.importedAt) {
+    const date = new Date(resume.importedAt);
+    if (!Number.isNaN(date.getTime())) {
+      const formatted = importDateFormatter
+        ? importDateFormatter.format(date)
+        : date.toLocaleString();
+      parts.push(`Imported ${formatted}`);
+    }
+  }
+  if (!parts.length) {
+    return null;
+  }
+  return parts.join(" • ");
 }
 
 export default function List({ resumes, setResumes }: Props) {
@@ -95,6 +121,8 @@ export default function List({ resumes, setResumes }: Props) {
           education: [],
           skills: [],
         },
+        sourceFilename: file.name || "Imported resume",
+        importedAt: new Date().toISOString(),
       };
       const updated = addResume(newResume);
       setResumes(updated);
@@ -120,71 +148,75 @@ export default function List({ resumes, setResumes }: Props) {
 
   return (
     <Box aria-label="Resume list">
-      {resumes.map((r) => (
-        <Box key={r.id} sx={{ mb: 2 }}>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <TextField
-              size="small"
-              value={r.title}
-              onChange={(e) =>
-                setResumes(
-                  resumes.map((res) =>
-                    res.id === r.id ? { ...res, title: e.target.value } : res,
-                  ),
-                )
-              }
-              onBlur={(e) => handleSave({ ...r, title: e.target.value })}
-              sx={{ flexGrow: 1 }}
-              inputProps={{ "aria-label": "Resume title" }}
-            />
-            <IconButton size="small" onClick={() => setSelected(r)} aria-label="edit">
-              <EditIcon fontSize="small" />
-            </IconButton>
-            <IconButton size="small" onClick={() => handleClone(r)} aria-label="clone">
-              <ContentCopyIcon fontSize="small" />
-            </IconButton>
-            <IconButton size="small" onClick={() => setDiffTarget(r)} aria-label="diff">
-              <DifferenceIcon fontSize="small" />
-            </IconButton>
-            <IconButton
-              size="small"
-              onClick={() => setConfirmDelete(r)}
-              aria-label="delete"
-            >
-              <DeleteIcon fontSize="small" />
-            </IconButton>
-            <IconButton
-              size="small"
-              onClick={() => handleExport(r)}
-              aria-label="export"
-            >
-              <FileDownloadIcon fontSize="small" />
-            </IconButton>
-            <IconButton
-              component="label"
-              size="small"
-              aria-label="import"
-            >
-              <UploadFileIcon fontSize="small" />
-              <input
-                type="file"
-                hidden
-                accept="application/json"
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  if (file) void handleImport(file);
-                  e.target.value = "";
-                }}
+      {resumes.map((r) => {
+        const metadataLabel = formatResumeMetadata(r);
+        return (
+          <Box key={r.id} sx={{ mb: 2 }}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <TextField
+                size="small"
+                value={r.title}
+                onChange={(e) =>
+                  setResumes(
+                    resumes.map((res) =>
+                      res.id === r.id ? { ...res, title: e.target.value } : res,
+                    ),
+                  )
+                }
+                onBlur={(e) => handleSave({ ...r, title: e.target.value })}
+                sx={{ flexGrow: 1 }}
+                inputProps={{ "aria-label": "Resume title" }}
               />
-            </IconButton>
-          </Stack>
-          <Stack direction="row" spacing={1} flexWrap="wrap">
-            {r.tags.map((tag) => (
-              <Chip key={tag} label={tag} sx={{ mb: 1 }} />
-            ))}
-          </Stack>
-        </Box>
-      ))}
+              <IconButton size="small" onClick={() => setSelected(r)} aria-label="edit">
+                <EditIcon fontSize="small" />
+              </IconButton>
+              <IconButton size="small" onClick={() => handleClone(r)} aria-label="clone">
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+              <IconButton size="small" onClick={() => setDiffTarget(r)} aria-label="diff">
+                <DifferenceIcon fontSize="small" />
+              </IconButton>
+              <IconButton
+                size="small"
+                onClick={() => setConfirmDelete(r)}
+                aria-label="delete"
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+              <IconButton
+                size="small"
+                onClick={() => handleExport(r)}
+                aria-label="export"
+              >
+                <FileDownloadIcon fontSize="small" />
+              </IconButton>
+              <IconButton component="label" size="small" aria-label="import">
+                <UploadFileIcon fontSize="small" />
+                <input
+                  type="file"
+                  hidden
+                  accept="application/json"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) void handleImport(file);
+                    e.target.value = "";
+                  }}
+                />
+              </IconButton>
+            </Stack>
+            {metadataLabel && (
+              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+                {metadataLabel}
+              </Typography>
+            )}
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              {r.tags.map((tag) => (
+                <Chip key={tag} label={tag} sx={{ mb: 1 }} />
+              ))}
+            </Stack>
+          </Box>
+        );
+      })}
       {selected && (
         <Detail
           resume={selected}

--- a/src/components/talentforge/onboarding/ResumeImportStep.tsx
+++ b/src/components/talentforge/onboarding/ResumeImportStep.tsx
@@ -33,7 +33,7 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
     setLoading(true);
     setError(null);
     try {
-      const text = await fileToText(file);
+      const { text, metadata } = await fileToText(file);
       const tags = await tagResume(text);
       let parsed;
       try {
@@ -51,6 +51,7 @@ export default function ResumeImportStep({ onNext, onBack }: StepProps) {
         content: text,
         parsed,
         tags,
+        ...metadata,
       });
       setFile(null);
       onNext();

--- a/src/hooks/useResumeParser.ts
+++ b/src/hooks/useResumeParser.ts
@@ -1,20 +1,32 @@
 import { useCallback, useState } from "react";
 
-import { fileToText } from "@/utils/talentforge/resumeIngest";
+import {
+  fileToText,
+  createPastedResumeMetadata,
+  type ResumeImportMetadata,
+  type ResumeTextResult,
+} from "@/utils/talentforge/resumeIngest";
 
 export default function useResumeParser() {
   const [resume, setResume] = useState("");
+  const [metadata, setMetadata] = useState<ResumeImportMetadata | null>(null);
 
-  const parseResume = useCallback(async (input: File | string) => {
-    if (typeof input === "string") {
-      setResume(input);
-      return input;
-    }
-    const text = await fileToText(input);
-    setResume(text);
-    return text;
-  }, []);
+  const parseResume = useCallback(
+    async (input: File | string): Promise<ResumeTextResult> => {
+      if (typeof input === "string") {
+        const metadataForPaste = createPastedResumeMetadata();
+        setResume(input);
+        setMetadata(metadataForPaste);
+        return { text: input, metadata: metadataForPaste };
+      }
+      const result = await fileToText(input);
+      setResume(result.text);
+      setMetadata(result.metadata);
+      return result;
+    },
+    [],
+  );
 
-  return { resume, parseResume };
+  return { resume, metadata, parseResume };
 }
 

--- a/src/tests/talentforge/dataStore.test.ts
+++ b/src/tests/talentforge/dataStore.test.ts
@@ -3,10 +3,12 @@ import {
   MESSAGES_VERSION,
   OFFERS_VERSION,
   APPLICATIONS_VERSION,
+  RESUMES_VERSION,
   getCurrentCompensation,
   saveCurrentCompensation,
 } from "../../utils/talentforge/dataStore";
 import { loadItem } from "../../utils/storage";
+import type { ResumeEntry } from "../../types";
 
 interface Message {
   replies: { body: string }[];
@@ -71,6 +73,44 @@ describe("dataStore migrations", () => {
     const apps = loadItem<JobApplication[]>("jobApplications", APPLICATIONS_VERSION)!;
     expect(apps).toHaveLength(1);
     expect(apps[0].role.title).toBe("Engineer");
+  });
+
+  test("importFromJson adds resume metadata when migrating snapshots", () => {
+    jest.useFakeTimers();
+    try {
+      const fixedDate = new Date("2024-03-01T12:00:00.000Z");
+      jest.setSystemTime(fixedDate);
+
+      const snapshot = {
+        version: 3,
+        data: {
+          resumes: {
+            version: 1,
+            data: [
+              {
+                id: "r1",
+                userId: "",
+                label: "",
+                title: "Legacy Resume",
+                url: "",
+                content: "",
+                tags: [],
+                parsed: { contact: "", experience: [], education: [], skills: [] },
+              },
+            ],
+          },
+        },
+      };
+
+      importFromJson(JSON.stringify(snapshot));
+
+      const resumes = loadItem<ResumeEntry[]>("resumes", RESUMES_VERSION)!;
+      expect(resumes).toHaveLength(1);
+      expect(resumes[0].importedAt).toBe(fixedDate.toISOString());
+      expect(resumes[0].sourceFilename).toBe("Imported resume");
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test("importFromJson ignores unknown keys", () => {

--- a/src/tests/talentforge/resumeVariants.test.ts
+++ b/src/tests/talentforge/resumeVariants.test.ts
@@ -16,6 +16,8 @@ describe("resume cloning", () => {
       content: "content A",
       tags: [],
       parsed: { contact: "", experience: [], education: [], skills: [] },
+      sourceFilename: "my-resume.pdf",
+      importedAt: "2024-01-01T00:00:00.000Z",
     };
     addResume(resume);
     const updated = cloneResume(resume);

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -35,6 +35,10 @@ export interface ResumeVariant {
   tags: string[];
   /** Additional notes about this resume variant. */
   notes?: string;
+  /** Original filename of the resume source, if known. */
+  sourceFilename?: string;
+  /** ISO timestamp capturing when this resume was imported. */
+  importedAt?: string;
 }
 
 /**

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -21,6 +21,8 @@ const emptyParsed: ParsedResume = {
   skills: [],
 };
 
+const MOCK_IMPORTED_AT = "2024-01-01T00:00:00.000Z";
+
 export const mockResumes: ResumeEntry[] = [
   {
     id: "resume-1",
@@ -31,16 +33,20 @@ export const mockResumes: ResumeEntry[] = [
     content: "",
     parsed: { ...emptyParsed },
     tags: ["software", "typescript"],
+    sourceFilename: "jane-doe-software.pdf",
+    importedAt: MOCK_IMPORTED_AT,
   },
   {
     id: "resume-2",
     userId: mockUserProfile.id,
     label: "Product Resume",
-     title: "Product Resume",
+    title: "Product Resume",
     url: "https://example.com/jane-doe-product.pdf",
     content: "",
     parsed: { ...emptyParsed },
     tags: ["product", "management"],
+    sourceFilename: "jane-doe-product.pdf",
+    importedAt: MOCK_IMPORTED_AT,
   },
 ];
 

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -88,7 +88,7 @@ const VERSION: { [K in keyof StoreSchema]: number } = {
   currentCompensation: CURRENT_COMP_VERSION,
 } as const;
 
-export const SNAPSHOT_VERSION = 3;
+export const SNAPSHOT_VERSION = 4;
 
 // Generic migration helper which applies migrations sequentially until the
 // data reaches `targetVersion`.
@@ -389,7 +389,8 @@ export function saveResumes(resumes: ResumeEntry[]): void {
 export function addResume(resume: ResumeEntry): ResumeEntry[] {
   const current = getResumes();
   const title = generateUniqueTitle(resume.title || "Resume", current);
-  const newResume = { ...resume, title };
+  const importedAt = resume.importedAt ?? new Date().toISOString();
+  const newResume = { ...resume, title, importedAt };
   const updated = [...current, newResume];
   saveResumes(updated);
   return updated;
@@ -696,6 +697,31 @@ function migrateSnapshot(
   const migrated = { ...data };
   if (fromVersion < 2) {
     migrated[KEYS.connectorTokens] = migrated[KEYS.connectorTokens] || {};
+  }
+  if (fromVersion < 4) {
+    const resumesEntry = migrated[KEYS.resumes];
+    if (
+      resumesEntry &&
+      typeof resumesEntry === "object" &&
+      "data" in (resumesEntry as Record<string, unknown>)
+    ) {
+      const payload = resumesEntry as { data?: ResumeEntry[] };
+      if (Array.isArray(payload.data)) {
+        const timestamp = new Date().toISOString();
+        const migratedResumes = payload.data.map((resume) => {
+          if (!resume || typeof resume !== "object") {
+            return resume;
+          }
+          const typed = resume as ResumeEntry;
+          return {
+            ...typed,
+            sourceFilename: typed.sourceFilename ?? "Imported resume",
+            importedAt: typed.importedAt ?? timestamp,
+          };
+        });
+        migrated[KEYS.resumes] = { ...(resumesEntry as Record<string, unknown>), data: migratedResumes };
+      }
+    }
   }
   return migrated;
 }

--- a/src/utils/talentforge/demoData.ts
+++ b/src/utils/talentforge/demoData.ts
@@ -38,6 +38,8 @@ export function getDemoData(): {
       skills: ["TypeScript", "React"],
     },
     tags: ["typescript", "react"],
+    sourceFilename: "demo-resume.pdf",
+    importedAt: "2024-01-01T00:00:00.000Z",
   };
 
   const role: RolePosting = {

--- a/src/utils/talentforge/resumeIngest.ts
+++ b/src/utils/talentforge/resumeIngest.ts
@@ -3,7 +3,7 @@
 import * as pdfjs from "pdfjs-dist";
 
 import { Buffer } from "buffer";
-import { ParsedResume } from "@/types";
+import type { ParsedResume, ResumeEntry } from "@/types";
 
 declare global {
   interface Window {
@@ -13,6 +13,33 @@ declare global {
 
 if (typeof window !== "undefined") {
   window.Buffer = window.Buffer || Buffer;
+}
+
+export type ResumeImportMetadata = Pick<ResumeEntry, "sourceFilename" | "importedAt">;
+
+export interface ResumeTextResult {
+  text: string;
+  metadata: ResumeImportMetadata;
+}
+
+const PASTED_RESUME_LABEL = "Pasted resume";
+
+function nowIsoString(): string {
+  return new Date().toISOString();
+}
+
+function createMetadataFromFile(file: File): ResumeImportMetadata {
+  return {
+    sourceFilename: file.name || undefined,
+    importedAt: nowIsoString(),
+  };
+}
+
+export function createPastedResumeMetadata(): ResumeImportMetadata {
+  return {
+    sourceFilename: PASTED_RESUME_LABEL,
+    importedAt: nowIsoString(),
+  };
 }
 
 /**
@@ -307,21 +334,23 @@ export async function docxToText(file: File): Promise<string> {
 }
 
 /**
- * Extract text from a file, supporting PDF and DOCX.
+ * Extract text from a file, supporting PDF and DOCX, and attach import metadata.
  */
-export async function fileToText(file: File): Promise<string> {
+export async function fileToText(file: File): Promise<ResumeTextResult> {
   const name = file.name.toLowerCase();
+  let text: string;
   if (file.type === "application/pdf" || name.endsWith(".pdf")) {
-    return pdfToText(file);
-  }
-  if (
+    text = await pdfToText(file);
+  } else if (
     file.type ===
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
     name.endsWith(".docx")
   ) {
-    return docxToText(file);
+    text = await docxToText(file);
+  } else {
+    text = await file.text();
   }
-  return await file.text();
+  return { text, metadata: createMetadataFromFile(file) };
 }
 
 /**
@@ -374,22 +403,22 @@ export function parseResumeText(text: string): ParsedResume {
  */
 export async function parsePdf(
   file: File,
-): Promise<{ text: string; parsed: ParsedResume }> {
+): Promise<{ text: string; parsed: ParsedResume; metadata: ResumeImportMetadata }> {
   const text = await pdfToText(file);
-  return { text, parsed: parseResumeText(text) };
+  return { text, parsed: parseResumeText(text), metadata: createMetadataFromFile(file) };
 }
 
 export async function parseDocx(
   file: File,
-): Promise<{ text: string; parsed: ParsedResume }> {
+): Promise<{ text: string; parsed: ParsedResume; metadata: ResumeImportMetadata }> {
   const text = await docxToText(file);
-  return { text, parsed: parseResumeText(text) };
+  return { text, parsed: parseResumeText(text), metadata: createMetadataFromFile(file) };
 }
 
 export async function parseResumeFile(
   file: File,
-): Promise<{ text: string; parsed: ParsedResume }> {
-  const text = await fileToText(file);
-  return { text, parsed: parseResumeText(text) };
+): Promise<{ text: string; parsed: ParsedResume; metadata: ResumeImportMetadata }> {
+  const { text, metadata } = await fileToText(file);
+  return { text, metadata, parsed: parseResumeText(text) };
 }
 


### PR DESCRIPTION
## Summary
- add resume metadata fields and capture metadata during ingest flows
- surface import metadata in resume list/detail views
- migrate stored data and adjust mock/demo data and tests for new metadata

## Testing
- npm run lint
- NEXT_PUBLIC_OPENAI_API_KEY=dummy npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8eeadd648330b3fe764fe48f28f1