### PR TITLE
Fix select change handlers typing

### DIFF
--- a/src/components/talentforge/ApplicationDetailDrawer.tsx
+++ b/src/components/talentforge/ApplicationDetailDrawer.tsx
@@ -220,7 +220,7 @@ export default function ApplicationDetailDrawer({
   }, [application, history]);
 
   const handleStatusDraftChange = (
-    event: SelectChangeEvent<ApplicationStatus>,
+    event: SelectChangeEvent<unknown>,
   ) => {
     const nextStatus = event.target.value as ApplicationStatus;
     setStatusDraft(nextStatus);
@@ -375,7 +375,7 @@ export default function ApplicationDetailDrawer({
                       select
                       size="small"
                       value={statusDraft}
-                      onChange={handleStatusDraftChange}
+                      SelectProps={{ onChange: handleStatusDraftChange }}
                       fullWidth
                     >
                       {STATUSES.map((status) => (

--- a/src/components/talentforge/offers/CompareOffers.tsx
+++ b/src/components/talentforge/offers/CompareOffers.tsx
@@ -172,12 +172,12 @@ export default function CompareOffers() {
     setOffers(getOffers());
   };
 
-  const handleSelectOfferA = (event: SelectChangeEvent<string>) => {
-    setOfferAId(event.target.value);
+  const handleSelectOfferA = (event: SelectChangeEvent<unknown>) => {
+    setOfferAId(event.target.value as string);
   };
 
-  const handleSelectOfferB = (event: SelectChangeEvent<string>) => {
-    setOfferBId(event.target.value);
+  const handleSelectOfferB = (event: SelectChangeEvent<unknown>) => {
+    setOfferBId(event.target.value as string);
   };
 
   const handleCompare = async () => {
@@ -271,7 +271,7 @@ export default function CompareOffers() {
             fullWidth
             label="Offer A"
             value={offerAId}
-            onChange={handleSelectOfferA}
+            SelectProps={{ onChange: handleSelectOfferA }}
             helperText={hasEnoughOffers ? undefined : "Save at least two offers to compare."}
             disabled={offers.length === 0}
           >
@@ -286,7 +286,7 @@ export default function CompareOffers() {
             fullWidth
             label="Offer B"
             value={offerBId}
-            onChange={handleSelectOfferB}
+            SelectProps={{ onChange: handleSelectOfferB }}
             disabled={offers.length < 2}
           >
             {offers.map((offer, index) => (


### PR DESCRIPTION
## Summary
- update ApplicationDetailDrawer to wire select changes through TextField SelectProps and safely cast values
- adjust CompareOffers select handlers to use SelectProps and accept unknown change events

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbda5bec1483308b309f69e3fca106