### PR TITLE
Handle OfferCompare errors and add regression test

### DIFF
--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -5,6 +5,7 @@ import Markdown from "react-markdown";
 import { v4 as uuid } from "uuid";
 
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -18,7 +19,8 @@ import { askOpenAI, pdfToMarkdown } from "@/utils/talentforge/utils";
 import RequireAIKey from "./RequireAIKey";
 import { addOffer } from "@/utils/talentforge/dataStore";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-import type { Offer, Message, ApplicationRecord } from "@/types";
+import type { Message } from "@/types";
+import { analyzeOfferWithAI, type OfferDrafts } from "./offerAnalysis";
 
 interface OfferCompareProps {
   onSave?: () => void;
@@ -29,12 +31,13 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
   const [offerText, setOfferText] = useState("");
   const [compensation, setCompensation] = useState("");
   const [analysis, setAnalysis] = useState("");
-  const [drafts, setDrafts] = useState({
+  const [drafts, setDrafts] = useState<OfferDrafts>({
     email: "",
     linkedin: "",
     indeed: "",
   });
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleFileChange = (
     filesFromParam: File[] | string | { filename: string; type: string; content: string } | undefined
@@ -57,53 +60,19 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
       "Then draft professional replies for email, LinkedIn, and Indeed. " +
       "Respond in JSON with keys analysis, email, linkedin, indeed.";
     setLoading(true);
-    const response = await askOpenAI({
+    setError(null);
+    await analyzeOfferWithAI({
       context,
-      user: prompt,
-      system:
-        "You analyze offers and produce structured response drafts.",
-      chatHistory: [],
-      returnFirstResponse: true,
+      prompt,
+      compensation,
+      setAnalysis,
+      setDrafts,
+      setError,
+      setLoading,
+      onSave,
+      ask: askOpenAI,
+      addOfferFn: addOffer,
     });
-    const message = response?.message || "";
-    try {
-      const parsed = JSON.parse(message) as {
-        analysis?: string;
-        email?: string;
-        linkedin?: string;
-        indeed?: string;
-      };
-      setAnalysis(parsed.analysis || "");
-      setDrafts({
-        email: parsed.email || "",
-        linkedin: parsed.linkedin || "",
-        indeed: parsed.indeed || "",
-      });
-      const offer: Offer = {
-        id: uuid(),
-        application: {} as ApplicationRecord,
-        compensation: [{ type: "note", amount: 0, notes: compensation }],
-        summary: [
-          `Analysis: ${parsed.analysis || ""}`,
-          `Email Draft: ${parsed.email || ""}`,
-          `LinkedIn Draft: ${parsed.linkedin || ""}`,
-          `Indeed Draft: ${parsed.indeed || ""}`,
-        ],
-      };
-      addOffer(offer);
-    } catch {
-      setAnalysis(message);
-      setDrafts({ email: "", linkedin: "", indeed: "" });
-      const offer: Offer = {
-        id: uuid(),
-        application: {} as ApplicationRecord,
-        compensation: [{ type: "note", amount: 0, notes: compensation }],
-        summary: [message],
-      };
-      addOffer(offer);
-    }
-    setLoading(false);
-    onSave?.();
   };
 
   const insertDraft = (connector: string, body: string) => {
@@ -146,6 +115,15 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
         >
           Analyze Offer
         </Button>
+        {error && (
+          <Alert
+            severity="error"
+            onClose={() => setError(null)}
+            sx={{ mt: 1 }}
+          >
+            {error}
+          </Alert>
+        )}
         {loading && (
           <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
             <CircularProgress />

--- a/src/components/talentforge/offerAnalysis.ts
+++ b/src/components/talentforge/offerAnalysis.ts
@@ -1,0 +1,96 @@
+import { v4 as uuid } from "uuid";
+
+import type { Offer, ApplicationRecord } from "@/types";
+import type { askOpenAI as AskOpenAIFunc } from "@/utils/talentforge/utils";
+
+export type OfferDrafts = {
+  email: string;
+  linkedin: string;
+  indeed: string;
+};
+
+export interface AnalyzeOfferOptions {
+  context: string;
+  prompt: string;
+  compensation: string;
+  setAnalysis: (value: string) => void;
+  setDrafts: (value: OfferDrafts) => void;
+  setError: (value: string | null) => void;
+  setLoading: (value: boolean) => void;
+  onSave?: () => void;
+  ask: (...args: Parameters<AskOpenAIFunc>) => ReturnType<AskOpenAIFunc>;
+  addOfferFn: (offer: Offer) => void;
+}
+
+export async function analyzeOfferWithAI({
+  context,
+  prompt,
+  compensation,
+  setAnalysis,
+  setDrafts,
+  setError,
+  setLoading,
+  onSave,
+  ask,
+  addOfferFn,
+}: AnalyzeOfferOptions) {
+  try {
+    const response = await ask({
+      context,
+      user: prompt,
+      system: "You analyze offers and produce structured response drafts.",
+      chatHistory: [],
+      returnFirstResponse: true,
+    });
+    const message = response?.message || "";
+    try {
+      const parsed = JSON.parse(message) as {
+        analysis?: string;
+        email?: string;
+        linkedin?: string;
+        indeed?: string;
+      };
+      setAnalysis(parsed.analysis || "");
+      setDrafts({
+        email: parsed.email || "",
+        linkedin: parsed.linkedin || "",
+        indeed: parsed.indeed || "",
+      });
+      const offer: Offer = {
+        id: uuid(),
+        application: {} as ApplicationRecord,
+        compensation: [{ type: "note", amount: 0, notes: compensation }],
+        summary: [
+          `Analysis: ${parsed.analysis || ""}`,
+          `Email Draft: ${parsed.email || ""}`,
+          `LinkedIn Draft: ${parsed.linkedin || ""}`,
+          `Indeed Draft: ${parsed.indeed || ""}`,
+        ],
+      };
+      addOfferFn(offer);
+    } catch {
+      setAnalysis(message);
+      setDrafts({ email: "", linkedin: "", indeed: "" });
+      const offer: Offer = {
+        id: uuid(),
+        application: {} as ApplicationRecord,
+        compensation: [{ type: "note", amount: 0, notes: compensation }],
+        summary: [message],
+      };
+      addOfferFn(offer);
+    }
+    onSave?.();
+  } catch (err) {
+    console.error("Failed to analyze offer", err);
+    setAnalysis("");
+    setDrafts({ email: "", linkedin: "", indeed: "" });
+    setError(
+      err instanceof Error
+        ? err.message
+        : "Failed to analyze offer. Please try again.",
+    );
+  } finally {
+    setLoading(false);
+  }
+}
+

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,5 +1,8 @@
 export {};
 
+process.env.NEXT_PUBLIC_OPENAI_API_KEY =
+  process.env.NEXT_PUBLIC_OPENAI_API_KEY || "test-openai-key";
+
 const createStorage = () => {
   const storage: Record<string, string> = {};
   return {

--- a/src/tests/talentforge/OfferCompare.test.ts
+++ b/src/tests/talentforge/OfferCompare.test.ts
@@ -1,0 +1,43 @@
+import { analyzeOfferWithAI } from "@/components/talentforge/offerAnalysis";
+
+describe("OfferCompare analyzeOfferWithAI", () => {
+  it("clears loading and surfaces an error when the analysis fails", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    const setAnalysis = jest.fn();
+    const setDrafts = jest.fn();
+    const setError = jest.fn();
+    const setLoading = jest.fn();
+    const addOfferFn = jest.fn();
+    const onSave = jest.fn();
+    const ask = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("analysis failed"));
+
+    await analyzeOfferWithAI({
+      context: "Offer context",
+      prompt: "Prompt",
+      compensation: "Compensation",
+      setAnalysis,
+      setDrafts,
+      setError,
+      setLoading,
+      onSave,
+      ask,
+      addOfferFn,
+    });
+
+    expect(setAnalysis).toHaveBeenCalledWith("");
+    expect(setDrafts).toHaveBeenCalledWith({
+      email: "",
+      linkedin: "",
+      indeed: "",
+    });
+    expect(setError).toHaveBeenCalledWith("analysis failed");
+    expect(setLoading).toHaveBeenCalledWith(false);
+    expect(addOfferFn).not.toHaveBeenCalled();
+    expect(onSave).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- surface AI analysis errors in OfferCompare via a shared helper that always clears the loading flag
- display an inline error alert when OpenAI analysis fails and reset drafts/analysis state
- add a regression test for the failure path and seed a default OpenAI API key for Jest runs

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cb970491c083309d0daf60d3cb343d