### PR TITLE
Add talentforge application workspace with chat integration

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -40,6 +40,7 @@ import type {
   ResumeEntry,
   Offer,
   OfferComp,
+  Message,
 } from "@/types";
 import {
   addJobApplication,
@@ -48,6 +49,8 @@ import {
   updateJobApplication,
   getResumes,
   getCurrentCompensation,
+  cloneResume,
+  updateResume,
 } from "@/utils/talentforge/dataStore";
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
 import EmptyState from "./EmptyState";
@@ -59,6 +62,8 @@ import ResumeStepperModal from "./ResumeStepperModal";
 import ManageResumesModal from "./ManageResumesModal";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import { STATUSES, getNextStatus } from "@/utils/talentforge/keyboard";
+import ChatWorkspace from "./ChatWorkspace";
+import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 
 interface Issue {
   severity: "red" | "yellow";
@@ -105,6 +110,7 @@ function Card({
   onSetInterviewLocation,
   onKeyDown,
   activeId,
+  onOpenWorkspace,
 }: {
   app: JobApplication;
   onRunTile: (id: string, app: JobApplication) => void;
@@ -114,6 +120,7 @@ function Card({
   onSetInterviewLocation: (appId: string, value: string) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   activeId: string | null;
+  onOpenWorkspace: (app: JobApplication) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({ id: app.id });
@@ -195,41 +202,56 @@ function Card({
             />
           </>
         )}
-      {app.role.description && (
-        <Stack direction="column" spacing={1} sx={{ mt: 1 }}>
-          <Button
-            size="small"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={() => onRunTile("screenRole", app)}
-            variant="outlined"
-            fullWidth
-          >
-            Analyze Risks
-          </Button>
-          {app.status !== "offer" && (
-            <>
-              <Button
-                size="small"
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => onRunTile("resumeCompare", app)}
-                variant="outlined"
-                fullWidth
-              >
-                Compare to Resume
-              </Button>
-              <Button
-                size="small"
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => onRunTile("coverLetter", app)}
-                variant="outlined"
-                fullWidth
-              >
-                Cover Letter
-              </Button>
-            </>
-          )}
-        </Stack>
-      )}
+      <Stack
+        direction="column"
+        spacing={1}
+        sx={{ mt: app.role.description ? 1 : 2 }}
+      >
+        <Button
+          size="small"
+          variant="contained"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() => onOpenWorkspace(app)}
+          fullWidth
+        >
+          Open Workspace
+        </Button>
+        {app.role.description && (
+          <>
+            <Button
+              size="small"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={() => onRunTile("screenRole", app)}
+              variant="outlined"
+              fullWidth
+            >
+              Analyze Risks
+            </Button>
+            {app.status !== "offer" && (
+              <>
+                <Button
+                  size="small"
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={() => onRunTile("resumeCompare", app)}
+                  variant="outlined"
+                  fullWidth
+                >
+                  Compare to Resume
+                </Button>
+                <Button
+                  size="small"
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={() => onRunTile("coverLetter", app)}
+                  variant="outlined"
+                  fullWidth
+                >
+                  Cover Letter
+                </Button>
+              </>
+            )}
+          </>
+        )}
+      </Stack>
       {app.status === "offer" && (
         <Box sx={{ mt: 1 }}>
           <Button
@@ -292,6 +314,7 @@ function Card({
 }
 
 export default function ApplicationBoard() {
+  const data = useTalentForgeData();
   const [applications, setApplications] = useState<JobApplication[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -327,6 +350,7 @@ export default function ApplicationBoard() {
   const [resumeModalOpen, setResumeModalOpen] = useState(false);
   const [manageResumesOpen, setManageResumesOpen] = useState(false);
   const negotiationRef = useRef<HTMLDivElement | null>(null);
+  const [workspaceResumeId, setWorkspaceResumeId] = useState<string | null>(null);
 
   useEffect(() => {
     const existing = getJobApplications();
@@ -352,6 +376,10 @@ export default function ApplicationBoard() {
       setLoading(false);
     }
   }, []);
+
+  useEffect(() => {
+    setWorkspaceResumeId(drawerApp?.resumeVariant?.id || null);
+  }, [drawerApp]);
 
   if (loading) {
     return (
@@ -644,16 +672,26 @@ export default function ApplicationBoard() {
     if (!resume) return;
     const updated = updateJobApplication(appId, { resumeVariant: resume });
     setApplications(updated);
+    if (drawerApp && drawerApp.id === appId) {
+      setDrawerApp(updated.find((a) => a.id === appId) || null);
+    }
+    setWorkspaceResumeId(resume.id);
   };
 
   const handleInterviewDate = (appId: string, value: string) => {
     const updated = updateJobApplication(appId, { interviewDateTime: value });
     setApplications(updated);
+    if (drawerApp && drawerApp.id === appId) {
+      setDrawerApp(updated.find((a) => a.id === appId) || null);
+    }
   };
 
   const handleInterviewLocation = (appId: string, value: string) => {
     const updated = updateJobApplication(appId, { interviewLocation: value });
     setApplications(updated);
+    if (drawerApp && drawerApp.id === appId) {
+      setDrawerApp(updated.find((a) => a.id === appId) || null);
+    }
   };
 
   const handleOfferUpload = async (file: File) => {
@@ -794,6 +832,12 @@ export default function ApplicationBoard() {
     if (resumeId && !updated.some((r) => r.id === resumeId)) {
       setResumeId("");
     }
+    if (
+      workspaceResumeId &&
+      !updated.some((resume) => resume.id === workspaceResumeId)
+    ) {
+      setWorkspaceResumeId(null);
+    }
   };
 
   const handleResumeModalClose = () => {
@@ -804,6 +848,76 @@ export default function ApplicationBoard() {
   const handleManageModalClose = () => {
     setManageResumesOpen(false);
     handleResumesUpdated(getResumes());
+  };
+
+  const openWorkspace = (app: JobApplication) => {
+    setDrawerTitle(`${app.role.title} Workspace`);
+    setDrawerTileId("workspace");
+    setDrawerMessages([]);
+    setDrawerAnalysis(null);
+    setDrawerMode("chat");
+    setDrawerPrompt("");
+    setDrawerLoading(false);
+    setDrawerOpen(true);
+    setDrawerApp(app);
+    setWorkspaceResumeId(app.resumeVariant?.id || null);
+  };
+
+  const handleWorkspaceInsert = (text: string) => {
+    const body = text.trim();
+    if (!body) return;
+    const decoratedBody = drawerApp
+      ? `Draft for ${drawerApp.role.title} at ${drawerApp.role.company}\n\n${body}`
+      : body;
+    const message: Message = {
+      id: uuid(),
+      threadId: uuid(),
+      senderId: "talentforge-ai",
+      sentAt: new Date().toISOString(),
+      body: decoratedBody,
+      connector: "Workspace",
+      status: "unread",
+      replies: [],
+    };
+    data.addMessage(message);
+    setLiveMessage("Draft inserted into Inbox");
+  };
+
+  const handleSaveResumeVariantFromWorkspace = (text: string) => {
+    if (!drawerApp) return;
+    const content = text.trim();
+    if (!content) return;
+    const selectedId =
+      workspaceResumeId || drawerApp.resumeVariant?.id || resumes[0]?.id;
+    const baseResume = selectedId
+      ? resumes.find((resume) => resume.id === selectedId)
+      : undefined;
+    if (!baseResume) return;
+
+    const previousIds = new Set(resumes.map((resume) => resume.id));
+    const cloned = cloneResume(baseResume);
+    const newResume = cloned.find((resume) => !previousIds.has(resume.id));
+    if (!newResume) return;
+
+    const variant: ResumeEntry = {
+      ...newResume,
+      content,
+      title: `${baseResume.title} – ${drawerApp.role.title}`,
+      notes: `Variant generated for ${drawerApp.role.title} at ${drawerApp.role.company}`,
+      importedAt: new Date().toISOString(),
+    };
+    const updatedResumes = updateResume(variant);
+    handleResumesUpdated(updatedResumes);
+    const finalResume =
+      updatedResumes.find((resume) => resume.id === variant.id) || variant;
+    const updatedApplications = updateJobApplication(drawerApp.id, {
+      resumeVariant: finalResume,
+    });
+    setApplications(updatedApplications);
+    const refreshed = updatedApplications.find((app) => app.id === drawerApp.id) || null;
+    setDrawerApp(refreshed);
+    setWorkspaceResumeId(finalResume.id);
+    setLiveMessage(`Saved resume variant for ${drawerApp.role.title}`);
   };
 
   return (
@@ -856,7 +970,15 @@ export default function ApplicationBoard() {
             helperText="Start tracking your job applications here."
           />
         ) : (
-          <Box sx={{ display: "flex", gap: 2 }}>
+          <Box
+            sx={{
+              display: "flex",
+              gap: 2,
+              flexWrap: { xs: "nowrap", md: "wrap" },
+              overflowX: { xs: "auto", md: "visible" },
+              pb: { xs: 1, md: 0 },
+            }}
+          >
             {STATUSES.map((status) => (
               <Column
                 key={status}
@@ -876,6 +998,7 @@ export default function ApplicationBoard() {
                       onSetInterviewLocation={handleInterviewLocation}
                       onKeyDown={(e) => handleCardKeyDown(e, app)}
                       activeId={activeId}
+                      onOpenWorkspace={openWorkspace}
                     />
                   ))}
               </Column>
@@ -956,8 +1079,9 @@ export default function ApplicationBoard() {
           variant="permanent"
           sx={{
             "& .MuiDrawer-paper": {
-              width: { xs: "100%", sm: 360 },
+              width: { xs: "100%", sm: 360, md: 400, lg: 420 },
               p: 2,
+              maxWidth: "100%",
             },
           }}
         >
@@ -965,10 +1089,15 @@ export default function ApplicationBoard() {
             onClick={() => setDrawerOpen(false)}
             sx={{ alignSelf: "flex-end" }}
             size="small"
+            aria-label="Close workspace"
           >
             <Close />
           </IconButton>
-          {drawerTileId === "screenRole" || drawerTileId === "offerNegotiation" ? (
+          {drawerTileId === "workspace" ? (
+            <Typography variant="h6" gutterBottom>
+              {drawerTitle}
+            </Typography>
+          ) : drawerTileId === "screenRole" || drawerTileId === "offerNegotiation" ? (
             <Accordion sx={{ mb: 2 }}>
               <AccordionSummary expandIcon={<ExpandMore />}>
                 <Typography variant="h6">{drawerTitle}</Typography>
@@ -984,7 +1113,20 @@ export default function ApplicationBoard() {
               {drawerTitle}
             </Typography>
           )}
-          {drawerAnalysis ? (
+          {drawerTileId === "workspace" ? (
+            <ChatWorkspace
+              onInsertIntoInbox={handleWorkspaceInsert}
+              onSaveResumeVariant={handleSaveResumeVariantFromWorkspace}
+              jobDescription={drawerApp?.role.description || ""}
+              resumes={resumes}
+              selectedResumeId={workspaceResumeId || drawerApp?.resumeVariant?.id}
+              onResumeSelect={(id) => {
+                if (drawerApp) {
+                  handleAssignResume(drawerApp.id, id);
+                }
+              }}
+            />
+          ) : drawerAnalysis ? (
             <Box sx={{ mt: 2 }}>
               {drawerAnalysis.issues.map((issue, idx) => (
                 <Stack

--- a/src/components/talentforge/ChatWorkspace.tsx
+++ b/src/components/talentforge/ChatWorkspace.tsx
@@ -1,21 +1,73 @@
 "use client";
 
-import { useState } from "react";
-import { Box, Button, Stack, Typography, TextField } from "@mui/material";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Stack,
+  Typography,
+  TextField,
+  MenuItem,
+} from "@mui/material";
+
+import type { ResumeEntry } from "@/types";
 
 import PromptTileGrid from "./promptTiles/PromptTileGrid";
 
 interface ChatWorkspaceProps {
   onInsertIntoInbox?: (text: string) => void;
   onSaveResumeVariant?: (text: string) => void;
+  jobDescription?: string;
+  resumes?: ResumeEntry[];
+  selectedResumeId?: string | null;
+  onResumeSelect?: (resumeId: string) => void;
 }
 
 export default function ChatWorkspace({
   onInsertIntoInbox,
   onSaveResumeVariant,
+  jobDescription: initialJobDescription = "",
+  resumes = [],
+  selectedResumeId = null,
+  onResumeSelect,
 }: ChatWorkspaceProps) {
   const [output, setOutput] = useState("");
-  const [jobDescription, setJobDescription] = useState("");
+  const [jobDescription, setJobDescription] = useState(initialJobDescription);
+  const [resumeId, setResumeId] = useState<string>(selectedResumeId || "");
+  const [resumeContent, setResumeContent] = useState<string>("");
+
+  useEffect(() => {
+    setJobDescription(initialJobDescription);
+  }, [initialJobDescription]);
+
+  useEffect(() => {
+    if (selectedResumeId && selectedResumeId !== resumeId) {
+      setResumeId(selectedResumeId);
+    } else if (!selectedResumeId && !resumeId && resumes.length > 0) {
+      setResumeId(resumes[0].id);
+    }
+  }, [selectedResumeId, resumes, resumeId]);
+
+  useEffect(() => {
+    const selected = resumes.find((resume) => resume.id === resumeId);
+    setResumeContent(selected?.content || "");
+  }, [resumeId, resumes]);
+
+  const promptInitialValues = useMemo(() => {
+    const base: Record<string, Record<string, string>> = {
+      jdRequirements: { jobDescription },
+      jobRequirements: { jobDescription },
+      screenRole: { jobDescription },
+    };
+    if (resumeId) {
+      base.resumeRewrite = { jobDescription, resumeVariantId: resumeId };
+      base.resumeCompare = { jobDescription, resumeVariantId: resumeId };
+    } else {
+      base.resumeRewrite = { jobDescription };
+      base.resumeCompare = { jobDescription };
+    }
+    return base;
+  }, [jobDescription, resumeId]);
 
   const handleCopy = () => {
     if (navigator.clipboard && output) {
@@ -31,44 +83,88 @@ export default function ChatWorkspace({
     onSaveResumeVariant?.(output);
   };
 
+  const handleResumeChange = (value: string) => {
+    setResumeId(value);
+    onResumeSelect?.(value);
+  };
+
   return (
     <Box
       sx={{
         display: "flex",
-        flexDirection: { xs: "column", md: "row" },
+        flexDirection: { xs: "column", xl: "row" },
         gap: 2,
       }}
     >
-      <Box sx={{ flex: 1 }}>
-        <TextField
-          label="Job Description"
-          multiline
-          minRows={4}
-          fullWidth
-          value={jobDescription}
-          onChange={(e) => setJobDescription(e.target.value)}
-          sx={{ mb: 2 }}
-        />
-        <PromptTileGrid
-          onResponse={setOutput}
-          initialValues={{ jdRequirements: { jobDescription } }}
-        />
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Stack spacing={2}>
+          <TextField
+            label="Job Description"
+            multiline
+            minRows={4}
+            fullWidth
+            value={jobDescription}
+            onChange={(e) => setJobDescription(e.target.value)}
+          />
+          {resumes.length > 0 && (
+            <TextField
+              label="Resume"
+              select
+              value={resumeId}
+              onChange={(e) => handleResumeChange(e.target.value)}
+              fullWidth
+            >
+              {resumes.map((resume) => (
+                <MenuItem key={resume.id} value={resume.id}>
+                  {resume.title}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+          <TextField
+            label="Resume Preview"
+            multiline
+            minRows={6}
+            fullWidth
+            value={resumeContent}
+            placeholder={
+              resumes.length
+                ? "Select a resume to view its content"
+                : "Upload a resume to enable resume-based prompts"
+            }
+            InputProps={{ readOnly: true }}
+          />
+          <PromptTileGrid
+            onResponse={setOutput}
+            initialValues={promptInitialValues}
+          />
+        </Stack>
       </Box>
       <Box
         sx={{
-          flexBasis: { md: "30%" },
+          flexBasis: { xl: "32%" },
           border: 1,
           borderColor: "divider",
           p: 2,
           borderRadius: 1,
           minHeight: 200,
+          minWidth: { xl: 300 },
         }}
       >
         <Typography variant="h6" gutterBottom>
           Output
         </Typography>
-        <Box sx={{ whiteSpace: "pre-wrap", mb: 2 }}>{output}</Box>
-        <Stack direction="row" spacing={1}>
+        <Box
+          sx={{
+            whiteSpace: "pre-wrap",
+            mb: 2,
+            maxHeight: { xs: 240, xl: "unset" },
+            overflowY: "auto",
+          }}
+        >
+          {output}
+        </Box>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
           <Button variant="outlined" onClick={handleCopy} disabled={!output}>
             Copy
           </Button>


### PR DESCRIPTION
## Summary
- add a chat workspace drawer for each application card that pre-fills prompts from the selected job description and resume
- connect workspace actions to insert drafts in the inbox and to clone/update resume variants while keeping drawer state in sync
- tweak the applications board layout and drawer sizing so it remains usable on smaller screens

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb8fcd31908330bfc151bc1c248386