### PR TITLE
Fix Indeed job search filtering

### DIFF
--- a/src/tests/talentforge/indeedConnector.test.ts
+++ b/src/tests/talentforge/indeedConnector.test.ts
@@ -1,0 +1,38 @@
+import { IndeedConnector } from "@/utils/talentforge/connectors/indeed";
+
+describe("IndeedConnector.searchJobs", () => {
+  it("returns all listings when no query is provided", async () => {
+    const connector = new IndeedConnector();
+
+    const results = await connector.searchJobs("   ");
+
+    expect(results).toHaveLength(2);
+    expect(results.map((job) => job.source)).toEqual([
+      "Indeed",
+      "Indeed",
+    ]);
+  });
+
+  it("performs a case-insensitive match on title, company, and location", async () => {
+    const connector = new IndeedConnector();
+
+    await expect(connector.searchJobs("software")).resolves.toEqual([
+      expect.objectContaining({ title: "Software Engineer" }),
+    ]);
+
+    await expect(connector.searchJobs("analytics llc")).resolves.toEqual([
+      expect.objectContaining({ company: "Analytics LLC" }),
+    ]);
+
+    await expect(connector.searchJobs("remote")).resolves.toEqual([
+      expect.objectContaining({ location: "Remote" }),
+    ]);
+  });
+
+  it("returns an empty array when no listings match the query", async () => {
+    const connector = new IndeedConnector();
+
+    await expect(connector.searchJobs("nonexistent role")).resolves.toEqual([]);
+  });
+});
+

--- a/src/utils/talentforge/connectors/indeed.ts
+++ b/src/utils/talentforge/connectors/indeed.ts
@@ -49,8 +49,24 @@ export class IndeedConnector {
   }
 
   async searchJobs(query: string): Promise<JobListing[]> {
-    void query;
-    return SAMPLE_LISTINGS;
+    const trimmed = query.trim();
+
+    if (!trimmed) {
+      return SAMPLE_LISTINGS;
+    }
+
+    const lowerQuery = trimmed.toLowerCase();
+    return SAMPLE_LISTINGS.filter((listing) => {
+      const title = listing.title.toLowerCase();
+      const company = listing.company.toLowerCase();
+      const location = listing.location.toLowerCase();
+
+      return (
+        title.includes(lowerQuery) ||
+        company.includes(lowerQuery) ||
+        location.includes(lowerQuery)
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- ensure the mocked Indeed connector respects text queries when searching jobs
- add unit tests covering query filtering across title, company, and location fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd07a633083309c57d3b8f938961d