### PR TITLE
Fix recruiter thread previews

### DIFF
--- a/src/components/talentforge/Recruiters/List.tsx
+++ b/src/components/talentforge/Recruiters/List.tsx
@@ -91,11 +91,14 @@ export default function RecruiterList() {
               <Typography variant="body2" color="text.secondary">
                 Threads:
               </Typography>
-              {r.threadIds.map((id) => {
-                const msg = messages.find((m) => m.id === id);
+              {r.threadIds.map((threadId) => {
+                const threadMessage = messages.find(
+                  (message) => message.threadId === threadId,
+                );
+                const previewText = threadMessage?.body ?? `Thread ${threadId}`;
                 return (
-                  <Typography key={id} variant="body2">
-                    {msg ? msg.body : id}
+                  <Typography key={threadId} variant="body2">
+                    {previewText}
                   </Typography>
                 );
               })}


### PR DESCRIPTION
## Summary
- update recruiter thread lookup to match messages by their threadId
- show a message body preview for each thread with a fallback label when no message is found

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd3c9bf608330b1f1e751806e014c