### PR TITLE
Enhance TalentForge onboarding workflow

### DIFF
--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Box, Button, Step, StepLabel, Stepper, Typography } from "@mui/material";
 
 import {
@@ -10,17 +10,64 @@ import {
 } from "@/utils/talentforge/dataStore";
 
 import KeyEntryStep from "./onboarding/KeyEntryStep";
+import PersonalInfoStep from "./onboarding/PersonalInfoStep";
 import ResumeImportStep from "./onboarding/ResumeImportStep";
+import ResumePreviewStep from "./onboarding/ResumePreviewStep";
 import ConnectorMockStep from "./onboarding/ConnectorMockStep";
+import DemoDataStep from "./onboarding/DemoDataStep";
 import CompensationStep from "./onboarding/CompensationStep";
 import GoalSelectionStep from "./onboarding/GoalSelectionStep";
 
-const steps = [
-  { label: "Enter API Key", Component: KeyEntryStep },
-  { label: "Import Resume", Component: ResumeImportStep },
-  { label: "Connect Accounts", Component: ConnectorMockStep },
-  { label: "Enter Compensation", Component: CompensationStep },
-  { label: "Select Goals", Component: GoalSelectionStep },
+type OnboardingStepComponent = (props: {
+  onNext: () => void;
+  onBack?: () => void;
+}) => JSX.Element;
+
+const steps: Array<{
+  label: string;
+  ariaLabel: string;
+  Component: OnboardingStepComponent;
+}> = [
+  {
+    label: "Connect OpenAI",
+    ariaLabel: "Step 1 of 8: Connect your OpenAI API key",
+    Component: KeyEntryStep,
+  },
+  {
+    label: "Add Your Name",
+    ariaLabel: "Step 2 of 8: Provide your first and last name",
+    Component: PersonalInfoStep,
+  },
+  {
+    label: "Upload Resume",
+    ariaLabel: "Step 3 of 8: Upload your resume",
+    Component: ResumeImportStep,
+  },
+  {
+    label: "Review Resume",
+    ariaLabel: "Step 4 of 8: Review your imported resume",
+    Component: ResumePreviewStep,
+  },
+  {
+    label: "Sync Connectors",
+    ariaLabel: "Step 5 of 8: Sync the mock connector",
+    Component: ConnectorMockStep,
+  },
+  {
+    label: "Demo Data",
+    ariaLabel: "Step 6 of 8: Toggle demo data",
+    Component: DemoDataStep,
+  },
+  {
+    label: "Current Compensation",
+    ariaLabel: "Step 7 of 8: Enter your current compensation",
+    Component: CompensationStep,
+  },
+  {
+    label: "Choose Goals",
+    ariaLabel: "Step 8 of 8: Choose your goals",
+    Component: GoalSelectionStep,
+  },
 ];
 
 export const TOTAL_ONBOARDING_STEPS = steps.length;
@@ -61,27 +108,56 @@ export default function OnboardingStepper({
   };
 
   const Current = steps[activeStep]?.Component;
+  const stepLabelId =
+    activeStep < steps.length
+      ? `onboarding-step-label-${activeStep}`
+      : undefined;
+  const stepPanelId =
+    activeStep < steps.length
+      ? `onboarding-step-panel-${activeStep}`
+      : undefined;
+
+  const stepperAriaLabel = useMemo(
+    () => `TalentForge onboarding progress, step ${Math.min(activeStep + 1, steps.length)} of ${steps.length}`,
+    [activeStep],
+  );
 
   return (
     <Box>
-      <Stepper activeStep={activeStep} alternativeLabel aria-label="Onboarding steps">
-        {steps.map((step) => (
-          <Step key={step.label}>
-            <StepLabel aria-label={step.label}>{step.label}</StepLabel>
+      <Stepper
+        component="nav"
+        activeStep={activeStep}
+        alternativeLabel
+        aria-label={stepperAriaLabel}
+      >
+        {steps.map((step, index) => (
+          <Step key={step.label} aria-label={step.ariaLabel}>
+            <StepLabel
+              id={`onboarding-step-label-${index}`}
+              aria-label={step.ariaLabel}
+              aria-current={activeStep === index ? "step" : undefined}
+            >
+              {step.label}
+            </StepLabel>
           </Step>
         ))}
       </Stepper>
       {activeStep === steps.length ? (
-        <Box sx={{ mt: 2 }}>
+        <Box sx={{ mt: 3 }} role="status" aria-live="polite">
           <Typography tabIndex={0}>
-            All steps completed - you&apos;re finished
+            All steps completed — you&apos;re ready to explore TalentForge.
           </Typography>
-          <Button sx={{ mt: 1 }} onClick={handleReset} aria-label="Reset">
+          <Button sx={{ mt: 1 }} onClick={handleReset} aria-label="Restart onboarding">
             Reset
           </Button>
         </Box>
       ) : (
-        <Box sx={{ mt: 2 }}>
+        <Box
+          sx={{ mt: 3 }}
+          role="region"
+          id={stepPanelId}
+          aria-labelledby={stepLabelId}
+        >
           {Current && <Current onNext={handleNext} onBack={handleBack} />}
         </Box>
       )}

--- a/src/components/talentforge/onboarding/ConnectorMockStep.tsx
+++ b/src/components/talentforge/onboarding/ConnectorMockStep.tsx
@@ -33,19 +33,30 @@ export default function ConnectorMockStep({ onNext, onBack }: StepProps) {
   };
 
   return (
-    <Stack spacing={2} aria-label="Connect accounts">
-      <Typography aria-label="Connection status">
-        {token ? `Connected: ${token.accessToken}` : "Not connected"}
+    <Stack spacing={2} aria-label="Sync mock connector">
+      <Typography variant="body1">
+        Sync the mock connector to simulate pulling recruiter conversations and
+        offers into TalentForge.
       </Typography>
-      {token ? (
-        <Button onClick={handleDisconnect} aria-label="Disconnect">
-          Disconnect
+      <Typography aria-live="polite">
+        {token
+          ? "Mock connector synced. You can resync or disconnect if needed."
+          : "Mock connector not yet synced."}
+      </Typography>
+      <Stack direction="row" spacing={1}>
+        <Button
+          onClick={handleConnect}
+          aria-label={token ? "Resync mock connector" : "Sync mock connector"}
+          variant="outlined"
+        >
+          {token ? "Resync Mock Connector" : "Sync Mock Connector"}
         </Button>
-      ) : (
-        <Button onClick={handleConnect} aria-label="Connect">
-          Generate Token
-        </Button>
-      )}
+        {token && (
+          <Button onClick={handleDisconnect} aria-label="Disconnect mock connector">
+            Disconnect
+          </Button>
+        )}
+      </Stack>
       <Stack direction="row" spacing={1}>
         {onBack && (
           <Button onClick={onBack} aria-label="Back">

--- a/src/components/talentforge/onboarding/DemoDataStep.tsx
+++ b/src/components/talentforge/onboarding/DemoDataStep.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useState, type ChangeEvent } from "react";
+import { Button, FormControlLabel, Stack, Switch, Typography } from "@mui/material";
+
+import { clearDemoData, loadDemoData } from "@/utils/talentforge/demoData";
+
+interface StepProps {
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+const DEMO_DATA_FLAG = "tf_demo_data_inserted";
+
+const readDemoFlag = () =>
+  typeof window !== "undefined" &&
+  window.localStorage.getItem(DEMO_DATA_FLAG) === "true";
+
+export default function DemoDataStep({ onNext, onBack }: StepProps) {
+  const [demoEnabled, setDemoEnabled] = useState(readDemoFlag);
+
+  const handleToggle = useCallback(
+    (_event: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+      if (checked) {
+        loadDemoData();
+      } else {
+        clearDemoData();
+      }
+      setDemoEnabled(checked);
+    },
+    [],
+  );
+
+  return (
+    <Stack spacing={2} aria-label="Toggle demo data">
+      <Typography variant="body1">
+        Load demo data to see how TalentForge works with sample resumes and job
+        applications. You can turn it off at any time.
+      </Typography>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={demoEnabled}
+            onChange={handleToggle}
+            inputProps={{ "aria-label": "Enable demo data" }}
+          />
+        }
+        label={demoEnabled ? "Demo data enabled" : "Demo data disabled"}
+      />
+      <Typography variant="body2" color="text.secondary">
+        Disabling demo data removes the sample user profile, resumes, offers,
+        and applications so you can start fresh with your own information.
+      </Typography>
+      <Stack direction="row" spacing={1}>
+        {onBack && (
+          <Button onClick={onBack} aria-label="Back">
+            Back
+          </Button>
+        )}
+        <Button variant="contained" onClick={onNext} aria-label="Continue">
+          Continue
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/talentforge/onboarding/GoalSelectionStep.tsx
+++ b/src/components/talentforge/onboarding/GoalSelectionStep.tsx
@@ -1,76 +1,118 @@
 "use client";
 
-import { useState } from "react";
-import { Button, Checkbox, FormControlLabel, Stack } from "@mui/material";
+import { useMemo, useState, type ChangeEvent } from "react";
+import {
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Stack,
+  Typography,
+} from "@mui/material";
+
+import type { TalentForgeGoalTag } from "@/utils/talentforge/promptRegistry";
+import {
+  getSelectedGoals,
+  saveSelectedGoals,
+} from "@/utils/talentforge/dataStore";
 
 interface StepProps {
   onNext: () => void;
   onBack?: () => void;
 }
 
-export default function GoalSelectionStep({ onNext, onBack }: StepProps) {
-  const [goals, setGoals] = useState({
-    resume: false,
-    networking: false,
-    search: false,
-  });
+const GOAL_OPTIONS: Array<{
+  key: TalentForgeGoalTag;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "resume",
+    label: "Polish my resume",
+    description: "Highlight achievements, tailor bullets, and generate summaries.",
+  },
+  {
+    key: "networking",
+    label: "Grow my network",
+    description: "Draft recruiter outreach, follow-up nudges, and elevator pitches.",
+  },
+  {
+    key: "search",
+    label: "Accelerate my job search",
+    description: "Analyze job descriptions, prep for interviews, and compare offers.",
+  },
+];
 
-  const handleChange = (key: "resume" | "networking" | "search") => (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setGoals((g) => ({ ...g, [key]: event.target.checked }));
+export default function GoalSelectionStep({ onNext, onBack }: StepProps) {
+  const initialGoals = useMemo(() => getSelectedGoals(), []);
+  const [selectedGoals, setSelectedGoals] = useState<TalentForgeGoalTag[]>(
+    initialGoals,
+  );
+
+  const handleChange = (goal: TalentForgeGoalTag) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const { checked } = event.target;
+      setSelectedGoals((current) => {
+        if (checked) {
+          return current.includes(goal) ? current : [...current, goal];
+        }
+        return current.filter((item) => item !== goal);
+      });
+    };
+
+  const handleFinish = () => {
+    const orderedGoals = GOAL_OPTIONS.map((option) => option.key).filter((key) =>
+      selectedGoals.includes(key),
+    );
+    saveSelectedGoals(orderedGoals);
+    onNext();
   };
 
-  const hasGoal = Object.values(goals).some(Boolean);
+  const hasGoal = selectedGoals.length > 0;
 
   return (
     <Stack spacing={2} aria-label="Select goals">
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={goals.resume}
-              onChange={handleChange("resume")}
-              inputProps={{ "aria-label": "Improve resume" }}
-            />
-          }
-          label="Improve resume"
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={goals.networking}
-              onChange={handleChange("networking")}
-              inputProps={{ "aria-label": "Enhance networking" }}
-            />
-          }
-          label="Enhance networking"
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={goals.search}
-              onChange={handleChange("search")}
-              inputProps={{ "aria-label": "Streamline job search" }}
-            />
-          }
-          label="Streamline job search"
-        />
-        <Stack direction="row" spacing={1}>
-          {onBack && (
-            <Button onClick={onBack} aria-label="Back">
-              Back
-            </Button>
-          )}
-          <Button
-            variant="contained"
-            onClick={onNext}
-            disabled={!hasGoal}
-            aria-label="Finish"
-          >
-            Finish
-          </Button>
-        </Stack>
+      <Typography variant="body1">
+        Choose the outcomes you care about most. We&apos;ll highlight prompts that
+        match these goals throughout TalentForge.
+      </Typography>
+      <Stack spacing={1} role="group" aria-label="Goal options">
+        {GOAL_OPTIONS.map((option) => (
+          <FormControlLabel
+            key={option.key}
+            control={
+              <Checkbox
+                checked={selectedGoals.includes(option.key)}
+                onChange={handleChange(option.key)}
+                inputProps={{ "aria-label": option.label }}
+              />
+            }
+            label={
+              <Stack spacing={0.5}>
+                <Typography variant="subtitle1">{option.label}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {option.description}
+                </Typography>
+              </Stack>
+            }
+          />
+        ))}
       </Stack>
+      <Stack direction="row" spacing={1}>
+        {onBack && (
+          <Button onClick={onBack} aria-label="Back">
+            Back
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          onClick={handleFinish}
+          disabled={!hasGoal}
+          aria-label="Finish onboarding"
+        >
+          Finish
+        </Button>
+      </Stack>
+    </Stack>
   );
 }
 

--- a/src/components/talentforge/onboarding/PersonalInfoStep.tsx
+++ b/src/components/talentforge/onboarding/PersonalInfoStep.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button, Stack, TextField, Typography } from "@mui/material";
+import { v4 as uuid } from "uuid";
+
+import type { UserProfile } from "@/utils/talentforge/dataStore";
+import { getUserProfile, saveUserProfile } from "@/utils/talentforge/dataStore";
+
+interface StepProps {
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+const deriveNameParts = (profile: UserProfile | undefined) => {
+  const first = profile?.firstName?.trim();
+  const last = profile?.lastName?.trim();
+  if (first || last) {
+    return {
+      firstName: first ?? "",
+      lastName: last ?? "",
+    };
+  }
+  const parts = profile?.name?.trim().split(/\s+/) ?? [];
+  if (parts.length === 0) {
+    return { firstName: "", lastName: "" };
+  }
+  const [derivedFirst, ...rest] = parts;
+  return {
+    firstName: derivedFirst ?? "",
+    lastName: rest.join(" ") ?? "",
+  };
+};
+
+export default function PersonalInfoStep({ onNext, onBack }: StepProps) {
+  const initialProfile = useMemo(() => getUserProfile(), []);
+  const [profileId] = useState(() => initialProfile?.id ?? uuid());
+  const initialNames = useMemo(
+    () => deriveNameParts(initialProfile),
+    [initialProfile],
+  );
+  const [firstName, setFirstName] = useState(initialNames.firstName);
+  const [lastName, setLastName] = useState(initialNames.lastName);
+
+  const handleContinue = () => {
+    const trimmedFirst = firstName.trim();
+    const trimmedLast = lastName.trim();
+    const latestProfile = getUserProfile();
+    const baseProfile: UserProfile = latestProfile ?? {
+      id: profileId,
+      name: "",
+      email: "",
+    };
+
+    const updatedProfile: UserProfile = {
+      ...baseProfile,
+      id: baseProfile.id || profileId,
+      email: baseProfile.email ?? "",
+      name: `${trimmedFirst} ${trimmedLast}`.trim(),
+      firstName: trimmedFirst,
+      lastName: trimmedLast,
+    };
+
+    saveUserProfile(updatedProfile);
+    onNext();
+  };
+
+  const canContinue = firstName.trim().length > 0 && lastName.trim().length > 0;
+
+  return (
+    <Stack spacing={2} aria-label="Provide your name">
+      <Typography variant="body1">
+        We&apos;ll use your name to personalize prompt outputs like cover letters
+        and outreach messages.
+      </Typography>
+      <TextField
+        label="First Name"
+        aria-label="First name"
+        value={firstName}
+        onChange={(event) => setFirstName(event.target.value)}
+        autoComplete="given-name"
+        autoFocus
+      />
+      <TextField
+        label="Last Name"
+        aria-label="Last name"
+        value={lastName}
+        onChange={(event) => setLastName(event.target.value)}
+        autoComplete="family-name"
+      />
+      <Stack direction="row" spacing={1}>
+        {onBack && (
+          <Button onClick={onBack} aria-label="Back">
+            Back
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          onClick={handleContinue}
+          disabled={!canContinue}
+          aria-label="Continue"
+        >
+          Continue
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/talentforge/onboarding/ResumePreviewStep.tsx
+++ b/src/components/talentforge/onboarding/ResumePreviewStep.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useMemo } from "react";
+import { Alert, Box, Button, Paper, Stack, Typography } from "@mui/material";
+
+import type { ResumeEntry } from "@/types";
+import { getResumes } from "@/utils/talentforge/dataStore";
+
+interface StepProps {
+  onNext: () => void;
+  onBack?: () => void;
+}
+
+const formatTimestamp = (value?: string) => {
+  if (!value) return "Unknown import time";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown import time";
+  }
+  return date.toLocaleString();
+};
+
+const buildPreview = (resume: ResumeEntry) => {
+  const text = resume.content?.trim() ?? "";
+  if (!text) return "No extracted text available.";
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  return lines.slice(0, 12).join("\n");
+};
+
+export default function ResumePreviewStep({ onNext, onBack }: StepProps) {
+  const resumes = useMemo(() => getResumes(), []);
+  const hasResume = resumes.length > 0;
+  const primaryResume = resumes[0];
+
+  return (
+    <Stack spacing={2} aria-label="Review uploaded resume">
+      <Typography variant="body1">
+        Confirm that we captured the correct resume details. You can re-upload
+        if something looks off.
+      </Typography>
+      {!hasResume ? (
+        <Alert severity="warning" role="status">
+          No resume has been imported yet. Go back to upload one before
+          continuing.
+        </Alert>
+      ) : (
+        <Paper variant="outlined" sx={{ p: 2 }} aria-live="polite">
+          <Stack spacing={1}>
+            <Typography variant="h6" component="h3">
+              {primaryResume.title || primaryResume.label || "Imported Resume"}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Source file: {primaryResume.sourceFilename || "Unknown"}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Imported: {formatTimestamp(primaryResume.importedAt)}
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                bgcolor: "background.default",
+                borderRadius: 1,
+                p: 2,
+                overflow: "auto",
+                maxHeight: 240,
+                whiteSpace: "pre-wrap",
+              }}
+              aria-label="Resume text preview"
+            >
+              {buildPreview(primaryResume)}
+            </Box>
+          </Stack>
+        </Paper>
+      )}
+      <Stack direction="row" spacing={1}>
+        {onBack && (
+          <Button onClick={onBack} aria-label="Back">
+            Back
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          onClick={onNext}
+          disabled={!hasResume}
+          aria-label="Continue"
+        >
+          Looks good
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/types/talentforge/models.ts
+++ b/src/types/talentforge/models.ts
@@ -17,6 +17,10 @@ export interface User {
   id: string;
   /** User's full name. */
   name: string;
+  /** User's given name captured during onboarding. */
+  firstName?: string;
+  /** User's family name captured during onboarding. */
+  lastName?: string;
   /** Email address for contacting the user. */
   email: string;
   /** Resume variants owned by the user. Optional because not all users upload resumes. */

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -22,6 +22,7 @@ import type {
   RecruiterEntry,
 } from "@/types";
 import { AUTO_REPLY_TEMPLATES } from "@/utils/autoReply/templates";
+import type { TalentForgeGoalTag } from "./promptRegistry";
 
 export type UserProfile = User;
 
@@ -45,6 +46,7 @@ interface StoreSchema {
   connectorTokens: Record<string, ConnectorToken>;
   autoReplyTemplates: Record<string, string>;
   currentCompensation: CurrentCompensation;
+  goalSelections: TalentForgeGoalTag[];
 }
 
 // Storage keys for each entity
@@ -60,6 +62,7 @@ const KEYS: { [K in keyof StoreSchema]: string } = {
   connectorTokens: "connectorTokens",
   autoReplyTemplates: "autoReplyTemplates",
   currentCompensation: "currentCompensation",
+  goalSelections: "talentforge-goal-selections",
 } as const;
 
 // Version constants per entity so tests and other modules can reference them.
@@ -74,6 +77,7 @@ export const OPENAI_VERSION = 1;
 export const CONNECTOR_TOKENS_VERSION = 1;
 export const AUTO_REPLY_TEMPLATES_VERSION = 1;
 export const CURRENT_COMP_VERSION = 1;
+export const GOAL_SELECTIONS_VERSION = 1;
 
 const VERSION: { [K in keyof StoreSchema]: number } = {
   user: USER_VERSION,
@@ -87,6 +91,7 @@ const VERSION: { [K in keyof StoreSchema]: number } = {
   connectorTokens: CONNECTOR_TOKENS_VERSION,
   autoReplyTemplates: AUTO_REPLY_TEMPLATES_VERSION,
   currentCompensation: CURRENT_COMP_VERSION,
+  goalSelections: GOAL_SELECTIONS_VERSION,
 } as const;
 
 export const SNAPSHOT_VERSION = 4;
@@ -211,6 +216,35 @@ function migrateCurrentCompensation(
   );
 }
 
+function migrateGoalSelections(
+  data: unknown,
+  version: number,
+): TalentForgeGoalTag[] {
+  return migrate<TalentForgeGoalTag[]>(
+    data,
+    version,
+    GOAL_SELECTIONS_VERSION,
+    {
+      0: (d) => {
+        if (!Array.isArray(d)) return [];
+        const validTags: TalentForgeGoalTag[] = [];
+        for (const value of d) {
+          if (
+            value === "resume" ||
+            value === "networking" ||
+            value === "search"
+          ) {
+            if (!validTags.includes(value)) {
+              validTags.push(value);
+            }
+          }
+        }
+        return validTags;
+      },
+    },
+  );
+}
+
 const MIGRATORS: {
   [K in keyof StoreSchema]: (
     data: unknown,
@@ -228,6 +262,7 @@ const MIGRATORS: {
   connectorTokens: migrateConnectorTokens,
   autoReplyTemplates: migrateAutoReplyTemplates,
   currentCompensation: migrateCurrentCompensation,
+  goalSelections: migrateGoalSelections,
 };
 
 const DEFAULTS: { [K in keyof StoreSchema]: StoreSchema[K] } = {
@@ -242,6 +277,7 @@ const DEFAULTS: { [K in keyof StoreSchema]: StoreSchema[K] } = {
   connectorTokens: {},
   autoReplyTemplates: AUTO_REPLY_TEMPLATES as Record<string, string>,
   currentCompensation: { salary: "", benefits: "", stock: "" },
+  goalSelections: [],
 } as const;
 
 function load<K extends keyof StoreSchema>(
@@ -353,6 +389,17 @@ export function getCurrentCompensation(): CurrentCompensation {
 }
 export function saveCurrentCompensation(comp: CurrentCompensation): void {
   save("currentCompensation", comp);
+}
+
+export function getSelectedGoals(): TalentForgeGoalTag[] {
+  return load("goalSelections", []);
+}
+export function saveSelectedGoals(goals: TalentForgeGoalTag[]): void {
+  const allowed = new Set<TalentForgeGoalTag>(["resume", "networking", "search"]);
+  const unique = goals.filter(
+    (goal, index) => allowed.has(goal) && goals.indexOf(goal) === index,
+  );
+  save("goalSelections", unique);
 }
 
 // Resumes
@@ -927,6 +974,8 @@ const dataStore = {
   saveUserProfile,
   getCurrentCompensation,
   saveCurrentCompensation,
+  getSelectedGoals,
+  saveSelectedGoals,
   getResumes,
   saveResumes,
   addResume,

--- a/src/utils/talentforge/demoData.ts
+++ b/src/utils/talentforge/demoData.ts
@@ -9,6 +9,8 @@ import type {
 } from "@/types";
 import dataStore from "./dataStore";
 
+const DEMO_DATA_FLAG = "tf_demo_data_inserted";
+
 /**
  * Generate a small set of demo data for TalentForge.
  */
@@ -75,6 +77,9 @@ export function loadDemoData(): void {
   dataStore.saveUserProfile(user);
   dataStore.saveResumes(resumes);
   jobApplications.forEach((app) => dataStore.addJobApplication(app));
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(DEMO_DATA_FLAG, "true");
+  }
 }
 
 /**
@@ -87,7 +92,7 @@ export function clearDemoData(): void {
     window.localStorage.removeItem("resumes");
     window.localStorage.removeItem("jobApplications");
     window.localStorage.removeItem("offers");
-    window.localStorage.removeItem("tf_demo_data_inserted");
+    window.localStorage.removeItem(DEMO_DATA_FLAG);
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the onboarding stepper to cover personal info, resume review, connector syncing, demo data, and goal selection with improved accessibility copy
- add dedicated steps for capturing a user name, reviewing imported resumes, and toggling demo data alongside refreshed connector messaging
- persist selected goals and onboarding profile details in the data store to support personalized prompt experiences

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc05100fac8330acd203fc5ad36c24