### PR TITLE
Use prompt registry in inbox AI drafting

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -51,13 +51,13 @@ import {
 } from "@/utils/talentforge/dataStore";
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
 import EmptyState from "./EmptyState";
-import { PROMPT_TILES } from "@/consts/promptTiles";
 import { askOpenAI, pdfToMarkdown } from "@/utils/talentforge/utils";
 import RequireAIKey from "./RequireAIKey";
 import FileUploader from "./FileUploader";
 import ResumeStepperModal from "./ResumeStepperModal";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import { STATUSES, getNextStatus } from "@/utils/talentforge/keyboard";
+import { getPromptTile, type PromptContext } from "@/utils/talentforge/promptRegistry";
 
 interface Issue {
   severity: "red" | "yellow";
@@ -106,7 +106,7 @@ function Card({
   activeId,
 }: {
   app: JobApplication;
-  onRunTile: (id: string, app: JobApplication) => void;
+  onRunTile: (id: string, context: PromptContext) => void;
   resumes: ResumeEntry[];
   onAssignResume: (appId: string, resumeId: string) => void;
   onSetInterviewDate: (appId: string, value: string) => void;
@@ -121,6 +121,13 @@ function Card({
     opacity: isDragging ? 0.5 : 1,
     cursor: "grab",
   } as const;
+
+  const offerNegotiationTile = getPromptTile("offerNegotiation", {
+    contexts: "offers",
+  });
+  const compareCurrentCompTile = getPromptTile("compareCurrentComp", {
+    contexts: "offers",
+  });
 
   return (
     <Box
@@ -199,7 +206,7 @@ function Card({
           <Button
             size="small"
             onPointerDown={(e) => e.stopPropagation()}
-            onClick={() => onRunTile("screenRole", app)}
+            onClick={() => onRunTile("screenRole", "jobSearch")}
             variant="outlined"
             fullWidth
           >
@@ -210,7 +217,7 @@ function Card({
               <Button
                 size="small"
                 onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => onRunTile("resumeCompare", app)}
+                onClick={() => onRunTile("resumeCompare", "resume")}
                 variant="outlined"
                 fullWidth
               >
@@ -219,7 +226,7 @@ function Card({
               <Button
                 size="small"
                 onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => onRunTile("coverLetter", app)}
+                onClick={() => onRunTile("coverLetter", "resume")}
                 variant="outlined"
                 fullWidth
               >
@@ -234,7 +241,7 @@ function Card({
           <Button
             size="small"
             onPointerDown={(e) => e.stopPropagation()}
-            onClick={() => onRunTile("offerDetails", app)}
+            onClick={() => onRunTile("offerDetails", "offers")}
             variant="outlined"
             fullWidth
           >
@@ -265,22 +272,22 @@ function Card({
               <Button
                 size="small"
                 onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => onRunTile("offerNegotiation", app)}
+                onClick={() => onRunTile("offerNegotiation", "offers")}
                 variant="outlined"
                 fullWidth
                 sx={{ mt: 1 }}
               >
-                {PROMPT_TILES.offerNegotiation.display}
+                {offerNegotiationTile?.display || "Renegotiation Offer"}
               </Button>
               <Button
                 size="small"
                 onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => onRunTile("compareCurrentComp", app)}
+                onClick={() => onRunTile("compareCurrentComp", "offers")}
                 variant="outlined"
                 fullWidth
                 sx={{ mt: 1 }}
               >
-                {PROMPT_TILES.compareCurrentComp.display}
+                {compareCurrentCompTile?.display || "Compare to Current Comp"}
               </Button>
             </>
           )}
@@ -435,8 +442,12 @@ export default function ApplicationBoard() {
     setSource("Company Site");
   };
 
-  const runTile = async (tileId: string, app: JobApplication) => {
-    const tile = PROMPT_TILES[tileId];
+  const runTile = async (
+    tileId: string,
+    context: PromptContext,
+    app: JobApplication,
+  ) => {
+    const tile = getPromptTile(tileId, { contexts: context });
     if (!tile) return;
     if (tileId === "resumeCompare") {
       if (resumes.length === 0) {
@@ -669,10 +680,14 @@ export default function ApplicationBoard() {
         ...prev,
         { role: "assistant", text: "Parsing offer details..." },
       ]);
-      const prompt = PROMPT_TILES.offerDetails.fullPrompt.replace(
-        "{{offerText}}",
-        text
-      );
+      const offerTile = getPromptTile("offerDetails", { contexts: "offers" });
+      if (!offerTile) {
+        setDrawerMessages([
+          { role: "assistant", text: "Offer analysis prompt unavailable." },
+        ]);
+        return;
+      }
+      const prompt = offerTile.fullPrompt.replace("{{offerText}}", text);
       const res = await askOpenAI({
         context: "",
         user: prompt,
@@ -720,7 +735,20 @@ export default function ApplicationBoard() {
       ...prev,
       { role: "user", text: `Using resume: ${resume.title}` },
     ]);
-    const prompt = PROMPT_TILES.resumeCompare.fullPrompt
+    const resumeTile = getPromptTile("resumeCompare", {
+      contexts: ["resume", "jobSearch"],
+    });
+    if (!resumeTile) {
+      setDrawerMessages((prev) => [
+        ...prev,
+        { role: "assistant", text: "Resume comparison prompt unavailable." },
+      ]);
+      setDrawerLoading(false);
+      setDrawerMode("chat");
+      setResumeCompareApp(null);
+      return;
+    }
+    const prompt = resumeTile.fullPrompt
       .replaceAll("{{jobDescription}}", resumeCompareApp.role.description || "")
       .replaceAll("{{resumeContent}}", resume.content);
     setDrawerLoading(true);
@@ -854,7 +882,7 @@ export default function ApplicationBoard() {
                     <Card
                       key={app.id}
                       app={app}
-                      onRunTile={(id) => runTile(id, app)}
+                      onRunTile={(id, context) => runTile(id, context, app)}
                       resumes={resumes}
                       onAssignResume={handleAssignResume}
                       onSetInterviewDate={handleInterviewDate}

--- a/src/components/talentforge/ChatWorkspace.tsx
+++ b/src/components/talentforge/ChatWorkspace.tsx
@@ -52,6 +52,7 @@ export default function ChatWorkspace({
         <PromptTileGrid
           onResponse={setOutput}
           initialValues={{ jdRequirements: { jobDescription } }}
+          contexts={["resume", "jobSearch"]}
         />
       </Box>
       <Box

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -32,7 +32,7 @@ import type { Message, RecruiterEntry } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 import PromptSelector from "./PromptSelector";
 import Tile from "./promptTiles/Tile";
-import { PROMPT_TILES } from "@/consts/promptTiles";
+import { getPromptTile } from "@/utils/talentforge/promptRegistry";
 import EmptyState from "./EmptyState";
 
 export default function Inbox() {
@@ -220,6 +220,18 @@ export default function Inbox() {
     );
   }
 
+  const selectedPromptTile =
+    promptKey !== ""
+      ? getPromptTile(promptKey, { contexts: "messaging" })
+      : undefined;
+
+  const promptTileInitialValues =
+    promptKey === "recruiterNudge" && aiThread
+      ? {
+          messageContext: threads.find((m) => m.id === aiThread)?.body || "",
+        }
+      : undefined;
+
   return (
     <Box aria-busy={loading} aria-label={loading ? "Loading inbox" : undefined}>
       <Stack direction="row" spacing={2} sx={{ height: "100%" }}>
@@ -392,18 +404,21 @@ export default function Inbox() {
         <DialogTitle>Draft with AI</DialogTitle>
         <DialogContent>
           <Stack spacing={2}>
-            <PromptSelector value={promptKey} onChange={setPromptKey} />
-            {promptKey && (
+            <PromptSelector
+              value={promptKey}
+              onChange={setPromptKey}
+              contexts="messaging"
+            />
+            {promptKey && !selectedPromptTile && (
+              <Typography color="text.secondary">
+                The selected prompt is unavailable in this workspace.
+              </Typography>
+            )}
+            {selectedPromptTile && (
               <Tile
-                {...PROMPT_TILES[promptKey]}
+                {...selectedPromptTile}
                 onInsert={handleInsertAIDraft}
-                initialValues=
-                  {promptKey === "recruiterNudge" && aiThread
-                    ? {
-                        messageContext:
-                          threads.find((m) => m.id === aiThread)?.body || "",
-                      }
-                    : undefined}
+                initialValues={promptTileInitialValues}
               />
             )}
           </Stack>

--- a/src/components/talentforge/PromptSelector.tsx
+++ b/src/components/talentforge/PromptSelector.tsx
@@ -8,37 +8,75 @@ import {
   SelectChangeEvent,
 } from "@mui/material";
 
-import { PROMPT_TEMPLATES, PROMPT_GROUPS } from "@/consts/prompts";
+import {
+  PROMPT_CONTEXT_LABELS,
+  PROMPT_CONTEXT_ORDER,
+  getPromptTiles,
+  type PromptContext,
+  type PromptTileWithMetadata,
+} from "@/utils/talentforge/promptRegistry";
 
 interface PromptSelectorProps {
   value: string;
   onChange: (value: string) => void;
+  contexts?: PromptContext | PromptContext[];
 }
 
-export default function PromptSelector({ value, onChange }: PromptSelectorProps) {
+export default function PromptSelector({
+  value,
+  onChange,
+  contexts,
+}: PromptSelectorProps) {
   const handleChange = (event: SelectChangeEvent<string>) => {
     onChange(event.target.value as string);
   };
+
+  const requestedContexts: PromptContext[] = contexts
+    ? Array.isArray(contexts)
+      ? contexts
+      : [contexts]
+    : PROMPT_CONTEXT_ORDER;
+
+  const tiles = getPromptTiles({ contexts: requestedContexts });
+
+  const seen = new Set<string>();
+  const groups = requestedContexts
+    .map((context) => {
+      const contextTiles = tiles.filter((tile) => {
+        if (!tile.contexts.includes(context) || seen.has(tile.id)) {
+          return false;
+        }
+        seen.add(tile.id);
+        return true;
+      });
+      return { context, tiles: contextTiles };
+    })
+    .filter((group) => group.tiles.length > 0);
+
+  const fallbackTiles: PromptTileWithMetadata[] =
+    groups.length === 0 ? tiles : [];
 
   return (
     <Select value={value} onChange={handleChange} displayEmpty fullWidth>
       <MenuItem value="" disabled>
         Select a prompt
       </MenuItem>
-      {Object.entries(PROMPT_GROUPS).map(([group, keys]) => (
-        <React.Fragment key={group}>
-          <ListSubheader>{group}</ListSubheader>
-          {keys.map((key) => {
-            const template = PROMPT_TEMPLATES[key];
-            if (!template) return null;
-            return (
-              <MenuItem key={key} value={key}>
-                {template.displayText}
-              </MenuItem>
-            );
-          })}
-        </React.Fragment>
-      ))}
+      {groups.length > 0
+        ? groups.map(({ context, tiles: contextTiles }) => (
+            <React.Fragment key={context}>
+              <ListSubheader>{PROMPT_CONTEXT_LABELS[context]}</ListSubheader>
+              {contextTiles.map((tile) => (
+                <MenuItem key={tile.id} value={tile.id}>
+                  {tile.display}
+                </MenuItem>
+              ))}
+            </React.Fragment>
+          ))
+        : fallbackTiles.map((tile) => (
+            <MenuItem key={tile.id} value={tile.id}>
+              {tile.display}
+            </MenuItem>
+          ))}
     </Select>
   );
 }

--- a/src/components/talentforge/promptTiles/PromptTileGrid.tsx
+++ b/src/components/talentforge/promptTiles/PromptTileGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
   Box,
   Button,
@@ -14,20 +14,25 @@ import {
 import RequireAIKey from "../RequireAIKey";
 import { askOpenAI } from "@/utils/talentforge/utils";
 import { getResumes } from "@/utils/talentforge/dataStore";
-import { PROMPT_TILES, type PromptTileDefinition } from "@/consts/promptTiles";
-
-const registry: Record<string, PromptTileDefinition> = PROMPT_TILES;
+import {
+  getPromptTiles,
+  type PromptContext,
+  type PromptTileFilters,
+  type PromptTileWithMetadata,
+} from "@/utils/talentforge/promptRegistry";
 
 interface PromptTileGridProps {
   onResponse?: (response: string) => void;
   tileIds?: string[];
   initialValues?: Record<string, Record<string, string>>;
+  contexts?: PromptContext | PromptContext[];
 }
 
 export default function PromptTileGrid({
   onResponse,
   tileIds,
   initialValues = {},
+  contexts,
 }: PromptTileGridProps) {
   const [values, setValues] = useState<
     Record<string, Record<string, string>>
@@ -45,8 +50,19 @@ export default function PromptTileGrid({
     }));
   };
 
+  const tiles: PromptTileWithMetadata[] = useMemo(() => {
+    const filters: PromptTileFilters = {};
+    if (tileIds && tileIds.length > 0) {
+      filters.ids = tileIds;
+    }
+    if (contexts !== undefined) {
+      filters.contexts = contexts;
+    }
+    return getPromptTiles(filters);
+  }, [tileIds, contexts]);
+
   const runTile = async (id: string) => {
-    const tile = registry[id];
+    const tile = tiles.find((entry) => entry.id === id);
     if (!tile) return;
 
     setLoading((prev) => ({ ...prev, [id]: true }));
@@ -86,10 +102,6 @@ export default function PromptTileGrid({
       setLoading((prev) => ({ ...prev, [id]: false }));
     }
   };
-
-  const tiles = tileIds
-    ? tileIds.map((id) => registry[id]).filter(Boolean)
-    : Object.values(registry);
 
   return (
     <RequireAIKey>

--- a/src/tests/talentforge/promptRegistry.test.ts
+++ b/src/tests/talentforge/promptRegistry.test.ts
@@ -1,0 +1,30 @@
+import { getPromptTile, getPromptTiles } from "@/utils/talentforge/promptRegistry";
+
+describe("promptRegistry", () => {
+  it("filters tiles by context", () => {
+    const tiles = getPromptTiles({ contexts: "resume" });
+    expect(tiles.length).toBeGreaterThan(0);
+    for (const tile of tiles) {
+      expect(tile.contexts).toContain("resume");
+    }
+  });
+
+  it("respects id ordering when filtering", () => {
+    const ids = ["resumeSummary", "offerDetails", "coverLetter"];
+    const tiles = getPromptTiles({ ids, contexts: "resume" });
+    expect(tiles.map((tile) => tile.id)).toEqual([
+      "resumeSummary",
+      "coverLetter",
+    ]);
+  });
+
+  it("returns undefined when context does not match", () => {
+    const tile = getPromptTile("offerDetails", { contexts: "resume" });
+    expect(tile).toBeUndefined();
+  });
+
+  it("includes recommended goal tags metadata", () => {
+    const tile = getPromptTile("coverLetter");
+    expect(tile?.recommendedGoalTags).toContain("resume");
+  });
+});

--- a/src/utils/talentforge/promptRegistry.ts
+++ b/src/utils/talentforge/promptRegistry.ts
@@ -1,0 +1,210 @@
+import { PROMPT_TILES, type PromptTileDefinition } from "@/consts/promptTiles";
+
+export type PromptContext = "resume" | "offers" | "messaging" | "jobSearch";
+export type TalentForgeGoalTag = "resume" | "networking" | "search";
+
+export interface PromptTileWithMetadata extends PromptTileDefinition {
+  contexts: PromptContext[];
+  recommendedGoalTags: TalentForgeGoalTag[];
+}
+
+export interface PromptTileFilters {
+  contexts?: PromptContext | PromptContext[];
+  goalTags?: TalentForgeGoalTag | TalentForgeGoalTag[];
+  ids?: string[];
+}
+
+const TILE_METADATA: Record<keyof typeof PROMPT_TILES, {
+  contexts: PromptContext[];
+  recommendedGoalTags: TalentForgeGoalTag[];
+}> = {
+  resumeSummary: {
+    contexts: ["resume"],
+    recommendedGoalTags: ["resume"],
+  },
+  coverLetter: {
+    contexts: ["resume", "messaging"],
+    recommendedGoalTags: ["resume", "networking"],
+  },
+  bulletRewrite: {
+    contexts: ["resume"],
+    recommendedGoalTags: ["resume"],
+  },
+  negotiateOffer: {
+    contexts: ["offers", "messaging"],
+    recommendedGoalTags: ["search", "networking"],
+  },
+  interviewPreparation: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  salaryResearch: {
+    contexts: ["offers", "jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  skillGapAnalysis: {
+    contexts: ["jobSearch", "resume"],
+    recommendedGoalTags: ["resume", "search"],
+  },
+  compareResumeToJob: {
+    contexts: ["resume", "jobSearch"],
+    recommendedGoalTags: ["resume", "search"],
+  },
+  jobDescriptionRewrite: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  jobDescriptionRisk: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  screenRole: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  jobRequirements: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  networkingOutreach: {
+    contexts: ["messaging", "jobSearch"],
+    recommendedGoalTags: ["networking"],
+  },
+  recruiterNudge: {
+    contexts: ["messaging"],
+    recommendedGoalTags: ["networking"],
+  },
+  portfolioReview: {
+    contexts: ["resume"],
+    recommendedGoalTags: ["resume"],
+  },
+  elevatorPitch: {
+    contexts: ["messaging", "resume"],
+    recommendedGoalTags: ["networking", "resume"],
+  },
+  projectSummary: {
+    contexts: ["resume"],
+    recommendedGoalTags: ["resume"],
+  },
+  careerGoals: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  linkedinProfileOptimization: {
+    contexts: ["messaging", "jobSearch"],
+    recommendedGoalTags: ["networking", "search"],
+  },
+  resumeRewrite: {
+    contexts: ["resume"],
+    recommendedGoalTags: ["resume"],
+  },
+  resumeCompare: {
+    contexts: ["resume", "jobSearch"],
+    recommendedGoalTags: ["resume", "search"],
+  },
+  jdRequirements: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  compareOffers: {
+    contexts: ["offers"],
+    recommendedGoalTags: ["search"],
+  },
+  offerDetails: {
+    contexts: ["offers"],
+    recommendedGoalTags: ["search"],
+  },
+  offerNegotiation: {
+    contexts: ["offers", "messaging"],
+    recommendedGoalTags: ["search", "networking"],
+  },
+  compareCurrentComp: {
+    contexts: ["offers"],
+    recommendedGoalTags: ["search"],
+  },
+};
+
+const registryEntries = Object.entries(PROMPT_TILES) as Array<[
+  keyof typeof PROMPT_TILES,
+  PromptTileDefinition,
+]>;
+
+export const PROMPT_TILE_REGISTRY: Record<string, PromptTileWithMetadata> = Object.fromEntries(
+  registryEntries.map(([id, definition]) => {
+    const metadata = TILE_METADATA[id];
+    return [
+      id,
+      {
+        ...definition,
+        contexts: metadata.contexts,
+        recommendedGoalTags: metadata.recommendedGoalTags,
+      },
+    ];
+  }),
+);
+
+export const PROMPT_CONTEXT_LABELS: Record<PromptContext, string> = {
+  resume: "Resumes",
+  offers: "Offers",
+  messaging: "Messaging",
+  jobSearch: "Job Search",
+};
+
+export const PROMPT_CONTEXT_ORDER: PromptContext[] = [
+  "resume",
+  "offers",
+  "messaging",
+  "jobSearch",
+];
+
+const toArray = <T,>(value?: T | T[]): T[] => {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+const matchesContexts = (
+  tile: PromptTileWithMetadata,
+  contexts: PromptContext[],
+) =>
+  contexts.length === 0 || contexts.some((ctx) => tile.contexts.includes(ctx));
+
+const matchesGoalTags = (
+  tile: PromptTileWithMetadata,
+  goalTags: TalentForgeGoalTag[],
+) =>
+  goalTags.length === 0 || goalTags.some((tag) => tile.recommendedGoalTags.includes(tag));
+
+export function getPromptTile(
+  id: string,
+  filters: PromptTileFilters = {},
+): PromptTileWithMetadata | undefined {
+  const tile = PROMPT_TILE_REGISTRY[id];
+  if (!tile) return undefined;
+
+  const contexts = toArray(filters.contexts);
+  const goalTags = toArray(filters.goalTags);
+
+  if (!matchesContexts(tile, contexts)) return undefined;
+  if (!matchesGoalTags(tile, goalTags)) return undefined;
+
+  return tile;
+}
+
+export function getPromptTiles(
+  filters: PromptTileFilters = {},
+): PromptTileWithMetadata[] {
+  const contexts = toArray(filters.contexts);
+  const goalTags = toArray(filters.goalTags);
+
+  if (filters.ids && filters.ids.length > 0) {
+    return filters.ids
+      .map((id) => getPromptTile(id, { contexts, goalTags }))
+      .filter((tile): tile is PromptTileWithMetadata => Boolean(tile));
+  }
+
+  return Object.values(PROMPT_TILE_REGISTRY).filter(
+    (tile) => matchesContexts(tile, contexts) && matchesGoalTags(tile, goalTags),
+  );
+}


### PR DESCRIPTION
## Summary
- resolve inbox prompt tile lookup through the shared registry so AI drafting respects messaging contexts

## Testing
- NEXT_PUBLIC_OPENAI_API_KEY=dummy npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9315abd883308d79c15822a65cd9