### PR TITLE
Add TalentForge data store subscriptions and selectors

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState, useRef } from "react";
+import React, { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import {
   Box,
   Paper,
@@ -44,11 +44,8 @@ import type {
 } from "@/types";
 import {
   addJobApplication,
-  getJobApplications,
   updateJobApplicationStatus,
   updateJobApplication,
-  getResumes,
-  getCurrentCompensation,
 } from "@/utils/talentforge/dataStore";
 import { fetchAllListings } from "@/utils/talentforge/jobAggregator";
 import EmptyState from "./EmptyState";
@@ -61,7 +58,10 @@ import ChatWorkspace from "./ChatWorkspace";
 import { exportElementToPdf } from "@/utils/pdfExport";
 import { STATUSES, getNextStatus } from "@/utils/talentforge/keyboard";
 import { getPromptTile, type PromptContext } from "@/utils/talentforge/promptRegistry";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import ApplicationDetailDrawer from "./ApplicationDetailDrawer";
 
 interface Issue {
@@ -357,8 +357,13 @@ function Card({
 }
 
 export default function ApplicationBoard() {
-  const [applications, setApplications] = useState<JobApplication[]>([]);
-  const [loading, setLoading] = useState(true);
+  const data = useTalentForgeData();
+  const applications = useTalentForgeSelector((store) => store.getJobApplications());
+  const resumes = useTalentForgeSelector((store) => store.getResumes());
+  const currentCompensation = useTalentForgeSelector((store) =>
+    store.getCurrentCompensation(),
+  );
+  const [loading, setLoading] = useState(() => applications.length === 0);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [company, setCompany] = useState("");
@@ -390,11 +395,10 @@ export default function ApplicationBoard() {
   const [selectedApplicationId, setSelectedApplicationId] = useState<string | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [liveMessage, setLiveMessage] = useState("");
-  const [resumes, setResumes] = useState<ResumeEntry[]>(() => getResumes());
   const [resumeModalOpen, setResumeModalOpen] = useState(false);
   const [manageResumesOpen, setManageResumesOpen] = useState(false);
   const negotiationRef = useRef<HTMLDivElement | null>(null);
-  const data = useTalentForgeData();
+  const hasLoadedInitialData = useRef(false);
   const selectedApplication = useMemo(() => {
     if (!selectedApplicationId) {
       return null;
@@ -405,12 +409,23 @@ export default function ApplicationBoard() {
   }, [applications, selectedApplicationId]);
 
   useEffect(() => {
-    const existing = getJobApplications();
-    if (existing.length === 0) {
-      fetchAllListings("").then((listings) => {
-        let apps = existing;
+    if (applications.length > 0) {
+      setLoading(false);
+      hasLoadedInitialData.current = true;
+      return;
+    }
+    if (hasLoadedInitialData.current) {
+      setLoading(false);
+      return;
+    }
+    hasLoadedInitialData.current = true;
+    let cancelled = false;
+    setLoading(true);
+    fetchAllListings("")
+      .then((listings) => {
+        if (cancelled) return;
         listings.forEach((listing) => {
-          apps = addJobApplication({
+          addJobApplication({
             id: uuid(),
             applicant: { id: "", name: "", email: "" },
             role: { ...listing, id: uuid() },
@@ -420,14 +435,16 @@ export default function ApplicationBoard() {
             ],
           });
         });
-        setApplications(apps);
-        setLoading(false);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
       });
-    } else {
-      setApplications(existing);
-      setLoading(false);
-    }
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [applications.length]);
 
   useEffect(() => {
     if (detailDrawerOpen && !selectedApplication) {
@@ -454,7 +471,6 @@ export default function ApplicationBoard() {
     if (!over) return;
     const newStatus = over.id as ApplicationStatus;
     const updated = updateJobApplicationStatus(active.id as string, newStatus);
-    setApplications(updated);
     const movedApp = updated.find((a) => a.id === active.id);
     if (movedApp) {
       setLiveMessage(`${movedApp.role.title} moved to ${newStatus}`);
@@ -467,7 +483,6 @@ export default function ApplicationBoard() {
     const newStatus = getNextStatus(app.status, key);
     if (newStatus !== app.status) {
       const updated = updateJobApplicationStatus(appId, newStatus);
-      setApplications(updated);
       const movedApp = updated.find((a) => a.id === appId);
       if (movedApp) {
         setLiveMessage(`${movedApp.role.title} moved to ${newStatus}`);
@@ -576,13 +591,11 @@ export default function ApplicationBoard() {
       importedAt: new Date().toISOString(),
     };
     const updatedResumes = data.addResume(newResume);
-    setResumes(updatedResumes);
     const storedResume =
       updatedResumes.find((resume) => resume.id === newResumeId) || newResume;
     const updatedApps = updateJobApplication(drawerApp.id, {
       resumeVariant: storedResume,
     });
-    setApplications(updatedApps);
     const refreshed =
       updatedApps.find((application) => application.id === drawerApp.id) ||
       ({ ...drawerApp, resumeVariant: storedResume } as JobApplication);
@@ -602,8 +615,7 @@ export default function ApplicationBoard() {
       status: "applied",
       history: [{ status: "applied", changedAt: new Date().toISOString() }],
     };
-    const updated = addJobApplication(newApp);
-    setApplications(updated);
+    addJobApplication(newApp);
     setDialogOpen(false);
     setTitle("");
     setCompany("");
@@ -728,7 +740,7 @@ export default function ApplicationBoard() {
       );
       app.offer?.summary?.forEach((s) => offerLines.push(s));
       const offerText = offerLines.join("\n");
-      const current = getCurrentCompensation();
+      const current = currentCompensation;
       const currentLines: string[] = [];
       if (current.salary) currentLines.push(`Salary: ${current.salary}`);
       if (current.benefits) currentLines.push(`Benefits: ${current.benefits}`);
@@ -822,18 +834,15 @@ export default function ApplicationBoard() {
   const handleAssignResume = (appId: string, resId: string) => {
     const resume = resumes.find((r) => r.id === resId);
     if (!resume) return;
-    const updated = updateJobApplication(appId, { resumeVariant: resume });
-    setApplications(updated);
+    updateJobApplication(appId, { resumeVariant: resume });
   };
 
   const handleInterviewDate = (appId: string, value: string) => {
-    const updated = updateJobApplication(appId, { interviewDateTime: value });
-    setApplications(updated);
+    updateJobApplication(appId, { interviewDateTime: value });
   };
 
   const handleInterviewLocation = (appId: string, value: string) => {
-    const updated = updateJobApplication(appId, { interviewLocation: value });
-    setApplications(updated);
+    updateJobApplication(appId, { interviewLocation: value });
   };
 
   const handleOfferUpload = async (file: File) => {
@@ -886,8 +895,7 @@ export default function ApplicationBoard() {
         compensation: parsed.compensation || [],
         summary: summaryLines,
       };
-      const updated = updateJobApplication(drawerApp.id, { offer });
-      setApplications(updated);
+      updateJobApplication(drawerApp.id, { offer });
       setDrawerMessages([
         {
           role: "assistant",
@@ -945,12 +953,11 @@ export default function ApplicationBoard() {
 
   const handleReject = () => {
     if (!drawerApp) return;
-    const updated = updateJobApplicationStatus(
+    updateJobApplicationStatus(
       drawerApp.id,
       "rejected",
       rejectReason || undefined
     );
-    setApplications(updated);
     setRejectReason("");
     setDrawerOpen(false);
     setDrawerApp(null);
@@ -982,25 +989,30 @@ export default function ApplicationBoard() {
     const text = negotiationRef.current?.innerText || "";
     const history = [...(drawerApp.offerHistory || []), text];
     const updated = updateJobApplication(drawerApp.id, { offerHistory: history });
-    setApplications(updated);
     setDrawerApp(updated.find((a) => a.id === drawerApp.id) || null);
   };
 
-  const handleResumesUpdated = (updated: ResumeEntry[]) => {
-    setResumes(updated);
-    if (resumeId && !updated.some((r) => r.id === resumeId)) {
-      setResumeId("");
-    }
-  };
+  const handleResumesUpdated = useCallback(
+    (updated: ResumeEntry[]) => {
+      if (resumeId && !updated.some((r) => r.id === resumeId)) {
+        setResumeId("");
+      }
+    },
+    [resumeId],
+  );
+
+  useEffect(() => {
+    handleResumesUpdated(resumes);
+  }, [handleResumesUpdated, resumes]);
 
   const handleResumeModalClose = () => {
     setResumeModalOpen(false);
-    handleResumesUpdated(getResumes());
+    handleResumesUpdated(resumes);
   };
 
   const handleManageModalClose = () => {
     setManageResumesOpen(false);
-    handleResumesUpdated(getResumes());
+    handleResumesUpdated(resumes);
   };
 
   return (

--- a/src/components/talentforge/Dashboard.tsx
+++ b/src/components/talentforge/Dashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Box, Card, CardContent, Grid, Typography, Skeleton } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import { useTalentForgeSelector } from "@/contexts/TalentForgeDataContext";
 
 interface Counts {
   resumes: number;
@@ -12,24 +12,25 @@ interface Counts {
 }
 
 export default function Dashboard() {
-  const data = useTalentForgeData();
-  const [counts, setCounts] = useState<Counts>({
-    resumes: 0,
-    applications: 0,
-    offers: 0,
-    messages: 0,
-  });
-  const [loading, setLoading] = useState(true);
+  const resumes = useTalentForgeSelector((store) => store.getResumes());
+  const applications = useTalentForgeSelector((store) => store.getJobApplications());
+  const offers = useTalentForgeSelector((store) => store.getOffers());
+  const messages = useTalentForgeSelector((store) => store.getMessages());
+  const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    setCounts({
-      resumes: data.getResumes().length,
-      applications: data.getJobApplications().length,
-      offers: data.getOffers().length,
-      messages: data.getMessages().length,
-    });
-    setLoading(false);
-  }, [data]);
+    const id = setTimeout(() => setHydrated(true), 0);
+    return () => clearTimeout(id);
+  }, []);
+
+  const counts: Counts = {
+    resumes: resumes.length,
+    applications: applications.length,
+    offers: offers.length,
+    messages: messages.length,
+  };
+
+  const loading = !hydrated;
 
   const items = [
     { label: "Resumes", value: counts.resumes },

--- a/src/components/talentforge/Inbox.tsx
+++ b/src/components/talentforge/Inbox.tsx
@@ -27,7 +27,10 @@ import {
   AutoReplyTemplate,
 } from "@/utils/autoReply";
 
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import type { Message, RecruiterEntry } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 import PromptSelector from "./PromptSelector";
@@ -37,33 +40,32 @@ import EmptyState from "./EmptyState";
 
 export default function Inbox() {
   const data = useTalentForgeData();
-  const [threads, setThreads] = useState<Message[]>([]);
+  const threads = useTalentForgeSelector((store) => store.getThreads());
   const [filter, setFilter] = useState<"all" | "unread" | "read">("all");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [templateSelections, setTemplateSelections] =
     useState<Record<string, AutoReplyTemplate>>({});
   const [quickTones, setQuickTones] = useState<Record<string, AutoReplyTemplate>>({});
-  const [templateDefs, setTemplateDefs] = useState<Record<string, string>>({});
   const [editorOpen, setEditorOpen] = useState(false);
   const [editorTemplates, setEditorTemplates] = useState<
     Array<{ name: string; prompt: string }>
   >([]);
   const [search, setSearch] = useState("");
-  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
+  const recruiters = useTalentForgeSelector((store) => store.getRecruiters());
+  const templateDefs = useTalentForgeSelector((store) =>
+    store.getAutoReplyTemplates(),
+  );
   const [aiThread, setAiThread] = useState<string | null>(null);
   const [promptKey, setPromptKey] = useState<string>("");
-  const [loading, setLoading] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    const id = setTimeout(() => {
-      setThreads(data.getThreads());
-      setRecruiters(data.getRecruiters());
-      setTemplateDefs(data.getAutoReplyTemplates());
-      setLoading(false);
-    }, 0);
+    const id = setTimeout(() => setHydrated(true), 0);
     return () => clearTimeout(id);
-  }, [data]);
+  }, []);
+
+  const loading = !hydrated;
 
   const handleFilterChange = (event: SelectChangeEvent) => {
     setFilter(event.target.value as "all" | "unread" | "read");
@@ -87,8 +89,7 @@ export default function Inbox() {
     setSelectedId(message.id);
     if (!drafts[message.id]) void handleAutoReply(message);
     if (message.status === "unread") {
-      const updated = data.updateThreadStatus(message.id, "read");
-      setThreads(updated);
+      data.updateThreadStatus(message.id, "read");
     }
   };
 
@@ -111,8 +112,7 @@ export default function Inbox() {
       sentAt: new Date().toISOString(),
       connector: message.connector,
     };
-    const updated = data.addThreadReply(message.id, reply);
-    setThreads(updated);
+    data.addThreadReply(message.id, reply);
   };
 
   const handleSendReply = (message: Message) => {
@@ -124,32 +124,27 @@ export default function Inbox() {
       sentAt: new Date().toISOString(),
       connector: message.connector,
     };
-    let updated = data.addThreadReply(message.id, reply);
+    data.addThreadReply(message.id, reply);
 
     const matchedRecruiter = recruiters.find(
       (r) => r.connector.toLowerCase() === message.connector.toLowerCase(),
     );
     if (matchedRecruiter) {
-      updated = data.linkThreadToRecruiter(message.id, matchedRecruiter.id);
-      setRecruiters(data.getRecruiters());
+      data.linkThreadToRecruiter(message.id, matchedRecruiter.id);
     }
 
-    setThreads(updated);
     setDrafts((d) => ({ ...d, [message.id]: "" }));
   };
 
   const handleToggleStatus = (message: Message) => {
-    const updated = data.updateThreadStatus(
+    data.updateThreadStatus(
       message.id,
       message.status === "unread" ? "read" : "unread",
     );
-    setThreads(updated);
   };
 
   const handleLinkRecruiter = (threadId: string, recruiterId: string) => {
-    const updated = data.linkThreadToRecruiter(threadId, recruiterId);
-    setThreads(updated);
-    setRecruiters(data.getRecruiters());
+    data.linkThreadToRecruiter(threadId, recruiterId);
   };
 
   const handleDraftWithAI = (threadId: string) => {
@@ -196,7 +191,6 @@ export default function Inbox() {
     for (const { name, prompt } of editorTemplates) {
       if (name.trim()) defs[name.trim()] = prompt;
     }
-    setTemplateDefs(defs);
     data.saveAutoReplyTemplates(defs);
     setEditorOpen(false);
   };

--- a/src/components/talentforge/Recruiters/List.tsx
+++ b/src/components/talentforge/Recruiters/List.tsx
@@ -9,22 +9,74 @@ import {
   TextField,
   Button,
 } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import type { RecruiterEntry, Message } from "@/types";
+
+function cloneRecruiter(recruiter: RecruiterEntry): RecruiterEntry {
+  return {
+    ...recruiter,
+    tags: [...recruiter.tags],
+    threadIds: [...recruiter.threadIds],
+  };
+}
+
+function areStringArraysEqual(a: string[], b: string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function mergeRecruiterDrafts(
+  source: RecruiterEntry[],
+  drafts: RecruiterEntry[],
+): RecruiterEntry[] {
+  if (drafts.length === 0) {
+    return source.map(cloneRecruiter);
+  }
+
+  const draftMap = new Map(drafts.map((draft) => [draft.id, draft]));
+
+  return source.map((recruiter) => {
+    const existing = draftMap.get(recruiter.id);
+    if (!existing) {
+      return cloneRecruiter(recruiter);
+    }
+
+    const merged = cloneRecruiter(recruiter);
+
+    if (!areStringArraysEqual(existing.tags, recruiter.tags)) {
+      merged.tags = [...existing.tags];
+    }
+
+    if (existing.notes !== recruiter.notes) {
+      merged.notes = existing.notes;
+    }
+
+    return merged;
+  });
+}
 
 export default function RecruiterList() {
   const data = useTalentForgeData();
-  const [recruiters, setRecruiters] = useState<RecruiterEntry[]>([]);
-  const [messages, setMessages] = useState<Message[]>([]);
+  const recruiterList = useTalentForgeSelector((store) => store.getRecruiters());
+  const messages = useTalentForgeSelector((store) => store.getMessages());
+  const [recruiterDrafts, setRecruiterDrafts] = useState<RecruiterEntry[]>([]);
 
   useEffect(() => {
-    setRecruiters(data.getRecruiters());
-    setMessages(data.getMessages());
-  }, [data]);
+    setRecruiterDrafts((drafts) => mergeRecruiterDrafts(recruiterList, drafts));
+  }, [recruiterList]);
 
   const handleSave = (recruiter: RecruiterEntry) => {
     const updated = data.updateRecruiter(recruiter);
-    setRecruiters(updated);
+    setRecruiterDrafts((drafts) => mergeRecruiterDrafts(updated, drafts));
   };
 
   return (
@@ -32,7 +84,7 @@ export default function RecruiterList() {
       <Typography variant="h5" sx={{ mb: 2 }}>
         Recruiters
       </Typography>
-      {recruiters.map((r) => (
+      {recruiterDrafts.map((r) => (
         <Box key={r.id} sx={{ mb: 3 }}>
           <Typography variant="subtitle1" fontWeight="bold">
             {r.name}
@@ -46,7 +98,7 @@ export default function RecruiterList() {
             label="Tags"
             value={r.tags.join(", ")}
             onChange={(e) =>
-              setRecruiters((rec) =>
+              setRecruiterDrafts((rec) =>
                 rec.map((rr) =>
                   rr.id === r.id
                     ? {
@@ -69,7 +121,7 @@ export default function RecruiterList() {
             rows={3}
             value={r.notes}
             onChange={(e) =>
-              setRecruiters((rec) =>
+              setRecruiterDrafts((rec) =>
                 rec.map((rr) =>
                   rr.id === r.id ? { ...rr, notes: e.target.value } : rr,
                 ),

--- a/src/components/talentforge/Settings.tsx
+++ b/src/components/talentforge/Settings.tsx
@@ -17,13 +17,19 @@ import {
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
 import OpenAIKeyModal from "@/components/talentforge/OpenAiKeyModal";
 import { loadDemoData, clearDemoData } from "@/utils/talentforge/demoData";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 import { exportSnapshot, importSnapshot } from "@/utils/talentforge/snapshot";
 import { SNAPSHOT_VERSION } from "@/utils/talentforge/dataStore";
 import { useOpenAIKey } from "@/contexts/OpenAIKeyContext";
 
 export default function Settings() {
   const dataStore = useTalentForgeData();
+  const currentCompensation = useTalentForgeSelector((store) =>
+    store.getCurrentCompensation(),
+  );
   const [openKeyModal, setOpenKeyModal] = React.useState(false);
   const [comp, setComp] = React.useState({
     salary: "",
@@ -35,8 +41,8 @@ export default function Settings() {
   const { hasKey, clearKey, reloadFromStorage } = useOpenAIKey();
 
   React.useEffect(() => {
-    setComp(dataStore.getCurrentCompensation());
-  }, [dataStore]);
+    setComp(currentCompensation);
+  }, [currentCompensation]);
 
   const handleRemoveKey = () => {
     clearKey();

--- a/src/components/talentforge/onboarding/CompensationStep.tsx
+++ b/src/components/talentforge/onboarding/CompensationStep.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useEffect } from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
-import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
+import {
+  useTalentForgeData,
+  useTalentForgeSelector,
+} from "@/contexts/TalentForgeDataContext";
 
 interface StepProps {
   onNext: () => void;
@@ -11,6 +14,9 @@ interface StepProps {
 
 export default function CompensationStep({ onNext, onBack }: StepProps) {
   const dataStore = useTalentForgeData();
+  const existingCompensation = useTalentForgeSelector((store) =>
+    store.getCurrentCompensation(),
+  );
   const [comp, setComp] = useState({
     salary: "",
     benefits: "",
@@ -18,9 +24,8 @@ export default function CompensationStep({ onNext, onBack }: StepProps) {
   });
 
   useEffect(() => {
-    const existing = dataStore.getCurrentCompensation();
-    setComp(existing);
-  }, [dataStore]);
+    setComp(existingCompensation);
+  }, [existingCompensation]);
 
   const handleChange = (field: "salary" | "benefits" | "stock") => (
     event: React.ChangeEvent<HTMLInputElement>

--- a/src/contexts/TalentForgeDataContext.tsx
+++ b/src/contexts/TalentForgeDataContext.tsx
@@ -21,4 +21,41 @@ export function useTalentForgeData() {
   return context;
 }
 
+export function useTalentForgeSelector<T>(
+  selector: (store: typeof dataStore) => T,
+  isEqual: (a: T, b: T) => boolean = Object.is,
+) {
+  const store = useTalentForgeData();
+  const selectorRef = React.useRef(selector);
+  selectorRef.current = selector;
+  const equalityRef = React.useRef(isEqual);
+  equalityRef.current = isEqual;
+  const lastValueRef = React.useRef<T>();
+
+  const getSnapshot = React.useCallback(() => {
+    const next = selectorRef.current(store);
+    lastValueRef.current = next;
+    return next;
+  }, [store]);
+
+  return React.useSyncExternalStore(
+    (onStoreChange) => {
+      const handleChange = () => {
+        const next = selectorRef.current(store);
+        const previous = lastValueRef.current;
+        if (previous === undefined || !equalityRef.current(previous, next)) {
+          lastValueRef.current = next;
+          onStoreChange();
+        }
+      };
+      const unsubscribe = store.subscribe(handleChange);
+      return () => {
+        unsubscribe();
+      };
+    },
+    getSnapshot,
+    getSnapshot,
+  );
+}
+
 export default TalentForgeDataContext;

--- a/src/tests/talentforge/loaders.test.tsx
+++ b/src/tests/talentforge/loaders.test.tsx
@@ -5,21 +5,26 @@ import ApplicationBoard from '@/components/talentforge/ApplicationBoard';
 
 jest.mock('@/utils/talentforge/dataStore', () => ({
   getResumes: jest.fn(() => []),
-  addResume: jest.fn(),
+  addResume: jest.fn(() => []),
   getJobApplications: jest.fn(() => []),
   addJobApplication: jest.fn(),
-  updateJobApplicationStatus: jest.fn(),
-  updateJobApplication: jest.fn(),
+  updateJobApplicationStatus: jest.fn(() => []),
+  updateJobApplication: jest.fn(() => []),
   getRecruiters: jest.fn(() => []),
   getThreads: jest.fn(() => []),
   getAutoReplyTemplates: jest.fn(() => ({})),
   linkThreadToRecruiter: jest.fn(),
   saveAutoReplyTemplates: jest.fn(),
-  getCurrentCompensation: jest.fn(),
+  getCurrentCompensation: jest.fn(() => ({
+    salary: '',
+    benefits: '',
+    stock: '',
+  })),
+  subscribe: jest.fn(() => () => {}),
 }));
 
-jest.mock('@/contexts/TalentForgeDataContext', () => ({
-  useTalentForgeData: () => ({
+jest.mock('@/contexts/TalentForgeDataContext', () => {
+  const store = {
     getThreads: () => [],
     getRecruiters: () => [],
     getAutoReplyTemplates: () => ({}),
@@ -27,8 +32,27 @@ jest.mock('@/contexts/TalentForgeDataContext', () => ({
     addThreadReply: jest.fn(),
     linkThreadToRecruiter: jest.fn(),
     saveAutoReplyTemplates: jest.fn(),
-  }),
-}));
+    addThread: jest.fn(),
+    addResume: jest.fn(() => []),
+    addJobApplication: jest.fn(),
+    updateJobApplicationStatus: jest.fn(() => []),
+    updateJobApplication: jest.fn(() => []),
+    getJobApplications: () => [],
+    getResumes: () => [],
+    getCurrentCompensation: () => ({
+      salary: '',
+      benefits: '',
+      stock: '',
+    }),
+    subscribe: jest.fn(() => () => {}),
+  } as const;
+
+  return {
+    useTalentForgeData: () => store,
+    useTalentForgeSelector: (selector: (store: typeof store) => unknown) =>
+      selector(store),
+  };
+});
 
 jest.mock('@/utils/talentforge/jobAggregator', () => ({
   fetchAllListings: jest.fn(() => Promise.resolve([])),

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -61,6 +61,13 @@ const KEYS: { [K in keyof StoreSchema]: string } = {
   currentCompensation: "currentCompensation",
 } as const;
 
+const KEY_LOOKUP = Object.fromEntries(
+  (Object.entries(KEYS) as [keyof StoreSchema, string][]).map(([key, value]) => [
+    value,
+    key,
+  ]),
+) as Record<string, keyof StoreSchema>;
+
 // Version constants per entity so tests and other modules can reference them.
 export const USER_VERSION = 1;
 export const RESUMES_VERSION = 1;
@@ -243,25 +250,58 @@ const DEFAULTS: { [K in keyof StoreSchema]: StoreSchema[K] } = {
   currentCompensation: { salary: "", benefits: "", stock: "" },
 } as const;
 
+type StoreSubscriber = (key: keyof StoreSchema) => void;
+
+const subscribers = new Set<StoreSubscriber>();
+
+const cache: Partial<{ [K in keyof StoreSchema]: StoreSchema[K] }> = {};
+
+const hasOwn = Object.prototype.hasOwnProperty;
+
+function notify(key: keyof StoreSchema) {
+  for (const listener of subscribers) {
+    try {
+      listener(key);
+    } catch {
+      // Ignore subscriber errors to avoid breaking the data flow
+    }
+  }
+}
+
+export function subscribe(listener: StoreSubscriber): () => void {
+  subscribers.add(listener);
+  return () => {
+    subscribers.delete(listener);
+  };
+}
+
 function load<K extends keyof StoreSchema>(
   key: K,
   fallback: StoreSchema[K],
 ): StoreSchema[K] {
+  if (hasOwn.call(cache, key)) {
+    return cache[key] as StoreSchema[K];
+  }
   const value = loadItem<StoreSchema[K]>(
     KEYS[key],
     VERSION[key],
     MIGRATORS[key],
   );
-  if (value !== undefined) return value;
-  return fallback;
+  const result = value !== undefined ? value : fallback;
+  cache[key] = result;
+  return result;
 }
 
 function save<K extends keyof StoreSchema>(key: K, value: StoreSchema[K]): void {
+  cache[key] = value;
   saveItem(KEYS[key], value, VERSION[key]);
+  notify(key);
 }
 
 function remove<K extends keyof StoreSchema>(key: K): void {
+  delete cache[key];
   deleteItem(KEYS[key]);
+  notify(key);
 }
 
 // Migrations
@@ -375,13 +415,20 @@ export function getResumes(): ResumeEntry[] {
     const title = r.title
       ? generateUniqueTitle(r.title, existing)
       : generateUniqueTitle("Resume", existing);
-    if (title !== r.title) changed = true;
-    const updatedResume = { ...r, title };
-    existing.push(updatedResume);
-    return updatedResume;
+    if (title !== r.title) {
+      changed = true;
+      const updatedResume = { ...r, title };
+      existing.push(updatedResume);
+      return updatedResume;
+    }
+    existing.push(r);
+    return r;
   });
-  if (changed) saveResumes(updated);
-  return updated;
+  if (changed) {
+    saveResumes(updated);
+    return updated;
+  }
+  return loaded;
 }
 export function saveResumes(resumes: ResumeEntry[]): void {
   save("resumes", resumes);
@@ -500,8 +547,9 @@ export function getOffers(): Offer[] {
   });
   if (migrated) {
     save("offers", updated);
+    return updated;
   }
-  return updated;
+  return offers;
 }
 export function addOffer(offer: Offer): Offer[] {
   const updated = [...getOffers(), offer];
@@ -540,8 +588,9 @@ export function getJobApplications(): JobApplication[] {
   });
   if (migrated) {
     save("applications", updated);
+    return updated;
   }
-  return updated;
+  return apps;
 }
 export function addJobApplication(app: JobApplication): JobApplication[] {
   const withHistory = {
@@ -625,15 +674,25 @@ export function linkThreadToRecruiter(
   save("messages", messages);
 
   const recruiters = getRecruiters();
-  for (const r of recruiters) {
+  let recruitersChanged = false;
+  const updatedRecruiters = recruiters.map((r) => {
     const hasThread = r.threadIds.includes(threadId);
-    if (r.id === recruiterId && !hasThread) {
-      r.threadIds.push(threadId);
-    } else if (r.id !== recruiterId && hasThread) {
-      r.threadIds = r.threadIds.filter((t) => t !== threadId);
+    if (r.id === recruiterId) {
+      if (hasThread) {
+        return r;
+      }
+      recruitersChanged = true;
+      return { ...r, threadIds: [...r.threadIds, threadId] };
     }
+    if (!hasThread) {
+      return r;
+    }
+    recruitersChanged = true;
+    return { ...r, threadIds: r.threadIds.filter((t) => t !== threadId) };
+  });
+  if (recruitersChanged) {
+    save("recruiters", updatedRecruiters);
   }
-  save("recruiters", recruiters);
   return messages;
 }
 
@@ -679,14 +738,17 @@ export function saveConnectorToken(
   token: ConnectorToken,
 ): void {
   const tokens = getConnectorTokens();
-  tokens[connector] = token;
-  save("connectorTokens", tokens);
+  const updated = { ...tokens, [connector]: token };
+  save("connectorTokens", updated);
 }
 
 export function deleteConnectorToken(connector: string): void {
   const tokens = getConnectorTokens();
-  delete tokens[connector];
-  save("connectorTokens", tokens);
+  if (!hasOwn.call(tokens, connector)) {
+    return;
+  }
+  const { [connector]: _removed, ...rest } = tokens;
+  save("connectorTokens", rest as ConnectorTokenMap);
 }
 
 // Export / Import
@@ -768,6 +830,7 @@ export function importFromJson(json: string): void {
       data = migrateSnapshot(version, data);
     }
     const validKeys = Object.values(KEYS) as string[];
+    const changedKeys = new Set<keyof StoreSchema>();
     for (const [key, value] of Object.entries(data)) {
       if (validKeys.includes(key)) {
         try {
@@ -776,14 +839,24 @@ export function importFromJson(json: string): void {
               ? (value as object)
               : { version: 0, data: value };
           window.localStorage.setItem(key, JSON.stringify(payload));
+          const storeKey = KEY_LOOKUP[key];
+          if (storeKey) {
+            delete cache[storeKey];
+            changedKeys.add(storeKey);
+          }
         } catch {
           // ignore write errors
         }
       }
     }
-    // Trigger migrations for all known keys after importing
+    // Trigger migrations for changed keys after importing
     for (const key of Object.keys(KEYS) as (keyof StoreSchema)[]) {
-      load(key, DEFAULTS[key]);
+      if (changedKeys.has(key) || !hasOwn.call(cache, key)) {
+        load(key, DEFAULTS[key]);
+      }
+    }
+    for (const key of changedKeys) {
+      notify(key);
     }
   } catch {
     // ignore parse errors
@@ -837,6 +910,7 @@ const dataStore = {
   deleteConnectorToken,
   exportToJson,
   importFromJson,
+  subscribe,
 };
 
 export default dataStore;


### PR DESCRIPTION
## Summary
- add cache-backed pub/sub support to the talentforge data store so save and remove operations notify listeners
- expose a `useTalentForgeSelector` hook that subscribes components to store slices
- refactor the major talentforge consumers to use selectors, merge recruiter drafts safely, and update the loader test mocks for the new APIs

## Testing
- npm test -- --runTestsByPath src/tests/talentforge/loaders.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cbc9776a5c833091a6a2671582cc47