### PR TITLE
Clarify optional timeline props

### DIFF
--- a/src/components/showcase/Timeline/index.tsx
+++ b/src/components/showcase/Timeline/index.tsx
@@ -31,9 +31,16 @@ export interface TimelineEvent {
 }
 
 export interface TimelineProps {
-  /** Events to render, in order.  One of events or mermaid is required. */
+  /**
+   * Optional events to render, in order.  Leaving both events and mermaid
+   * undefined renders an empty timeline, and tests cover that empty state to
+   * guard against regressions.
+   */
   events?: TimelineEvent[];
-  /** Optional Mermaid‐format timeline.  One of mermaid or events is required. */
+  /**
+   * Optional Mermaid‐format timeline.  Omitting both mermaid and events renders
+   * an empty timeline, which is covered by tests to catch regressions.
+   */
   mermaid?: string;
   /** Show a loading skeleton instead of real events */
   loading?: boolean;


### PR DESCRIPTION
## Summary
- clarify the Timeline events prop comment to note both data sources are optional and empty timelines are supported
- update the mermaid prop documentation to mention the empty-state behavior is covered by tests

## Testing
- not run (doc-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cba2cd022483308ebd2d2440929ee1