### PR TITLE
Add status timeline editing in application drawer

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -511,6 +511,19 @@ export default function ApplicationBoard() {
     setSelectedApplicationId(null);
   };
 
+  const handleDetailStatusUpdate = (
+    appId: string,
+    status: ApplicationStatus,
+    options?: { reason?: string; changedAt?: string },
+  ) => {
+    const updated = updateJobApplicationStatus(appId, status, options);
+    setApplications(updated);
+    const updatedApp = updated.find((a) => a.id === appId);
+    if (updatedApp) {
+      setLiveMessage(`${updatedApp.role.title} updated to ${status}`);
+    }
+  };
+
   const handleOpenWorkspace = (app: JobApplication) => {
     setWorkspaceApp(app);
     setWorkspaceOpen(true);
@@ -960,10 +973,11 @@ export default function ApplicationBoard() {
   const handleReject = (source: "drawer" | "workspace") => {
     const app = source === "drawer" ? drawerApp : workspaceApp;
     if (!app) return;
+    const trimmedReason = rejectReason.trim();
     const updated = updateJobApplicationStatus(
       app.id,
       "rejected",
-      rejectReason || undefined
+      trimmedReason ? { reason: trimmedReason } : undefined,
     );
     setApplications(updated);
     setRejectReason("");
@@ -1183,6 +1197,7 @@ export default function ApplicationBoard() {
         application={selectedApplication}
         onClose={handleCloseDetails}
         promptDrawerOpen={drawerOpen}
+        onUpdateStatus={handleDetailStatusUpdate}
       />
       {drawerOpen && (
         <Drawer

--- a/src/components/talentforge/ApplicationDetailDrawer.tsx
+++ b/src/components/talentforge/ApplicationDetailDrawer.tsx
@@ -1,33 +1,47 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { ChangeEvent, FormEvent } from "react";
 import {
   Box,
+  Button,
   Chip,
   Drawer,
   IconButton,
   Link,
+  MenuItem,
   Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  TextField,
   Typography,
   Divider,
 } from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material";
 import { Close } from "@mui/icons-material";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
 
-import type { JobApplication } from "@/types";
+import type { ApplicationStatus, JobApplication } from "@/types";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import PromptTileGrid from "./promptTiles/PromptTileGrid";
 import {
   getPromptTiles,
   type PromptContext,
 } from "@/utils/talentforge/promptRegistry";
+import { STATUSES } from "@/utils/talentforge/keyboard";
 
 interface ApplicationDetailDrawerProps {
   open: boolean;
   application: JobApplication | null;
   onClose: () => void;
   promptDrawerOpen?: boolean;
+  onUpdateStatus: (
+    id: string,
+    status: ApplicationStatus,
+    options?: { reason?: string; changedAt?: string },
+  ) => void;
 }
 
 interface ConnectorStatus {
@@ -43,10 +57,53 @@ const slugifyConnector = (value: string) =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 
+const ensureValidIso = (value?: string): string => {
+  if (!value) {
+    return new Date().toISOString();
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+};
+
+const toDateTimeLocalValue = (iso: string): string => {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const offset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - offset * 60_000);
+  return local.toISOString().slice(0, 16);
+};
+
+const toIsoFromLocalValue = (value: string): string => {
+  if (!value) {
+    return new Date().toISOString();
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+};
+
+const formatTimelineDate = (value: string): string => {
+  if (!value) return "Unknown date";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
+const formatStatusLabel = (status: ApplicationStatus): string =>
+  status.charAt(0).toUpperCase() + status.slice(1);
+
 export default function ApplicationDetailDrawer({
   open,
   application,
   onClose,
+  onUpdateStatus,
   promptDrawerOpen = false,
 }: ApplicationDetailDrawerProps) {
   const data = useTalentForgeData();
@@ -127,6 +184,80 @@ export default function ApplicationDetailDrawer({
     return defaults;
   }, [application, promptContexts]);
 
+  const history = useMemo(() => {
+    if (!application?.history) {
+      return [] as JobApplication["history"];
+    }
+    return [...application.history].sort((a, b) => {
+      const timeA = new Date(a.changedAt).getTime();
+      const timeB = new Date(b.changedAt).getTime();
+      const normalizedA = Number.isNaN(timeA) ? 0 : timeA;
+      const normalizedB = Number.isNaN(timeB) ? 0 : timeB;
+      return normalizedA - normalizedB;
+    });
+  }, [application?.history]);
+
+  const latestHistoryEntry = history.length > 0 ? history[history.length - 1] : null;
+
+  const [statusDraft, setStatusDraft] = useState<ApplicationStatus>("applied");
+  const [dateDraft, setDateDraft] = useState<string>(() =>
+    toDateTimeLocalValue(new Date().toISOString()),
+  );
+  const [reasonDraft, setReasonDraft] = useState<string>("");
+
+  useEffect(() => {
+    if (!application) {
+      setStatusDraft("applied");
+      setDateDraft(toDateTimeLocalValue(new Date().toISOString()));
+      setReasonDraft("");
+      return;
+    }
+    const latest = history[history.length - 1];
+    setStatusDraft(application.status);
+    const iso = ensureValidIso(latest?.changedAt);
+    setDateDraft(toDateTimeLocalValue(iso));
+    setReasonDraft(latest?.reason ?? "");
+  }, [application, history]);
+
+  const handleStatusDraftChange = (
+    event: SelectChangeEvent<ApplicationStatus>,
+  ) => {
+    const nextStatus = event.target.value as ApplicationStatus;
+    setStatusDraft(nextStatus);
+    if (!application) {
+      setDateDraft(toDateTimeLocalValue(new Date().toISOString()));
+      setReasonDraft("");
+      return;
+    }
+    if (nextStatus === application.status) {
+      const iso = ensureValidIso(latestHistoryEntry?.changedAt);
+      setDateDraft(toDateTimeLocalValue(iso));
+      setReasonDraft(latestHistoryEntry?.reason ?? "");
+    } else {
+      const nowIso = new Date().toISOString();
+      setDateDraft(toDateTimeLocalValue(nowIso));
+      setReasonDraft("");
+    }
+  };
+
+  const handleDateDraftChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setDateDraft(event.target.value);
+  };
+
+  const handleReasonDraftChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setReasonDraft(event.target.value);
+  };
+
+  const handleStatusSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!application) return;
+    const iso = toIsoFromLocalValue(dateDraft);
+    onUpdateStatus(application.id, statusDraft, {
+      changedAt: iso,
+      reason: reasonDraft,
+    });
+  };
+
   return (
     <Drawer
       anchor="right"
@@ -194,6 +325,98 @@ export default function ApplicationDetailDrawer({
         </Stack>
         <Box sx={{ flexGrow: 1, overflowY: "auto", mt: 2, pr: 1 }}>
           <Stack spacing={3} divider={<Divider flexItem />}>
+            {application && (
+              <Box>
+                <Typography variant="subtitle2" gutterBottom>
+                  Status timeline
+                </Typography>
+                {history.length > 0 ? (
+                  <Stepper
+                    orientation="vertical"
+                    activeStep={history.length - 1}
+                    sx={{ mt: 1 }}
+                  >
+                    {history.map((entry, index) => (
+                      <Step
+                        key={`${entry.status}-${entry.changedAt}-${index}`}
+                        completed={index < history.length - 1}
+                        expanded
+                      >
+                        <StepLabel
+                          optional={
+                            <Typography variant="caption" color="text.secondary">
+                              {formatTimelineDate(entry.changedAt)}
+                            </Typography>
+                          }
+                        >
+                          {formatStatusLabel(entry.status)}
+                        </StepLabel>
+                        <Box sx={{ pl: 4, pb: index === history.length - 1 ? 0 : 2 }}>
+                          <Typography
+                            variant="body2"
+                            color={entry.reason ? "text.secondary" : "text.disabled"}
+                            sx={{ fontStyle: entry.reason ? "normal" : "italic" }}
+                          >
+                            {entry.reason || "No reason provided"}
+                          </Typography>
+                        </Box>
+                      </Step>
+                    ))}
+                  </Stepper>
+                ) : (
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                    No status updates logged yet.
+                  </Typography>
+                )}
+                <Box component="form" onSubmit={handleStatusSubmit} noValidate sx={{ mt: 2 }}>
+                  <Stack spacing={2}>
+                    <TextField
+                      label="Status"
+                      select
+                      size="small"
+                      value={statusDraft}
+                      onChange={handleStatusDraftChange}
+                      fullWidth
+                    >
+                      {STATUSES.map((status) => (
+                        <MenuItem key={status} value={status}>
+                          {formatStatusLabel(status)}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                    <TextField
+                      label="Date"
+                      type="datetime-local"
+                      size="small"
+                      value={dateDraft}
+                      onChange={handleDateDraftChange}
+                      fullWidth
+                      required
+                      InputLabelProps={{ shrink: true }}
+                    />
+                    <TextField
+                      label="Reason"
+                      value={reasonDraft}
+                      onChange={handleReasonDraftChange}
+                      fullWidth
+                      multiline
+                      minRows={2}
+                      placeholder="Optional details about this status change"
+                    />
+                    <Button
+                      type="submit"
+                      variant="contained"
+                      disabled={!application || !dateDraft}
+                      sx={{ alignSelf: "flex-start" }}
+                    >
+                      {statusDraft === application.status
+                        ? "Update status"
+                        : "Log status change"}
+                    </Button>
+                  </Stack>
+                </Box>
+              </Box>
+            )}
             <Box>
               <Typography variant="subtitle2" gutterBottom>
                 Job description

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -569,14 +569,63 @@ export function updateJobApplication(
 export function updateJobApplicationStatus(
   id: string,
   status: ApplicationStatus,
-  reason?: string,
+  options?: { reason?: string; changedAt?: string },
 ): JobApplication[] {
   const updated = getJobApplications().map((app) => {
     if (app.id === id) {
-      const history = [
-        ...(app.history || []),
-        { status, changedAt: new Date().toISOString(), ...(reason ? { reason } : {}) },
-      ];
+      const opts = options ?? {};
+      const hasReasonOption = Object.prototype.hasOwnProperty.call(opts, "reason");
+      const rawReason = hasReasonOption ? opts.reason ?? "" : undefined;
+      const trimmedReason = rawReason?.trim();
+      const hasChangedAtOption = Object.prototype.hasOwnProperty.call(
+        opts,
+        "changedAt",
+      );
+      const changedAtValue = hasChangedAtOption ? opts.changedAt : undefined;
+
+      const parseChangedAt = (value?: string) => {
+        if (!value) return new Date();
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+      };
+
+      const history = [...(app.history || [])];
+      const lastEntry = history[history.length - 1];
+
+      if (
+        lastEntry &&
+        lastEntry.status === status &&
+        (hasReasonOption || hasChangedAtOption)
+      ) {
+        const updatedEntry: StatusChange = {
+          ...lastEntry,
+          status,
+          changedAt: hasChangedAtOption
+            ? parseChangedAt(changedAtValue).toISOString()
+            : lastEntry.changedAt,
+        };
+        if (hasReasonOption) {
+          if (trimmedReason) {
+            updatedEntry.reason = trimmedReason;
+          } else {
+            delete updatedEntry.reason;
+          }
+        }
+        history[history.length - 1] = updatedEntry;
+        return { ...app, status, history };
+      }
+
+      const baseDate = hasChangedAtOption
+        ? parseChangedAt(changedAtValue)
+        : new Date();
+      const entry: StatusChange = {
+        status,
+        changedAt: baseDate.toISOString(),
+      };
+      if (trimmedReason) {
+        entry.reason = trimmedReason;
+      }
+      history.push(entry);
       return { ...app, status, history };
     }
     return app;


### PR DESCRIPTION
## Summary
- add a vertical Stepper-based timeline and editing form to the application detail drawer so users can review and update status history
- wire the drawer to update job applications via `updateJobApplicationStatus`, including support for reasons and custom timestamps
- extend the data store helper to accept optional reason/date overrides and update the most recent history entry when editing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd4f6c82c8330b364926ff51ea22c