### PR TITLE
Fix PowerPoint spelling in metadata descriptions

### DIFF
--- a/src/app/aisummary/page.tsx
+++ b/src/app/aisummary/page.tsx
@@ -4,7 +4,7 @@ import { projectData } from "./project";
 
 export const metadata: Metadata = {
   title: "AISummary Project",
-  description: "Powerpoint-style presentation for the AISummary page",
+  description: "PowerPoint-style presentation for the AISummary page",
 };
 
 export default function AISummaryPage() {

--- a/src/app/assignmentlist/page.tsx
+++ b/src/app/assignmentlist/page.tsx
@@ -4,7 +4,7 @@ import { projectData } from "./project";
 
 export const metadata: Metadata = {
   title: "Patient Assignment List Project",
-  description: "Powerpoint-style presentation for the Patient List project",
+  description: "PowerPoint-style presentation for the Patient List project",
 };
 
 export default function Page() {

--- a/src/app/patientlist/page.tsx
+++ b/src/app/patientlist/page.tsx
@@ -4,7 +4,7 @@ import { projectData } from "./project";
 
 export const metadata: Metadata = {
   title: "Patient List Project",
-  description: "Powerpoint-style presentation for the Patient List project",
+  description: "PowerPoint-style presentation for the Patient List project",
 };
 
 export default function Page() {

--- a/src/app/patientlistpodcasts/page.tsx
+++ b/src/app/patientlistpodcasts/page.tsx
@@ -5,7 +5,7 @@ import { projectData } from "./project";
 export const metadata: Metadata = {
   title: "Patient List Podcast Project",
   description:
-    "Powerpoint-style presentation for the Patient List Podcast project",
+    "PowerPoint-style presentation for the Patient List Podcast project",
 };
 
 export default function Page() {


### PR DESCRIPTION
## Summary
- correct the capitalization of "PowerPoint" in project metadata descriptions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cba2af4a348330b903ffb3ba670f98