### PR TITLE
Ensure auto-reply templates fall back to defaults

### DIFF
--- a/src/tests/talentforge/autoReply.test.ts
+++ b/src/tests/talentforge/autoReply.test.ts
@@ -106,4 +106,30 @@ describe("autoReply utilities", () => {
       { role: "user", content: "Just checking in." },
     ]);
   });
+
+  test("buildAutoReplyMessages falls back to defaults when overrides are cleared", () => {
+    const messages = buildAutoReplyMessages(
+      "politeFollowUp",
+      "Checking in.",
+      {},
+    );
+
+    expect(messages[0].content).toBe(
+      AUTO_REPLY_TEMPLATES.politeFollowUp,
+    );
+    expect(messages[0].content).toBeDefined();
+  });
+
+  test("buildAutoReplyMessages handles undefined template", () => {
+    const messages = buildAutoReplyMessages(
+      undefined,
+      "Hello there.",
+      {},
+    );
+
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: AUTO_REPLY_TEMPLATES.general,
+    });
+  });
 });

--- a/src/utils/autoReply.ts
+++ b/src/utils/autoReply.ts
@@ -19,13 +19,28 @@ export interface AutoReplyMessage {
 }
 
 export const buildAutoReplyMessages = (
-  template: AutoReplyTemplate,
+  template: AutoReplyTemplate | undefined,
   content: string,
-  templates: Record<AutoReplyTemplate, string> = AUTO_REPLY_TEMPLATES,
-): AutoReplyMessage[] => [
-  { role: "system", content: templates[template] || templates.general },
-  { role: "user", content },
-];
+  templates: Record<string, string> = AUTO_REPLY_TEMPLATES,
+): AutoReplyMessage[] => {
+  const mergedTemplates: Record<string, string> = {
+    ...AUTO_REPLY_TEMPLATES,
+    ...templates,
+  };
+
+  const fallbackTemplate: AutoReplyTemplate = template ?? "general";
+
+  const systemPrompt =
+    (template ? mergedTemplates[template] : undefined) ??
+    AUTO_REPLY_TEMPLATES[fallbackTemplate] ??
+    mergedTemplates.general ??
+    AUTO_REPLY_TEMPLATES.general;
+
+  return [
+    { role: "system", content: systemPrompt },
+    { role: "user", content },
+  ];
+};
 
 export const setOpenAIKey = (key: string) => {
   setStoredOpenAIKey(key);


### PR DESCRIPTION
## Summary
- merge supplied auto-reply templates with the built-in defaults when constructing message prompts
- default to the general prompt when the requested template is missing or undefined
- add regression tests covering cleared template maps and undefined template selections

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cba2bf00848330abbf49dff97f0513