### PR TITLE
Fix spacing in FileUploader validation messages

### DIFF
--- a/src/components/talentforge/FileUploader.tsx
+++ b/src/components/talentforge/FileUploader.tsx
@@ -97,12 +97,12 @@ export default function FileUploader(props: FileUploaderProps) {
           if (validFiles.indexOf(file) > limit - 1) {
             updatedErrors[
               file.name
-            ] = `File not uploaded.  Maximum number of files exceeded. Must not be more than ${limit}.`;
+            ] = `File not uploaded. Maximum number of files exceeded. Must not be more than ${limit}.`;
             validFiles = validFiles.filter((f) => f.name !== file.name);
           } else if (file.size > maxFileSize) {
             updatedErrors[
               file.name
-            ] = `File not uploaded.  Maximum file size exceeded. Must not be more than ${getFileSize(
+            ] = `File not uploaded. Maximum file size exceeded. Must not be more than ${getFileSize(
               maxFileSize
             )}.`;
             validFiles = validFiles.filter((f) => f.name !== file.name);


### PR DESCRIPTION
## Summary
- remove the extra space after the period in the file limit and file size validation messages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb96f79db483308ecab11f1b79cf2d