### PR TITLE
Fix type errors surfaced during build

### DIFF
--- a/src/components/talentforge/ChatWorkspace.tsx
+++ b/src/components/talentforge/ChatWorkspace.tsx
@@ -11,7 +11,10 @@ import {
 } from "@mui/material";
 
 import type { ResumeEntry } from "@/types";
-import { getPromptTiles } from "@/utils/talentforge/promptRegistry";
+import {
+  getPromptTiles,
+  type PromptContext,
+} from "@/utils/talentforge/promptRegistry";
 
 import PromptTileGrid from "./promptTiles/PromptTileGrid";
 
@@ -23,7 +26,7 @@ interface ChatWorkspaceProps {
   resumes?: ResumeEntry[];
 }
 
-const WORKSPACE_CONTEXTS = ["resume", "jobSearch"] as const;
+const WORKSPACE_CONTEXTS: PromptContext[] = ["resume", "jobSearch"];
 
 export default function ChatWorkspace({
   onInsertIntoInbox,

--- a/src/components/talentforge/ResumeStepperModal.tsx
+++ b/src/components/talentforge/ResumeStepperModal.tsx
@@ -497,7 +497,7 @@ export default function ResumeStepperModal({
     emptyLibraryMessage: string;
     emptySelectionMessage: string;
     showOverview?: boolean;
-  }): JSX.Element => (
+  }) => (
     <Stack spacing={3}>
       <Typography variant="body1">{intro}</Typography>
       {loadingResumes ? (

--- a/src/components/talentforge/offerAnalysis.ts
+++ b/src/components/talentforge/offerAnalysis.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from "uuid";
 
 import type { Offer, ApplicationRecord } from "@/types";
-import type { askOpenAI as AskOpenAIFunc } from "@/utils/talentforge/utils";
+import type { AskOpenAIFunc } from "@/utils/talentforge/utils";
 
 export type OfferDrafts = {
   email: string;
@@ -18,7 +18,7 @@ export interface AnalyzeOfferOptions {
   setError: (value: string | null) => void;
   setLoading: (value: boolean) => void;
   onSave?: () => void;
-  ask: (...args: Parameters<AskOpenAIFunc>) => ReturnType<AskOpenAIFunc>;
+  ask: AskOpenAIFunc;
   addOfferFn: (offer: Offer) => void;
 }
 

--- a/src/contexts/OpenAIKeyContext.tsx
+++ b/src/contexts/OpenAIKeyContext.tsx
@@ -159,7 +159,7 @@ export function OpenAIKeyProvider({
   children,
 }: {
   children: React.ReactNode;
-}): JSX.Element {
+}): React.ReactElement {
   return (
     <OpenAIKeyContext.Provider value={store}>
       {children}

--- a/src/utils/talentforge/utils.ts
+++ b/src/utils/talentforge/utils.ts
@@ -190,6 +190,8 @@ export const askOpenAI = async ({
   return newChatHistory[newChatIndex];
 };
 
+export type AskOpenAIFunc = typeof askOpenAI;
+
 declare global {
   interface Window {
     Buffer: typeof Buffer;


### PR DESCRIPTION
## Summary
- type the TalentForge chat workspace contexts using PromptContext[] to match getPromptTiles and consumers
- simplify JSX return types by relying on React types and export an AskOpenAIFunc alias for reuse in offer analysis
- update OpenAI key provider return type to use React.ReactElement instead of the JSX namespace

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbcacc7b9083309293be132a008c0d