### PR TITLE
Add goal tag filtering test for prompt registry

### DIFF
--- a/src/tests/talentforge/promptRegistry.test.ts
+++ b/src/tests/talentforge/promptRegistry.test.ts
@@ -9,6 +9,15 @@ describe("promptRegistry", () => {
     }
   });
 
+  it("filters tiles by goal tags", () => {
+    const tiles = getPromptTiles({ goalTags: "networking" });
+    expect(tiles.length).toBeGreaterThan(0);
+    for (const tile of tiles) {
+      expect(tile.recommendedGoalTags).toContain("networking");
+    }
+    expect(tiles.map((tile) => tile.id)).not.toContain("resumeSummary");
+  });
+
   it("respects id ordering when filtering", () => {
     const ids = ["resumeSummary", "offerDetails", "coverLetter"];
     const tiles = getPromptTiles({ ids, contexts: "resume" });


### PR DESCRIPTION
## Summary
- add coverage confirming getPromptTiles filters by goal tags
- ensure networking filter excludes tiles lacking the tag

## Testing
- npm test -- --runInBand
- npm test -- --runTestsByPath src/tests/talentforge/promptRegistry.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb9f358058833089d114f3a24f4847