### PR TITLE
Show sidebet win reasons in blackjack web UI

### DIFF
--- a/go/blackjack/ui/messages/sidebets.go
+++ b/go/blackjack/ui/messages/sidebets.go
@@ -1,0 +1,110 @@
+package messages
+
+import (
+	"fmt"
+	"strings"
+
+	"blackjack/cards"
+	"blackjack/game"
+	"blackjack/player"
+	"blackjack/sidebets"
+)
+
+// SidebetReasons returns the textual descriptions for any winning sidebet
+// outcomes on the provided hand. The strings mirror the messaging produced by
+// the terminal UI so other front-ends can render consistent explanations.
+func SidebetReasons(hand player.Hand) []string {
+	switch game.GameMode {
+	case game.Spanish21:
+		return spanish21Reasons(hand)
+	case game.TrifectaStaxx:
+		return trifectaStaxxReasons(hand)
+	default:
+		return nil
+	}
+}
+
+func spanish21Reasons(hand player.Hand) []string {
+	if hand.TrifectaWager <= 0 || len(hand.Cards) < 2 {
+		return nil
+	}
+
+	winnings := sidebets.GetSpanish21Winnings(hand)
+	if winnings <= 0 {
+		return nil
+	}
+
+	reasons := make([]string, 0, 4)
+	firstCard := hand.Cards[0]
+	secondCard := hand.Cards[1]
+	dealerUpCard := sidebets.DealerUpCard()
+	dealerDownCard := sidebets.DealerDownCard()
+
+	if firstCard.Value == dealerUpCard.Value {
+		if sidebets.CardsMatchSuit(firstCard, dealerUpCard) {
+			reasons = append(reasons, fmt.Sprintf("First Card Matches Up Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier))
+		} else {
+			reasons = append(reasons, fmt.Sprintf("First Card Matches Up Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier))
+		}
+	}
+
+	if secondCard.Value == dealerUpCard.Value {
+		if sidebets.CardsMatchSuit(secondCard, dealerUpCard) {
+			reasons = append(reasons, fmt.Sprintf("Second Card Matches Up Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier))
+		} else {
+			reasons = append(reasons, fmt.Sprintf("Second Card Matches Up Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier))
+		}
+	}
+
+	if !dealerDownCard.Masked {
+		if firstCard.Value == dealerDownCard.Value {
+			if sidebets.CardsMatchSuit(firstCard, dealerDownCard) {
+				reasons = append(reasons, fmt.Sprintf("First Card Matches Down Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier))
+			} else {
+				reasons = append(reasons, fmt.Sprintf("First Card Matches Down Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier))
+			}
+		}
+
+		if secondCard.Value == dealerDownCard.Value {
+			if sidebets.CardsMatchSuit(secondCard, dealerDownCard) {
+				reasons = append(reasons, fmt.Sprintf("Second Card Matches Down Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier))
+			} else {
+				reasons = append(reasons, fmt.Sprintf("Second Card Matches Down Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier))
+			}
+		}
+	}
+
+	return reasons
+}
+
+func trifectaStaxxReasons(hand player.Hand) []string {
+	if hand.TrifectaWager <= 0 {
+		return nil
+	}
+
+	switch {
+	case sidebets.IsTrifectaTripAces(hand, true) || sidebets.IsTrifectaTripAces(hand, false) ||
+		sidebets.IsTrifectaTriplet(hand, cards.King, false) || sidebets.IsTrifectaTriplet(hand, cards.Queen, false):
+		return []string{"Trifecta PROGRESSIVE!"}
+	case sidebets.IsTrifectaStraightFlush(hand):
+		return []string{"Trifecta STRAIGHT FLUSH!"}
+	case sidebets.IsTrifectaTrips(hand, false):
+		return []string{"Trifecta TRIPS!"}
+	case sidebets.IsTrifectaFlush(hand):
+		return []string{"Trifecta FLUSH!"}
+	case sidebets.IsTrifectaStraight(hand):
+		return []string{"Trifecta STRAIGHT!"}
+	default:
+		return nil
+	}
+}
+
+// JoinReasons formats the provided reason strings with a separator suited for
+// human-readable output while preserving the original ordering used in the
+// terminal UI.
+func JoinReasons(reasons []string, separator string) string {
+	if len(reasons) == 0 {
+		return ""
+	}
+	return strings.Join(reasons, separator)
+}

--- a/go/blackjack/ui/terminal/print.go
+++ b/go/blackjack/ui/terminal/print.go
@@ -11,8 +11,10 @@ import (
 	"blackjack/player"
 	"blackjack/rules"
 	"blackjack/sidebets"
+	"blackjack/ui/messages"
 	"blackjack/utils"
 	"fmt"
+	"strings"
 	"unicode"
 )
 
@@ -527,87 +529,27 @@ func PrintShoeDetails() {
 }
 
 func PrintSidebetsOutcome(hand player.Hand) string {
+	reasons := messages.SidebetReasons(hand)
+	if len(reasons) == 0 {
+		return ""
+	}
+
+	outcome := constants.Purple + strings.Join(reasons, "")
+
 	switch game.GameMode {
 	case game.Spanish21:
-		firstCard := hand.Cards[0]
-		secondCard := hand.Cards[1]
-
-		outcome := constants.Purple
-		dealerUpCard := sidebets.DealerUpCard()
 		dealerDownCard := sidebets.DealerDownCard()
-
-		if firstCard.Value == dealerUpCard.Value {
-			if sidebets.CardsMatchSuit(firstCard, dealerUpCard) {
-				outcome += fmt.Sprintf("First Card Matches Up Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
-			} else {
-				outcome += fmt.Sprintf("First Card Matches Up Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier)
-			}
-		}
-
-		if secondCard.Value == dealerUpCard.Value {
-			if sidebets.CardsMatchSuit(secondCard, dealerUpCard) {
-				outcome += fmt.Sprintf("Second Card Matches Up Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
-			} else {
-				outcome += fmt.Sprintf("Second Card Matches Up Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier)
-			}
-		}
-
-		if !dealerDownCard.Masked {
-			if firstCard.Value == dealerDownCard.Value {
-				if sidebets.CardsMatchSuit(firstCard, dealerDownCard) {
-					outcome += fmt.Sprintf("First Card Matches Down Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
-				} else {
-					outcome += fmt.Sprintf("First Card Matches Down Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier)
-				}
-			}
-
-			if secondCard.Value == dealerDownCard.Value {
-				if sidebets.CardsMatchSuit(secondCard, dealerDownCard) {
-					outcome += fmt.Sprintf("Second Card Matches Down Card, Matches Suit! %d to 1 WINNER!", sidebets.Spanish21MatchSuitMultiplier)
-				} else {
-					outcome += fmt.Sprintf("Second Card Matches Down Card! %d to 1 WINNER!", sidebets.Spanish21MatchUnsuitedMultiplier)
-				}
-			}
-		}
-
 		winnings := sidebets.GetSpanish21Winnings(hand)
 		if winnings > 0 && !dealerDownCard.Masked {
 			outcome += fmt.Sprintf("\t$%d", winnings)
 		}
-
-		outcome += constants.Reset
-
-		return outcome
 	case game.TrifectaStaxx:
-		if hand.TrifectaWager > 0 && hand.TrifectaWinnings > 0 {
-			outcome := constants.Purple
-
-			if sidebets.IsTrifectaTripAces(hand, true) || sidebets.IsTrifectaTripAces(hand, false) || sidebets.IsTrifectaTriplet(hand, cards.King, false) || sidebets.IsTrifectaTriplet(hand, cards.Queen, false) {
-				outcome += "Trifecta PROGRESSIVE!"
-			} else if sidebets.IsTrifectaStraightFlush(hand) {
-				outcome += "Trifecta STRAIGHT FLUSH!"
-			} else if sidebets.IsTrifectaTrips(hand, false) {
-				outcome += "Trifecta TRIPS!"
-			} else if sidebets.IsTrifectaFlush(hand) {
-				outcome += "Trifecta FLUSH!"
-			} else if sidebets.IsTrifectaStraight(hand) {
-				outcome += "Trifecta STRAIGHT!"
-			}
-
-			if hand.TrifectaWinnings > 0 {
-				outcome += outcome + "\t" + PrintCurrency(hand.TrifectaWinnings)
-			}
-
-			outcome += constants.Reset
-
-			return outcome
+		if hand.TrifectaWinnings > 0 {
+			outcome += "\t" + PrintCurrency(hand.TrifectaWinnings)
 		}
-
-		return ""
-	case game.Blackjack:
-	default:
-		return ""
 	}
 
-	return ""
+	outcome += constants.Reset
+
+	return outcome
 }

--- a/go/blackjack/ui/web/web.go
+++ b/go/blackjack/ui/web/web.go
@@ -10,16 +10,20 @@ import (
 	"blackjack/rules"
 	"blackjack/sidebets"
 	"blackjack/ui"
+	"blackjack/ui/messages"
 	"errors"
 	"fmt"
+	"html"
 	"syscall/js"
 )
 
 type WebUI struct {
-	actionCh     chan rune
-	handlers     []handler
-	cfg          flags.Config
-	lastWinnings int
+	actionCh            chan rune
+	handlers            []handler
+	cfg                 flags.Config
+	lastWinnings        int
+	lastSidebetWinnings int
+	lastSidebetLosses   int
 }
 
 type handler struct {
@@ -193,29 +197,75 @@ func (w *WebUI) Render(state ui.GameState) {
 	// round result
 	if el := doc.Call("getElementById", "result"); el.Truthy() {
 		if state.AskingToDeal {
-			text := ""
-			color := ""
+			message := ""
 			if len(game.State.Players) > 0 {
 				p := game.State.Players[0]
-				diff := p.Winnings - w.lastWinnings
-				if diff > 0 {
-					text = fmt.Sprintf("You won %s", PrintCurrency(diff*100))
-					color = "green"
-				} else if diff < 0 {
-					text = fmt.Sprintf("You lost %s", PrintCurrency(-diff*100))
-					color = "red"
-				} else {
-					text = "Push"
+				baseDiff := p.Winnings - w.lastWinnings
+				bonusWinDiff := game.State.SidebetWinnings - w.lastSidebetWinnings
+				bonusLossDiff := game.State.SidebetLosses - w.lastSidebetLosses
+				bonusDiff := bonusWinDiff - bonusLossDiff
+				netDiff := baseDiff + bonusDiff
+
+				bonusReasonText := ""
+				if bonusDiff > 0 && len(p.Hands) > 0 {
+					if reasons := messages.SidebetReasons(p.Hands[0]); len(reasons) > 0 {
+						if joined := messages.JoinReasons(reasons, " "); joined != "" {
+							bonusReasonText = fmt.Sprintf(" <span class=\"text-bonus-reason\">%s</span>", html.EscapeString(joined))
+						}
+					}
+				}
+
+				netClass := func(amount int) string {
+					if amount > 0 {
+						return "text-win"
+					}
+					if amount < 0 {
+						return "text-loss"
+					}
+					return "text-neutral"
+				}
+
+				switch {
+				case baseDiff > 0:
+					message = fmt.Sprintf("Winner! <span class=\"text-win\">You won %s for the hand.</span>", PrintCurrency(baseDiff*100))
+					switch {
+					case bonusDiff > 0:
+						message += fmt.Sprintf(" You also won a <span class=\"text-bonus\">bonus of %s</span>!%s", PrintCurrency(bonusDiff*100), bonusReasonText)
+					case bonusDiff < 0:
+						message += fmt.Sprintf(" but <span class=\"text-loss\">lost %s on bonus wagers</span>.", PrintCurrency(-bonusDiff*100))
+						message += fmt.Sprintf(" For a net of <span class=\"%s\">%s</span>.", netClass(netDiff), PrintCurrency(netDiff*100))
+					}
+				case baseDiff < 0:
+					message = fmt.Sprintf("<span class=\"text-loss\">You lost %s on the hand</span>", PrintCurrency(-baseDiff*100))
+					switch {
+					case bonusDiff > 0:
+						message += fmt.Sprintf(", but <span class=\"text-bonus\">won a bonus of %s</span>%s,", PrintCurrency(bonusDiff*100), bonusReasonText)
+						message += fmt.Sprintf(" for a net of <span class=\"%s\">%s</span>.", netClass(netDiff), PrintCurrency(netDiff*100))
+					case bonusDiff < 0:
+						message += fmt.Sprintf(" and <span class=\"text-loss\">lost %s on bonus wagers</span>.", PrintCurrency(-bonusDiff*100))
+						message += fmt.Sprintf(" For a net of <span class=\"%s\">%s</span>.", netClass(netDiff), PrintCurrency(netDiff*100))
+					default:
+						message += "."
+					}
+				default:
+					message = "Push."
+					switch {
+					case bonusDiff > 0:
+						message += fmt.Sprintf(" You also won a <span class=\"text-bonus\">bonus of %s</span>!%s", PrintCurrency(bonusDiff*100), bonusReasonText)
+					case bonusDiff < 0:
+						message += fmt.Sprintf(" <span class=\"text-loss\">You lost %s on bonus wagers</span>.", PrintCurrency(-bonusDiff*100))
+						message += fmt.Sprintf(" For a net of <span class=\"%s\">%s</span>.", netClass(netDiff), PrintCurrency(netDiff*100))
+					}
 				}
 			}
-			el.Set("innerText", text)
-			el.Get("style").Set("color", color)
+			el.Set("innerHTML", message)
 		} else {
 			if len(game.State.Players) > 0 {
 				w.lastWinnings = game.State.Players[0].Winnings
 			}
-			el.Set("innerText", "")
-			el.Get("style").Set("color", "")
+			w.lastSidebetWinnings = game.State.SidebetWinnings
+			w.lastSidebetLosses = game.State.SidebetLosses
+			el.Set("innerHTML", "")
 		}
 	}
 

--- a/src/app/blackjack/page.css
+++ b/src/app/blackjack/page.css
@@ -35,3 +35,25 @@ button {
   margin-top: 1rem;
   white-space: pre-line;
 }
+
+.text-win {
+  color: #15803d;
+}
+
+.text-loss {
+  color: #dc2626;
+}
+
+.text-bonus {
+  color: #16a34a;
+  font-weight: 600;
+}
+
+.text-bonus-reason {
+  color: #16a34a;
+  font-style: italic;
+}
+
+.text-neutral {
+  color: #4b5563;
+}


### PR DESCRIPTION
## Summary
- share the sidebet win reason logic in a new ui/messages helper so multiple front-ends can format the same explanations
- extend the blackjack web UI result banner to include the sidebet win reason text alongside the bonus amount and add styling for it
- update the terminal UI to consume the shared helper so its output stays aligned with the web renderer

## Testing
- cd go/blackjack && go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cbcd398a6083308879a552fe224eb9