### PR TITLE
docs: clarify job application type

### DIFF
--- a/docs/talentforge.md
+++ b/docs/talentforge.md
@@ -17,7 +17,7 @@ TalentForge uses TypeScript interfaces to describe core entities:
 - **UserProfile** – user identifier, display name, email, and associated resumes.
 - **Resume** – file metadata and optional tags for the uploaded resume.
 - **JobListing** – title, company, location, URL, and source of a job post.
-- **JobApplication** – extends `JobListing` with an `id`, a `status` (`applied`, `interview`, `offer`, or `rejected`), and a `history` field (`StatusChange[]`).
+- **JobApplication** – exported as the `ApplicationRecord` type capturing applicant details, the associated role information, status history, linked recruiters, discussion threads, and optional offer data; it is aliased as `JobApplication` in `src/types/index.ts` for compatibility.
 - **Message** – sender, recipient, timestamp, and message body.
 - **Offer** – compensation details tied to a specific application.
 - **ChatMessage** – conversational messages exchanged with the AI assistant.


### PR DESCRIPTION
## Summary
- describe the ApplicationRecord shape in the JobApplication bullet of the TalentForge docs
- note the compatibility alias exported from src/types/index.ts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb9717ab048330b66b024fced26646