### PR TITLE
Fix onboarding step component type

### DIFF
--- a/src/components/talentforge/OnboardingStepper.tsx
+++ b/src/components/talentforge/OnboardingStepper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ComponentType } from "react";
 import { Box, Button, Step, StepLabel, Stepper, Typography } from "@mui/material";
 
 import {
@@ -18,10 +18,10 @@ import DemoDataStep from "./onboarding/DemoDataStep";
 import CompensationStep from "./onboarding/CompensationStep";
 import GoalSelectionStep from "./onboarding/GoalSelectionStep";
 
-type OnboardingStepComponent = (props: {
+type OnboardingStepComponent = ComponentType<{
   onNext: () => void;
   onBack?: () => void;
-}) => JSX.Element;
+}>;
 
 const steps: Array<{
   label: string;


### PR DESCRIPTION
## Summary
- update the onboarding step component type definition to use React's `ComponentType`, removing the JSX namespace dependency

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc0a5baf9c8330a0aeddfed7232507