### PR TITLE
Add OpenAI key interstitial for TalentForge onboarding

### DIFF
--- a/src/app/bookworm/page.tsx
+++ b/src/app/bookworm/page.tsx
@@ -6,10 +6,6 @@ import CssBaseline from "@mui/material/CssBaseline";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import Container from "@mui/material/Container";
-import TextField from "@mui/material/TextField";
-import Button from "@mui/material/Button";
-import Typography from "@mui/material/Typography";
 import AppAppBar from "@/components/bookworm/AppAppBar";
 import Hero from "@/components/bookworm/Hero";
 import Highlights from "@/components/bookworm/Highlights";
@@ -27,13 +23,14 @@ import "@fontsource/roboto/700.css";
 
 import "./page.css"; // Ensure global styles are applied
 import { hasOpenAIKey, setOpenAIKey } from "@/utils/bookworm/utils";
-import Image from "next/image";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import OpenAIKeyInterstitialContent from "@/components/OpenAIKeyInterstitialContent";
 
 export default function BookwormPage() {
   const [mode, setMode] = React.useState<PaletteMode>("light");
   const defaultTheme = createTheme({ palette: { mode } });
   const [apiKeyReady, setApiKeyReady] = React.useState(hasOpenAIKey());
+  const [draftKey, setDraftKey] = React.useState("");
   const { setDocumentTitle } = useDocumentTitle();
 
   React.useEffect(() => {
@@ -46,11 +43,11 @@ export default function BookwormPage() {
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const key = String(formData.get("apiKey"))?.trim();
+    const key = draftKey.trim();
     if (key) {
       setOpenAIKey(key);
       setApiKeyReady(true);
+      setDraftKey(key);
     }
   };
 
@@ -58,37 +55,13 @@ export default function BookwormPage() {
     return (
       <ThemeProvider theme={defaultTheme}>
         <CssBaseline />
-        <Container component="main" maxWidth="sm" sx={{ mt: 8, mb: 4 }}>
-          <Image
-            src="/logo192.png"
-            style={{ width: "192px", height: "auto" }}
-            alt="bookworm logo"
-            width={192}
-            height={194}
-          />
-          <Typography variant="h4" component="h1" gutterBottom>
-            Welcome to Bookworm
-          </Typography>
-          <Typography variant="body1" paragraph>
-            Bookworm needs an OpenAI API key to talk with OpenAI. The key you
-            type here goes straight from your browser to OpenAI and stays
-            between you and OpenAI. Bookworm does not store your key anywhere
-            and does not send it anywhere else. If you do not fully trust
-            Bookworm, do not enter your key.
-          </Typography>
-          <Box component="form" onSubmit={handleSubmit}>
-            <TextField
-              label="OpenAI API Key"
-              name="apiKey"
-              type="password"
-              fullWidth
-              required
-            />
-            <Button type="submit" variant="contained" sx={{ mt: 2 }}>
-              Continue
-            </Button>
-          </Box>
-        </Container>
+        <OpenAIKeyInterstitialContent
+          appName="Bookworm"
+          logoAlt="Bookworm logo"
+          value={draftKey}
+          onChange={setDraftKey}
+          onSubmit={handleSubmit}
+        />
       </ThemeProvider>
     );
   }

--- a/src/app/talentforge/page.tsx
+++ b/src/app/talentforge/page.tsx
@@ -3,21 +3,28 @@
 import React from "react";
 import Dashboard from "@/components/talentforge/Dashboard";
 import ErrorBoundary from "@/components/talentforge/ErrorBoundary";
+import OpenAIKeyInterstitial from "@/components/talentforge/OpenAIKeyInterstitial";
 import OnboardingStepper, {
   TOTAL_ONBOARDING_STEPS,
 } from "@/components/talentforge/OnboardingStepper";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useOpenAIKey } from "@/contexts/OpenAIKeyContext";
 import insertMockData from "@/utils/mockData";
 import { getOnboardingStep } from "@/utils/talentforge/dataStore";
 
 export default function TalentForgePage() {
   const { setDocumentTitle } = useDocumentTitle();
   const [step, setStep] = React.useState(getOnboardingStep());
+  const { hasKey } = useOpenAIKey();
 
   React.useEffect(() => {
     insertMockData();
     setDocumentTitle("TalentForge");
   }, [setDocumentTitle]);
+
+  if (!hasKey) {
+    return <OpenAIKeyInterstitial />;
+  }
 
   if (step < TOTAL_ONBOARDING_STEPS) {
     return <OnboardingStepper onComplete={() => setStep(TOTAL_ONBOARDING_STEPS)} />;

--- a/src/components/OpenAIKeyInterstitialContent.tsx
+++ b/src/components/OpenAIKeyInterstitialContent.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import Image from "next/image";
+
+export interface OpenAIKeyInterstitialContentProps {
+  appName: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  inputRef?: React.RefObject<HTMLInputElement>;
+  buttonLabel?: string;
+  logoSrc?: string;
+  logoAlt?: string;
+  textFieldName?: string;
+}
+
+export default function OpenAIKeyInterstitialContent({
+  appName,
+  value,
+  onChange,
+  onSubmit,
+  inputRef,
+  buttonLabel = "Continue",
+  logoSrc = "/logo192.png",
+  logoAlt,
+  textFieldName = "apiKey",
+}: OpenAIKeyInterstitialContentProps) {
+  const resolvedLogoAlt = logoAlt ?? `${appName} logo`;
+  const description = `${appName} needs an OpenAI API key to talk with OpenAI. The key you type here goes straight from your browser to OpenAI and stays between you and OpenAI. ${appName} does not store your key anywhere and does not send it anywhere else. If you do not fully trust ${appName}, do not enter your key.`;
+
+  return (
+    <Container component="main" maxWidth="sm" sx={{ mt: 8, mb: 4 }}>
+      <Image
+        src={logoSrc}
+        style={{ width: "192px", height: "auto" }}
+        alt={resolvedLogoAlt}
+        width={192}
+        height={194}
+      />
+      <Typography variant="h4" component="h1" gutterBottom>
+        {`Welcome to ${appName}`}
+      </Typography>
+      <Typography variant="body1" paragraph>
+        {description}
+      </Typography>
+      <Box component="form" onSubmit={onSubmit}>
+        <TextField
+          label="OpenAI API Key"
+          name={textFieldName}
+          type="password"
+          fullWidth
+          required
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          inputRef={inputRef}
+        />
+        <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+          {buttonLabel}
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/src/components/talentforge/OpenAIKeyInterstitial.tsx
+++ b/src/components/talentforge/OpenAIKeyInterstitial.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+
+import OpenAIKeyInterstitialContent from "@/components/OpenAIKeyInterstitialContent";
+import { useOpenAIKey } from "@/contexts/OpenAIKeyContext";
+
+export default function OpenAIKeyInterstitial() {
+  const { key, setKey } = useOpenAIKey();
+  const [value, setValue] = React.useState(key);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const previousFocusRef = React.useRef<Element | null>(null);
+
+  React.useEffect(() => {
+    setValue(key);
+  }, [key]);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    previousFocusRef.current = document.activeElement;
+    inputRef.current?.focus();
+
+    return () => {
+      const previous = previousFocusRef.current;
+      if (
+        previous &&
+        previous instanceof HTMLElement &&
+        typeof previous.focus === "function"
+      ) {
+        previous.focus();
+      }
+    };
+  }, []);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setKey(trimmed);
+    setValue(trimmed);
+  };
+
+  return (
+    <OpenAIKeyInterstitialContent
+      appName="TalentForge"
+      logoAlt="TalentForge logo"
+      value={value}
+      onChange={setValue}
+      onSubmit={handleSubmit}
+      inputRef={inputRef}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- extract the Bookworm API key prompt into a reusable interstitial component
- add a TalentForge wrapper that stores the key via OpenAIKeyContext and manages focus
- render the interstitial ahead of the onboarding stepper when no key is available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ce0f2e5083308a9e11952db535e8