### PR TITLE
Add TalentForge data store subscriptions

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -42,14 +42,6 @@ import type {
   OfferComp,
   Message,
 } from "@/types";
-import {
-  addJobApplication,
-  getJobApplications,
-  updateJobApplicationStatus,
-  updateJobApplication,
-  getResumes,
-  getCurrentCompensation,
-} from "@/utils/talentforge/dataStore";
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
 import EmptyState from "./EmptyState";
 import { askOpenAI, pdfToMarkdown } from "@/utils/talentforge/utils";
@@ -61,7 +53,10 @@ import ChatWorkspace from "./ChatWorkspace";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import { STATUSES, getNextStatus } from "@/utils/talentforge/keyboard";
 import { getPromptTile, type PromptContext } from "@/utils/talentforge/promptRegistry";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 
 interface Issue {
   severity: "red" | "yellow";
@@ -321,8 +316,15 @@ function Card({
 }
 
 export default function ApplicationBoard() {
-  const [applications, setApplications] = useState<JobApplication[]>([]);
-  const [loading, setLoading] = useState(true);
+  const data = useTalentForgeData();
+  const applications = useTalentForgeSelector((store) =>
+    store.getJobApplications(),
+  );
+  const resumes = useTalentForgeSelector((store) => store.getResumes());
+  const currentCompensation = useTalentForgeSelector((store) =>
+    store.getCurrentCompensation(),
+  );
+  const [loading, setLoading] = useState(() => applications.length === 0);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [company, setCompany] = useState("");
@@ -352,36 +354,49 @@ export default function ApplicationBoard() {
   const [rejectReason, setRejectReason] = useState("");
   const [activeId, setActiveId] = useState<string | null>(null);
   const [liveMessage, setLiveMessage] = useState("");
-  const [resumes, setResumes] = useState<ResumeEntry[]>(() => getResumes());
   const [resumeModalOpen, setResumeModalOpen] = useState(false);
   const [manageResumesOpen, setManageResumesOpen] = useState(false);
   const negotiationRef = useRef<HTMLDivElement | null>(null);
-  const data = useTalentForgeData();
+  const hasSeededRef = useRef(false);
 
   useEffect(() => {
-    const existing = getJobApplications();
-    if (existing.length === 0) {
-      fetchAllListings("").then((listings) => {
-        let apps = existing;
-        listings.forEach((listing) => {
-          apps = addJobApplication({
-            id: uuid(),
-            applicant: { id: "", name: "", email: "" },
-            role: { ...listing, id: uuid() },
-            status: "applied",
-            history: [
-              { status: "applied", changedAt: new Date().toISOString() },
-            ],
-          });
-        });
-        setApplications(apps);
-        setLoading(false);
-      });
-    } else {
-      setApplications(existing);
+    if (applications.length > 0) {
       setLoading(false);
+      return;
     }
-  }, []);
+    if (hasSeededRef.current) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    hasSeededRef.current = true;
+    void (async () => {
+      try {
+        const listings = await fetchAllListings("");
+        if (cancelled) return;
+        if (applications.length === 0) {
+          listings.forEach((listing) => {
+            data.addJobApplication({
+              id: uuid(),
+              applicant: { id: "", name: "", email: "" },
+              role: { ...listing, id: uuid() },
+              status: "applied",
+              history: [
+                { status: "applied", changedAt: new Date().toISOString() },
+              ],
+            });
+          });
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [applications.length, data]);
 
   if (loading) {
     return (
@@ -400,8 +415,10 @@ export default function ApplicationBoard() {
     const { active, over } = event;
     if (!over) return;
     const newStatus = over.id as ApplicationStatus;
-    const updated = updateJobApplicationStatus(active.id as string, newStatus);
-    setApplications(updated);
+    const updated = data.updateJobApplicationStatus(
+      active.id as string,
+      newStatus,
+    );
     const movedApp = updated.find((a) => a.id === active.id);
     if (movedApp) {
       setLiveMessage(`${movedApp.role.title} moved to ${newStatus}`);
@@ -413,8 +430,7 @@ export default function ApplicationBoard() {
     if (!app) return;
     const newStatus = getNextStatus(app.status, key);
     if (newStatus !== app.status) {
-      const updated = updateJobApplicationStatus(appId, newStatus);
-      setApplications(updated);
+      const updated = data.updateJobApplicationStatus(appId, newStatus);
       const movedApp = updated.find((a) => a.id === appId);
       if (movedApp) {
         setLiveMessage(`${movedApp.role.title} moved to ${newStatus}`);
@@ -513,13 +529,11 @@ export default function ApplicationBoard() {
       importedAt: new Date().toISOString(),
     };
     const updatedResumes = data.addResume(newResume);
-    setResumes(updatedResumes);
     const storedResume =
       updatedResumes.find((resume) => resume.id === newResumeId) || newResume;
-    const updatedApps = updateJobApplication(drawerApp.id, {
+    const updatedApps = data.updateJobApplication(drawerApp.id, {
       resumeVariant: storedResume,
     });
-    setApplications(updatedApps);
     const refreshed =
       updatedApps.find((application) => application.id === drawerApp.id) ||
       ({ ...drawerApp, resumeVariant: storedResume } as JobApplication);
@@ -539,8 +553,7 @@ export default function ApplicationBoard() {
       status: "applied",
       history: [{ status: "applied", changedAt: new Date().toISOString() }],
     };
-    const updated = addJobApplication(newApp);
-    setApplications(updated);
+    data.addJobApplication(newApp);
     setDialogOpen(false);
     setTitle("");
     setCompany("");
@@ -665,15 +678,15 @@ export default function ApplicationBoard() {
       );
       app.offer?.summary?.forEach((s) => offerLines.push(s));
       const offerText = offerLines.join("\n");
-      const current = getCurrentCompensation();
+      const current = currentCompensation;
       const currentLines: string[] = [];
       if (current.salary) currentLines.push(`Salary: ${current.salary}`);
       if (current.benefits) currentLines.push(`Benefits: ${current.benefits}`);
       if (current.stock) currentLines.push(`Stock: ${current.stock}`);
-      const currentComp = currentLines.join("\n");
+      const currentCompText = currentLines.join("\n");
       const prompt = tile.fullPrompt
         .replaceAll("{{offer}}", offerText)
-        .replaceAll("{{currentComp}}", currentComp);
+        .replaceAll("{{currentComp}}", currentCompText);
       setDrawerPrompt(prompt);
       setDrawerLoading(true);
       try {
@@ -759,18 +772,15 @@ export default function ApplicationBoard() {
   const handleAssignResume = (appId: string, resId: string) => {
     const resume = resumes.find((r) => r.id === resId);
     if (!resume) return;
-    const updated = updateJobApplication(appId, { resumeVariant: resume });
-    setApplications(updated);
+    data.updateJobApplication(appId, { resumeVariant: resume });
   };
 
   const handleInterviewDate = (appId: string, value: string) => {
-    const updated = updateJobApplication(appId, { interviewDateTime: value });
-    setApplications(updated);
+    data.updateJobApplication(appId, { interviewDateTime: value });
   };
 
   const handleInterviewLocation = (appId: string, value: string) => {
-    const updated = updateJobApplication(appId, { interviewLocation: value });
-    setApplications(updated);
+    data.updateJobApplication(appId, { interviewLocation: value });
   };
 
   const handleOfferUpload = async (file: File) => {
@@ -823,8 +833,7 @@ export default function ApplicationBoard() {
         compensation: parsed.compensation || [],
         summary: summaryLines,
       };
-      const updated = updateJobApplication(drawerApp.id, { offer });
-      setApplications(updated);
+      data.updateJobApplication(drawerApp.id, { offer });
       setDrawerMessages([
         {
           role: "assistant",
@@ -882,12 +891,11 @@ export default function ApplicationBoard() {
 
   const handleReject = () => {
     if (!drawerApp) return;
-    const updated = updateJobApplicationStatus(
+    const updated = data.updateJobApplicationStatus(
       drawerApp.id,
       "rejected",
-      rejectReason || undefined
+      rejectReason || undefined,
     );
-    setApplications(updated);
     setRejectReason("");
     setDrawerOpen(false);
     setDrawerApp(null);
@@ -918,13 +926,13 @@ export default function ApplicationBoard() {
     if (!drawerApp) return;
     const text = negotiationRef.current?.innerText || "";
     const history = [...(drawerApp.offerHistory || []), text];
-    const updated = updateJobApplication(drawerApp.id, { offerHistory: history });
-    setApplications(updated);
+    const updated = data.updateJobApplication(drawerApp.id, {
+      offerHistory: history,
+    });
     setDrawerApp(updated.find((a) => a.id === drawerApp.id) || null);
   };
 
   const handleResumesUpdated = (updated: ResumeEntry[]) => {
-    setResumes(updated);
     if (resumeId && !updated.some((r) => r.id === resumeId)) {
       setResumeId("");
     }
@@ -932,12 +940,12 @@ export default function ApplicationBoard() {
 
   const handleResumeModalClose = () => {
     setResumeModalOpen(false);
-    handleResumesUpdated(getResumes());
+    handleResumesUpdated(data.getResumes());
   };
 
   const handleManageModalClose = () => {
     setManageResumesOpen(false);
-    handleResumesUpdated(getResumes());
+    handleResumesUpdated(data.getResumes());
   };
 
   return (

--- a/src/components/talentforge/Dashboard.tsx
+++ b/src/components/talentforge/Dashboard.tsx
@@ -2,40 +2,32 @@
 
 import { useEffect, useState } from "react";
 import { Box, Card, CardContent, Grid, Typography, Skeleton } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
-
-interface Counts {
-  resumes: number;
-  applications: number;
-  offers: number;
-  messages: number;
-}
+import { useTalentForgeSelector } from "@/contexts/TalentForgeDataContext";
 
 export default function Dashboard() {
-  const data = useTalentForgeData();
-  const [counts, setCounts] = useState<Counts>({
-    resumes: 0,
-    applications: 0,
-    offers: 0,
-    messages: 0,
-  });
+  const resumeCount = useTalentForgeSelector(
+    (store) => store.getResumes().length,
+  );
+  const applicationCount = useTalentForgeSelector(
+    (store) => store.getJobApplications().length,
+  );
+  const offerCount = useTalentForgeSelector(
+    (store) => store.getOffers().length,
+  );
+  const messageCount = useTalentForgeSelector(
+    (store) => store.getMessages().length,
+  );
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setCounts({
-      resumes: data.getResumes().length,
-      applications: data.getJobApplications().length,
-      offers: data.getOffers().length,
-      messages: data.getMessages().length,
-    });
     setLoading(false);
-  }, [data]);
+  }, [resumeCount, applicationCount, offerCount, messageCount]);
 
   const items = [
-    { label: "Resumes", value: counts.resumes },
-    { label: "Applications", value: counts.applications },
-    { label: "Offers", value: counts.offers },
-    { label: "Messages", value: counts.messages },
+    { label: "Resumes", value: resumeCount },
+    { label: "Applications", value: applicationCount },
+    { label: "Offers", value: offerCount },
+    { label: "Messages", value: messageCount },
   ];
 
   return (

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -27,7 +27,10 @@ import {
   AutoReplyTemplate,
 } from "@/utils/autoReply";
 
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import type { Message, RecruiterEntry } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 import PromptSelector from "./PromptSelector";
@@ -37,33 +40,31 @@ import EmptyState from "./EmptyState";
 
 export default function Inbox() {
   const data = useTalentForgeData();
-  const [threads, setThreads] = useState<Message[]>([]);
+  const threads = useTalentForgeSelector((store) => store.getThreads());
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [templateSelections, setTemplateSelections] =
     useState<Record<string, AutoReplyTemplate>>({});
   const [quickTones, setQuickTones] = useState<Record<string, AutoReplyTemplate>>({});
-  const [templateDefs, setTemplateDefs] = useState<Record<string, string>>({});
+  const templateDefs = useTalentForgeSelector((store) =>
+    store.getAutoReplyTemplates(),
+  );
   const [editorOpen, setEditorOpen] = useState(false);
   const [editorTemplates, setEditorTemplates] = useState<
     Array<{ name: string; prompt: string }>
   >([]);
   const [search, setSearch] = useState("");
-  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
+  const recruiters = useTalentForgeSelector((store) =>
+    store.getRecruiters(),
+  );
   const [aiThread, setAiThread] = useState<string | null>(null);
   const [promptKey, setPromptKey] = useState<string>("");
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const id = setTimeout(() => {
-      setThreads(data.getThreads());
-      setRecruiters(data.getRecruiters());
-      setTemplateDefs(data.getAutoReplyTemplates());
-      setLoading(false);
-    }, 0);
-    return () => clearTimeout(id);
-  }, [data]);
+    setLoading(false);
+  }, [threads, recruiters, templateDefs]);
 
   const handleFilterChange = (event: SelectChangeEvent) => {
     setFilter(event.target.value as "all" | "unread" | "read");
@@ -87,8 +88,7 @@ export default function Inbox() {
     setSelectedId(message.id);
     if (!drafts[message.id]) void handleAutoReply(message);
     if (message.status === "unread") {
-      const updated = data.updateThreadStatus(message.id, "read");
-      setThreads(updated);
+      data.updateThreadStatus(message.id, "read");
     }
   };
 
@@ -111,8 +111,7 @@ export default function Inbox() {
       sentAt: new Date().toISOString(),
       connector: message.connector,
     };
-    const updated = data.addThreadReply(message.id, reply);
-    setThreads(updated);
+    data.addThreadReply(message.id, reply);
   };
 
   const handleSendReply = (message: Message) => {
@@ -131,25 +130,20 @@ export default function Inbox() {
     );
     if (matchedRecruiter) {
       updated = data.linkThreadToRecruiter(message.id, matchedRecruiter.id);
-      setRecruiters(data.getRecruiters());
     }
 
-    setThreads(updated);
     setDrafts((d) => ({ ...d, [message.id]: "" }));
   };
 
   const handleToggleStatus = (message: Message) => {
-    const updated = data.updateThreadStatus(
+    data.updateThreadStatus(
       message.id,
       message.status === "unread" ? "read" : "unread",
     );
-    setThreads(updated);
   };
 
   const handleLinkRecruiter = (threadId: string, recruiterId: string) => {
-    const updated = data.linkThreadToRecruiter(threadId, recruiterId);
-    setThreads(updated);
-    setRecruiters(data.getRecruiters());
+    data.linkThreadToRecruiter(threadId, recruiterId);
   };
 
   const handleDraftWithAI = (threadId: string) => {
@@ -196,7 +190,6 @@ export default function Inbox() {
     for (const { name, prompt } of editorTemplates) {
       if (name.trim()) defs[name.trim()] = prompt;
     }
-    setTemplateDefs(defs);
     data.saveAutoReplyTemplates(defs);
     setEditorOpen(false);
   };

--- a/src/components/talentforge/Recruiters/List.tsx
+++ b/src/components/talentforge/Recruiters/List.tsx
@@ -9,22 +9,24 @@ import {
   TextField,
   Button,
 } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import type { RecruiterEntry, Message } from "@/types";
 
 export default function RecruiterList() {
   const data = useTalentForgeData();
-  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
-  const [messages, setMessages] = useState<Message[]>([]);
+  const recruiters = useTalentForgeSelector((store) => store.getRecruiters());
+  const messages = useTalentForgeSelector((store) => store.getMessages());
+  const [draftRecruiters, setDraftRecruiters] = useState(recruiters);
 
   useEffect(() => {
-    setRecruiters(data.getRecruiters());
-    setMessages(data.getMessages());
-  }, [data]);
+    setDraftRecruiters(recruiters);
+  }, [recruiters]);
 
   const handleSave = (recruiter: RecruiterEntry) => {
-    const updated = data.updateRecruiter(recruiter);
-    setRecruiters(updated);
+    data.updateRecruiter(recruiter);
   };
 
   return (
@@ -32,7 +34,7 @@ export default function RecruiterList() {
       <Typography variant="h5" sx={{ mb: 2 }}>
         Recruiters
       </Typography>
-      {recruiters.map((r) => (
+      {draftRecruiters.map((r) => (
         <Box key={r.id} sx={{ mb: 3 }}>
           <Typography variant="subtitle1" fontWeight="bold">
             {r.name}
@@ -46,7 +48,7 @@ export default function RecruiterList() {
             label="Tags"
             value={r.tags.join(", ")}
             onChange={(e) =>
-              setRecruiters((rec) =>
+              setDraftRecruiters((rec) =>
                 rec.map((rr) =>
                   rr.id === r.id
                     ? {
@@ -69,7 +71,7 @@ export default function RecruiterList() {
             rows={3}
             value={r.notes}
             onChange={(e) =>
-              setRecruiters((rec) =>
+              setDraftRecruiters((rec) =>
                 rec.map((rr) =>
                   rr.id === r.id ? { ...rr, notes: e.target.value } : rr,
                 ),

--- a/src/components/talentforge/Settings.tsx
+++ b/src/components/talentforge/Settings.tsx
@@ -17,26 +17,28 @@ import {
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 import OpenAIKeyModal from "@/components/talentforge/OpenAiKeyModal";
 import { loadDemoData, clearDemoData } from "@/utils/talentforge/demoData";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import { exportSnapshot, importSnapshot } from "@/utils/talentforge/snapshot";
 import { SNAPSHOT_VERSION } from "@/utils/talentforge/dataStore";
 import { useOpenAIKey } from "@/contexts/OpenAIKeyContext";
 
 export default function Settings() {
   const dataStore = useTalentForgeData();
+  const currentComp = useTalentForgeSelector((store) =>
+    store.getCurrentCompensation(),
+  );
   const [openKeyModal, setOpenKeyModal] = React.useState(false);
-  const [comp, setComp] = React.useState({
-    salary: "",
-    benefits: "",
-    stock: "",
-  });
+  const [comp, setComp] = React.useState(currentComp);
   const [toastOpen, setToastOpen] = React.useState(false);
   const [toastMessage, setToastMessage] = React.useState("");
   const { hasKey, clearKey, reloadFromStorage } = useOpenAIKey();
 
   React.useEffect(() => {
-    setComp(dataStore.getCurrentCompensation());
-  }, [dataStore]);
+    setComp(currentComp);
+  }, [currentComp]);
 
   const handleRemoveKey = () => {
     clearKey();

--- a/src/components/talentforge/onboarding/CompensationStep.tsx
+++ b/src/components/talentforge/onboarding/CompensationStep.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useEffect } from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 
 interface StepProps {
   onNext: () => void;
@@ -11,16 +14,14 @@ interface StepProps {
 
 export default function CompensationStep({ onNext, onBack }: StepProps) {
   const dataStore = useTalentForgeData();
-  const [comp, setComp] = useState({
-    salary: "",
-    benefits: "",
-    stock: "",
-  });
+  const currentComp = useTalentForgeSelector((store) =>
+    store.getCurrentCompensation(),
+  );
+  const [comp, setComp] = useState(currentComp);
 
   useEffect(() => {
-    const existing = dataStore.getCurrentCompensation();
-    setComp(existing);
-  }, [dataStore]);
+    setComp(currentComp);
+  }, [currentComp]);
 
   const handleChange = (field: "salary" | "benefits" | "stock") => (
     event: React.ChangeEvent<HTMLInputElement>
@@ -62,10 +63,10 @@ export default function CompensationStep({ onNext, onBack }: StepProps) {
         )}
         <Button
           variant="contained"
-        onClick={() => {
-          dataStore.saveCurrentCompensation(comp);
-          onNext();
-        }}
+          onClick={() => {
+            dataStore.saveCurrentCompensation(comp);
+            onNext();
+          }}
           disabled={!hasValue}
           aria-label="Next"
         >

--- a/src/contexts/TalentForgeDataContext.tsx
+++ b/src/contexts/TalentForgeDataContext.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import React from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
 import * as dataStore from '@/utils/talentforge/dataStore';
 
 const TalentForgeDataContext = React.createContext<typeof dataStore | undefined>(undefined);
@@ -14,11 +19,28 @@ export function TalentForgeDataProvider({ children }: { children: React.ReactNod
 }
 
 export function useTalentForgeData() {
-  const context = React.useContext(TalentForgeDataContext);
+  const context = useContext(TalentForgeDataContext);
   if (!context) {
     throw new Error('useTalentForgeData must be used within a TalentForgeDataProvider');
   }
   return context;
+}
+
+type Selector<T> = (store: typeof dataStore) => T;
+
+export function useTalentForgeSelector<T>(selector: Selector<T>): T {
+  const store = useTalentForgeData();
+  const selectorRef = useRef(selector);
+  selectorRef.current = selector;
+
+  const getSnapshot = useCallback(() => selectorRef.current(store), [store]);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => store.subscribe(() => onStoreChange()),
+    [store],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export default TalentForgeDataContext;

--- a/src/tests/talentforge/loaders.test.tsx
+++ b/src/tests/talentforge/loaders.test.tsx
@@ -16,18 +16,35 @@ jest.mock('@/utils/talentforge/dataStore', () => ({
   linkThreadToRecruiter: jest.fn(),
   saveAutoReplyTemplates: jest.fn(),
   getCurrentCompensation: jest.fn(),
+  subscribe: jest.fn(() => jest.fn()),
 }));
 
+const mockStore = {
+  getThreads: () => [],
+  getRecruiters: () => [],
+  getAutoReplyTemplates: () => ({}),
+  updateThreadStatus: jest.fn(() => []),
+  addThreadReply: jest.fn(() => []),
+  linkThreadToRecruiter: jest.fn(() => []),
+  saveAutoReplyTemplates: jest.fn(),
+  addJobApplication: jest.fn(() => []),
+  updateJobApplicationStatus: jest.fn(() => []),
+  updateJobApplication: jest.fn(() => []),
+  addResume: jest.fn(() => []),
+  getJobApplications: () => [],
+  getResumes: () => [],
+  getCurrentCompensation: () => ({ salary: '', benefits: '', stock: '' }),
+  addThread: jest.fn(() => []),
+  addMessage: jest.fn(() => []),
+  getMessages: () => [],
+  getOffers: () => [],
+  subscribe: () => jest.fn(),
+} as const;
+
 jest.mock('@/contexts/TalentForgeDataContext', () => ({
-  useTalentForgeData: () => ({
-    getThreads: () => [],
-    getRecruiters: () => [],
-    getAutoReplyTemplates: () => ({}),
-    updateThreadStatus: jest.fn(),
-    addThreadReply: jest.fn(),
-    linkThreadToRecruiter: jest.fn(),
-    saveAutoReplyTemplates: jest.fn(),
-  }),
+  useTalentForgeData: () => mockStore,
+  useTalentForgeSelector: (selector: (store: typeof mockStore) => unknown) =>
+    selector(mockStore),
 }));
 
 jest.mock('@/utils/talentforge/jobAggregator', () => ({

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -46,6 +46,24 @@ interface StoreSchema {
   currentCompensation: CurrentCompensation;
 }
 
+type StoreKey = keyof StoreSchema;
+type StoreListener = (key: StoreKey) => void;
+
+const listeners = new Set<StoreListener>();
+
+export function subscribe(listener: StoreListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function notify(key: StoreKey): void {
+  for (const listener of listeners) {
+    listener(key);
+  }
+}
+
 // Storage keys for each entity
 const KEYS: { [K in keyof StoreSchema]: string } = {
   user: "userProfile",
@@ -258,10 +276,12 @@ function load<K extends keyof StoreSchema>(
 
 function save<K extends keyof StoreSchema>(key: K, value: StoreSchema[K]): void {
   saveItem(KEYS[key], value, VERSION[key]);
+  notify(key);
 }
 
 function remove<K extends keyof StoreSchema>(key: K): void {
   deleteItem(KEYS[key]);
+  notify(key);
 }
 
 // Migrations
@@ -784,6 +804,7 @@ export function importFromJson(json: string): void {
     // Trigger migrations for all known keys after importing
     for (const key of Object.keys(KEYS) as (keyof StoreSchema)[]) {
       load(key, DEFAULTS[key]);
+      notify(key);
     }
   } catch {
     // ignore parse errors
@@ -837,6 +858,7 @@ const dataStore = {
   deleteConnectorToken,
   exportToJson,
   importFromJson,
+  subscribe,
 };
 
 export default dataStore;


### PR DESCRIPTION
## Summary
- add a lightweight pub/sub API to the TalentForge data store so consumers can react to saves and deletes
- expose a `useTalentForgeSelector` hook from the data context that uses `useSyncExternalStore`
- refactor TalentForge feature components and tests to consume the new selector hook for live updates

## Testing
- npm test -- --runTestsByPath src/tests/talentforge/loaders.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb982b74e88330a0de1d33d6fc59b5