### PR TITLE
Clarify FileUploader accept default description

### DIFF
--- a/src/components/bookworm/FileUploader.tsx
+++ b/src/components/bookworm/FileUploader.tsx
@@ -27,7 +27,7 @@ export interface FileUploaderProps
    * * The string image/* meaning "any image file".
 
    * The accept attribute takes a string containing one or more of these unique file type specifiers as its value, separated by commas.
-   * @default "*.*"
+   * @default accepts all files (no restriction)
    */
   accept?: string;
   /**

--- a/src/components/talentforge/FileUploader.tsx
+++ b/src/components/talentforge/FileUploader.tsx
@@ -27,7 +27,7 @@ export interface FileUploaderProps
    * * The string image/* meaning "any image file".
 
    * The accept attribute takes a string containing one or more of these unique file type specifiers as its value, separated by commas.
-   * @default "*.*"
+   * @default accepts all files (no restriction)
    */
   accept?: string;
   /**


### PR DESCRIPTION
## Summary
- clarify the FileUploader accept prop JSDoc to state it allows all files by default in both variants

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb9f2e134c83309fc52f96bcf6e3d1