### PR TITLE
Include offer context in AI analysis prompt

### DIFF
--- a/src/components/talentforge/OfferCompare.tsx
+++ b/src/components/talentforge/OfferCompare.tsx
@@ -56,7 +56,7 @@ export default function OfferCompare({ onSave }: OfferCompareProps) {
   const analyzeOffer = async () => {
     const context = `Offer Letter:\n${offerText}\n\nCurrent Compensation:\n${compensation}`;
     const prompt =
-      "Compare the offer letter to the current compensation and summarize key differences. " +
+      "Using the provided offer and compensation context, compare the offer letter to the current compensation and summarize key differences. " +
       "Then draft professional replies for email, LinkedIn, and Indeed. " +
       "Respond in JSON with keys analysis, email, linkedin, indeed.";
     setLoading(true);

--- a/src/components/talentforge/offerAnalysis.ts
+++ b/src/components/talentforge/offerAnalysis.ts
@@ -38,7 +38,12 @@ export async function analyzeOfferWithAI({
     const response = await ask({
       context,
       user: prompt,
-      system: "You analyze offers and produce structured response drafts.",
+      system:
+        [
+          "You analyze offers and produce structured response drafts.",
+          "Use the following offer and compensation details as context:",
+          "{{context}}",
+        ].join("\n\n"),
       chatHistory: [],
       returnFirstResponse: true,
     });

--- a/src/tests/talentforge/OfferCompare.test.ts
+++ b/src/tests/talentforge/OfferCompare.test.ts
@@ -1,6 +1,83 @@
 import { analyzeOfferWithAI } from "@/components/talentforge/offerAnalysis";
+import type { AskOpenAIFunc } from "@/utils/talentforge/utils";
 
 describe("OfferCompare analyzeOfferWithAI", () => {
+  it("passes offer context into the OpenAI system message and updates drafts", async () => {
+    const setAnalysis = jest.fn();
+    const setDrafts = jest.fn();
+    const setError = jest.fn();
+    const setLoading = jest.fn();
+    const addOfferFn = jest.fn();
+    const onSave = jest.fn();
+
+    let capturedSystemMessage = "";
+    const askMock = jest.fn(async ({
+      context,
+      user,
+      system,
+    }: Parameters<AskOpenAIFunc>[0]) => {
+      capturedSystemMessage = `Question: ${user}\n\n${system.replaceAll("{{context}}", context)}`;
+      return {
+        message: JSON.stringify({
+          analysis: "New analysis",
+          email: "Email draft",
+          linkedin: "LinkedIn draft",
+          indeed: "Indeed draft",
+        }),
+      };
+    });
+    const ask = askMock as unknown as AskOpenAIFunc;
+
+    const offerText = "Offer letter content";
+    const compensationDetails = "Compensation breakdown";
+    const context = `Offer Letter:\n${offerText}\n\nCurrent Compensation:\n${compensationDetails}`;
+
+    await analyzeOfferWithAI({
+      context,
+      prompt: "Prompt instructions",
+      compensation: compensationDetails,
+      setAnalysis,
+      setDrafts,
+      setError,
+      setLoading,
+      onSave,
+      ask,
+      addOfferFn,
+    });
+
+    expect(askMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context,
+      }),
+    );
+    expect(capturedSystemMessage).toContain(offerText);
+    expect(capturedSystemMessage).toContain(compensationDetails);
+    expect(setAnalysis).toHaveBeenCalledWith("New analysis");
+    expect(setDrafts).toHaveBeenCalledWith({
+      email: "Email draft",
+      linkedin: "LinkedIn draft",
+      indeed: "Indeed draft",
+    });
+    expect(addOfferFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        compensation: [
+          expect.objectContaining({
+            notes: compensationDetails,
+          }),
+        ],
+        summary: expect.arrayContaining([
+          expect.stringContaining("New analysis"),
+          expect.stringContaining("Email draft"),
+          expect.stringContaining("LinkedIn draft"),
+          expect.stringContaining("Indeed draft"),
+        ]),
+      }),
+    );
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(setError).not.toHaveBeenCalled();
+    expect(setLoading).toHaveBeenCalledWith(false);
+  });
+
   it("clears loading and surfaces an error when the analysis fails", async () => {
     const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
     const setAnalysis = jest.fn();


### PR DESCRIPTION
## Summary
- embed the uploaded offer text and compensation details into the system prompt sent to OpenAI so the analysis has access to that context
- update the OfferCompare prompt copy to reference the provided context
- add a unit test that covers the happy path and verifies the OpenAI request sees the offer context while state updates are emitted

## Testing
- `npm run test -- OfferCompare`


------
https://chatgpt.com/codex/tasks/task_e_68cc08ddbf4483309764a9370c579706