### PR TITLE
Add tailored resume and offer prompt tiles

### DIFF
--- a/src/consts/promptTiles.ts
+++ b/src/consts/promptTiles.ts
@@ -23,11 +23,25 @@ const BASE_TILES: Record<string, PromptTileDefinition> = Object.fromEntries(
 // Overrides/additional metadata for specific tiles
 export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
   ...BASE_TILES,
+  tailorResumeToRole: {
+    ...BASE_TILES.tailorResumeToRole,
+    display: "Tailor Résumé",
+    fullPrompt:
+      "You're tailoring a resume to a specific opportunity. Review the resume and job description below. Produce markdown with four sections: \"Tailored Summary\" (two sentences), \"Priority Bullet Updates\" (three to five rewritten bullets that reference quantified achievements from the resume), \"Keywords to Emphasize\" (comma-separated keywords), and \"Gaps to Address\" (bullet list of missing experience or evidence to gather). Resume:\n{{resumeText}}\n\nJob Description:\n{{jobDescription}}",
+    inputs: ["resumeText", "jobDescription"],
+  },
   coverLetter: {
     ...BASE_TILES.coverLetter,
     fullPrompt:
       "Write a cover letter applying for the position of {{position}} at {{company}}. Highlight relevant skills and enthusiasm.",
     inputs: ["position", "company"],
+  },
+  targetedCoverLetter: {
+    ...BASE_TILES.targetedCoverLetter,
+    display: "Targeted Cover Letter",
+    fullPrompt:
+      "Write a targeted cover letter for the {{roleTitle}} role at {{company}}. Use the resume highlights and job description below to craft three paragraphs: an engaging opening that aligns motivations, a middle paragraph citing two to three measurable achievements mapped to the role's priorities, and a closing paragraph that reiterates interest and requests next steps. Close with a professional sign-off using \"Sincerely\" and a placeholder for the candidate's name. Resume Highlights:\n{{resumeText}}\n\nJob Description:\n{{jobDescription}}",
+    inputs: ["roleTitle", "company", "resumeText", "jobDescription"],
   },
   elevatorPitch: {
     ...BASE_TILES.elevatorPitch,
@@ -56,6 +70,13 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Compare the following resume to the job description. List items that align with the job description, items missing from the resume, and recommendations to better align the resume with the job description.\n\nJob Description:\n{{jobDescription}}\n\nResume:\n{{resumeContent}}",
     inputs: ["resumeVariantId", "jobDescription"],
   },
+  extractKeyRequirements: {
+    ...BASE_TILES.extractKeyRequirements,
+    display: "Extract Requirements",
+    fullPrompt:
+      "Extract the key requirements from the job description below. Organize the response as markdown sections titled \"Core Responsibilities\", \"Required Qualifications\", \"Preferred Skills\", and \"Notable Keywords\" with concise bullet points under each heading. Job Description:\n{{jobDescription}}",
+    inputs: ["jobDescription"],
+  },
   jdRequirements: {
     id: "jdRequirements",
     display: "JD Requirements",
@@ -69,12 +90,26 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "From the following job description, list the key job requirements as bullet points:\n\n{{jobDescription}}",
     inputs: ["jobDescription"],
   },
+  negotiateBetterOffer: {
+    ...BASE_TILES.negotiateBetterOffer,
+    display: "Negotiate Better Offer",
+    fullPrompt:
+      "Help the candidate negotiate for better terms. Review the offer details, current compensation, and leverage points below. First provide a markdown section titled \"Negotiation Strategy\" summarizing the strongest arguments with bullet points referencing numbers or evidence. Then provide a section titled \"Draft Message\" containing a polished email requesting the desired improvements. Offer Details:\n{{offerDetails}}\n\nCurrent Compensation:\n{{currentComp}}\n\nLeverage Points:\n{{leveragePoints}}",
+    inputs: ["offerDetails", "currentComp", "leveragePoints"],
+  },
   compareOffers: {
     id: "compareOffers",
     display: "Compare Offers",
     fullPrompt:
       "Compare the following two job offers in a markdown table highlighting differences in compensation, benefits, and other terms. Then provide a brief summary of which offer is more advantageous.\n\nOffer A:\n{{offerA}}\n\nOffer B:\n{{offerB}}",
     inputs: ["offerA", "offerB"],
+  },
+  compareTwoOffers: {
+    ...BASE_TILES.compareTwoOffers,
+    display: "Compare Two Offers",
+    fullPrompt:
+      "Compare the two offers below. Create a markdown table with rows for Base Salary, Bonus, Equity, Benefits, Time Off, and Other Notes using the details provided. After the table, add sections titled \"Key Differences\" and \"Recommendation\" summarizing trade-offs and advising which offer better aligns with the candidate's stated priorities. Offer A:\n{{offerA}}\n\nOffer B:\n{{offerB}}\n\nCandidate Priorities:\n{{priorities}}",
+    inputs: ["offerA", "offerB", "priorities"],
   },
   offerDetails: {
     id: "offerDetails",
@@ -108,6 +143,13 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
       "Review the following job description, provide a brief summary, and list potential issues candidates should note. Return JSON with a 'summary' and an 'issues' array of objects with 'severity' ('red' or 'yellow') and 'message'.\n\n{{jobDescription}}",
     inputs: ["jobDescription"],
   },
+  screenRoleForRedFlags: {
+    ...BASE_TILES.screenRoleForRedFlags,
+    display: "Spot Red Flags",
+    fullPrompt:
+      "Screen the job description below for potential red flags. Begin with a two-sentence summary of the role. Then produce a markdown table with columns \"Flag\", \"Severity\", and \"Why it Matters\" where severity is either red or yellow. Conclude with a bullet list of clarifying questions to ask. Job Description:\n{{jobDescription}}",
+    inputs: ["jobDescription"],
+  },
   negotiateOffer: {
     ...BASE_TILES.negotiateOffer,
     fullPrompt:
@@ -119,6 +161,13 @@ export const PROMPT_TILES: Record<string, PromptTileDefinition> = {
     fullPrompt:
       "Given the message context, draft a polite follow-up and a polite decline for a recruiter. Provide versions for email, LinkedIn, and Indeed in JSON with keys followUp and decline, each containing email, linkedin, and indeed.\n\nMessage context:\n{{messageContext}}",
     inputs: ["messageContext"],
+  },
+  recruiterFollowUpNudge: {
+    ...BASE_TILES.recruiterFollowUpNudge,
+    display: "Follow-Up Nudge",
+    fullPrompt:
+      "Draft a professional follow-up to a recruiter based on the conversation context below. Provide two polished messages: one for email and one for LinkedIn InMail. Each message should acknowledge the previous touchpoint, restate interest or value, and suggest a next step or question. Format the output using markdown headings \"Email\" and \"LinkedIn\" followed by the respective message. Conversation context:\n{{conversationContext}}",
+    inputs: ["conversationContext"],
   },
 };
 

--- a/src/consts/prompts.ts
+++ b/src/consts/prompts.ts
@@ -9,10 +9,20 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Summarize your professional experience and key strengths in 2-3 sentences.",
   },
+  tailorResumeToRole: {
+    displayText: "Tailor my résumé to this role",
+    fullText:
+      "Analyze the job description alongside my resume and outline a tailored summary, priority bullet updates, keywords to weave in, and gaps I should close for the role.",
+  },
   coverLetter: {
     displayText: "Cover Letter",
     fullText:
       "Write a professional cover letter with exactly three paragraphs tailored to the job description.",
+  },
+  targetedCoverLetter: {
+    displayText: "Create a targeted cover letter",
+    fullText:
+      "Using my resume highlights and the job description, craft a three-paragraph cover letter that clearly ties my achievements to the role and ends with a confident call to action.",
   },
   bulletRewrite: {
     displayText: "Bullet Rewrite",
@@ -23,6 +33,16 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     displayText: "Negotiate Offer",
     fullText:
       "Review the job offer alongside the current compensation and suggest negotiation strategies. Draft a polite response to the employer summarizing your position.",
+  },
+  negotiateBetterOffer: {
+    displayText: "Help me negotiate a more favorable offer",
+    fullText:
+      "Compare the current offer to my existing compensation, leverage the proof points I provide, and draft a persuasive negotiation message requesting improved terms.",
+  },
+  compareTwoOffers: {
+    displayText: "Compare two offers",
+    fullText:
+      "Review two offers side by side, highlight the major differences across compensation and benefits, and recommend which option best aligns with the stated priorities.",
   },
   interviewPreparation: {
     displayText: "Interview Preparation",
@@ -59,10 +79,20 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     fullText:
       "Review the following job description, provide a brief summary, and list potential issues candidates should note. Return JSON with a 'summary' and an 'issues' array of objects with 'severity' ('red' or 'yellow') and 'message'.",
   },
+  screenRoleForRedFlags: {
+    displayText: "Screen this role for red flags",
+    fullText:
+      "Evaluate the job description for potential red flags, note anything unusual or vague, and provide clarifying questions I should ask before proceeding.",
+  },
   jobRequirements: {
     displayText: "Job Requirements",
     fullText:
       "List the key job requirements from the provided job description in bullet points.",
+  },
+  extractKeyRequirements: {
+    displayText: "Extract key requirements",
+    fullText:
+      "Break down the job description into core responsibilities, required qualifications, nice-to-have skills, and high-priority keywords so I can target my application.",
   },
   networkingOutreach: {
     displayText: "Networking Outreach",
@@ -73,6 +103,11 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
     displayText: "Recruiter Nudge",
     fullText:
       "Generate polite follow-up and decline messages for a recruiter. Provide versions for email, LinkedIn, and Indeed.",
+  },
+  recruiterFollowUpNudge: {
+    displayText: "Recruiter follow-up nudge",
+    fullText:
+      "Draft a friendly follow-up that reaffirms my interest, references our last conversation, and asks about next steps across both email and LinkedIn.",
   },
   portfolioReview: {
     displayText: "Portfolio Review",
@@ -104,21 +139,31 @@ export const PROMPT_TEMPLATES: Record<string, PromptTemplate> = {
 export const PROMPT_GROUPS: Record<string, string[]> = {
   Resumes: [
     "resumeSummary",
+    "tailorResumeToRole",
     "coverLetter",
+    "targetedCoverLetter",
     "bulletRewrite",
     "portfolioReview",
     "projectSummary",
   ],
-  Offers: ["negotiateOffer", "salaryResearch"],
+  Offers: [
+    "negotiateOffer",
+    "negotiateBetterOffer",
+    "compareTwoOffers",
+    "salaryResearch",
+  ],
   "Recruiter Replies": [
     "interviewPreparation",
     "networkingOutreach",
     "recruiterNudge",
+    "recruiterFollowUpNudge",
   ],
   "Career Growth": [
     "skillGapAnalysis",
     "jobDescriptionRewrite",
     "jobRequirements",
+    "extractKeyRequirements",
+    "screenRoleForRedFlags",
     "careerGoals",
     "elevatorPitch",
     "linkedinProfileOptimization",

--- a/src/tests/talentforge/promptRegistryNewTiles.test.ts
+++ b/src/tests/talentforge/promptRegistryNewTiles.test.ts
@@ -1,0 +1,63 @@
+import { PROMPT_TILES } from "@/consts/promptTiles";
+import { getPromptTile } from "@/utils/talentforge/promptRegistry";
+
+const NEW_TILE_IDS = [
+  "tailorResumeToRole",
+  "extractKeyRequirements",
+  "targetedCoverLetter",
+  "negotiateBetterOffer",
+  "compareTwoOffers",
+  "screenRoleForRedFlags",
+  "recruiterFollowUpNudge",
+] as const;
+
+describe("prompt registry new tiles", () => {
+  test.each(NEW_TILE_IDS)("registry exposes %s", (id) => {
+    expect(PROMPT_TILES[id]).toBeDefined();
+    const tile = getPromptTile(id);
+    expect(tile).toBeDefined();
+    expect(tile?.id).toBe(id);
+  });
+
+  test("tailor resume tile requests structured sections", () => {
+    const tile = PROMPT_TILES.tailorResumeToRole;
+    expect(tile.inputs).toEqual(["resumeText", "jobDescription"]);
+    expect(tile.fullPrompt).toMatch(/Tailored Summary/);
+    expect(tile.fullPrompt).toMatch(/Priority Bullet Updates/);
+  });
+
+  test("extract requirements tile outlines headings", () => {
+    const tile = PROMPT_TILES.extractKeyRequirements;
+    expect(tile.fullPrompt).toMatch(/Core Responsibilities/);
+    expect(tile.fullPrompt).toMatch(/Notable Keywords/);
+  });
+
+  test("negotiate better offer tile includes strategy and draft message", () => {
+    const tile = PROMPT_TILES.negotiateBetterOffer;
+    expect(tile.inputs).toEqual([
+      "offerDetails",
+      "currentComp",
+      "leveragePoints",
+    ]);
+    expect(tile.fullPrompt).toMatch(/Negotiation Strategy/);
+    expect(tile.fullPrompt).toMatch(/Draft Message/);
+  });
+
+  test("compare two offers tile captures candidate priorities", () => {
+    const tile = PROMPT_TILES.compareTwoOffers;
+    expect(tile.inputs).toEqual(["offerA", "offerB", "priorities"]);
+    expect(tile.fullPrompt).toMatch(/Candidate Priorities/);
+  });
+
+  test("screen role for red flags tile requires severity guidance", () => {
+    const tile = PROMPT_TILES.screenRoleForRedFlags;
+    expect(tile.fullPrompt).toMatch(/Severity/);
+    expect(tile.fullPrompt).toMatch(/clarifying questions/i);
+  });
+
+  test("recruiter follow up nudge tile covers both channels", () => {
+    const tile = PROMPT_TILES.recruiterFollowUpNudge;
+    expect(tile.fullPrompt).toMatch(/Email/);
+    expect(tile.fullPrompt).toMatch(/LinkedIn/);
+  });
+});

--- a/src/utils/talentforge/promptRegistry.ts
+++ b/src/utils/talentforge/promptRegistry.ts
@@ -22,7 +22,15 @@ const TILE_METADATA: Record<keyof typeof PROMPT_TILES, {
     contexts: ["resume"],
     recommendedGoalTags: ["resume"],
   },
+  tailorResumeToRole: {
+    contexts: ["resume"],
+    recommendedGoalTags: ["resume"],
+  },
   coverLetter: {
+    contexts: ["resume", "messaging"],
+    recommendedGoalTags: ["resume", "networking"],
+  },
+  targetedCoverLetter: {
     contexts: ["resume", "messaging"],
     recommendedGoalTags: ["resume", "networking"],
   },
@@ -31,6 +39,10 @@ const TILE_METADATA: Record<keyof typeof PROMPT_TILES, {
     recommendedGoalTags: ["resume"],
   },
   negotiateOffer: {
+    contexts: ["offers", "messaging"],
+    recommendedGoalTags: ["search", "networking"],
+  },
+  negotiateBetterOffer: {
     contexts: ["offers", "messaging"],
     recommendedGoalTags: ["search", "networking"],
   },
@@ -50,6 +62,10 @@ const TILE_METADATA: Record<keyof typeof PROMPT_TILES, {
     contexts: ["resume", "jobSearch"],
     recommendedGoalTags: ["resume", "search"],
   },
+  compareTwoOffers: {
+    contexts: ["offers"],
+    recommendedGoalTags: ["search"],
+  },
   jobDescriptionRewrite: {
     contexts: ["jobSearch"],
     recommendedGoalTags: ["search"],
@@ -62,7 +78,15 @@ const TILE_METADATA: Record<keyof typeof PROMPT_TILES, {
     contexts: ["jobSearch"],
     recommendedGoalTags: ["search"],
   },
+  screenRoleForRedFlags: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
   jobRequirements: {
+    contexts: ["jobSearch"],
+    recommendedGoalTags: ["search"],
+  },
+  extractKeyRequirements: {
     contexts: ["jobSearch"],
     recommendedGoalTags: ["search"],
   },
@@ -71,6 +95,10 @@ const TILE_METADATA: Record<keyof typeof PROMPT_TILES, {
     recommendedGoalTags: ["networking"],
   },
   recruiterNudge: {
+    contexts: ["messaging"],
+    recommendedGoalTags: ["networking"],
+  },
+  recruiterFollowUpNudge: {
     contexts: ["messaging"],
     recommendedGoalTags: ["networking"],
   },


### PR DESCRIPTION
## Summary
- add prompt templates for tailoring resumes, extracting requirements, targeted cover letters, offer comparisons, and recruiter follow-ups
- map the new templates to prompt tiles with structured prompts and metadata updates for the registry
- cover the additional tiles with jest tests to confirm they are discoverable and correctly configured

## Testing
- npm test -- --runTestsByPath src/tests/talentforge/promptRegistryNewTiles.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbd95c66dc833097b5eca9a1b6948a