### PR TITLE
Handle decimal amounts in offer parser

### DIFF
--- a/src/tests/talentforge/offerParser.test.ts
+++ b/src/tests/talentforge/offerParser.test.ts
@@ -14,4 +14,17 @@ describe("parseOfferText", () => {
     );
     expect(parsed.summary).toBeTruthy();
   });
+
+  it("supports decimal compensation amounts", () => {
+    const text = `Base Salary: $120,000.50\nAnnual Bonus: $5,000.75\nEquity: 1,000.25 RSUs`;
+    const parsed = parseOfferText(text);
+
+    expect(parsed.compensation).toEqual(
+      expect.arrayContaining([
+        { type: "base", amount: 120000.5 },
+        { type: "bonus", amount: 5000.75 },
+        { type: "equity", amount: 1000.25, notes: "RSUs" },
+      ]),
+    );
+  });
 });

--- a/src/utils/talentforge/offerParser.ts
+++ b/src/utils/talentforge/offerParser.ts
@@ -8,23 +8,34 @@ export interface ParsedOffer {
 }
 
 function extractAmount(value: string): number {
-  return Number(value.replace(/[^0-9]/g, ""));
+  const digitsAndDots = value.replace(/[^0-9.]/g, "");
+  const firstDecimalIndex = digitsAndDots.indexOf(".");
+
+  let normalized = digitsAndDots;
+  if (firstDecimalIndex !== -1) {
+    normalized =
+      digitsAndDots.slice(0, firstDecimalIndex + 1) +
+      digitsAndDots.slice(firstDecimalIndex + 1).replace(/\./g, "");
+  }
+
+  const amount = parseFloat(normalized);
+  return Number.isNaN(amount) ? 0 : amount;
 }
 
 export function parseOfferText(text: string): ParsedOffer {
   const comps: OfferComp[] = [];
 
-  const base = /base\s+salary[^$]*\$?([0-9,]+)/i.exec(text);
+  const base = /base\s+salary[^$]*\$?([0-9,]+(?:\.[0-9]+)?)/i.exec(text);
   if (base) {
     comps.push({ type: "base", amount: extractAmount(base[1]) });
   }
 
-  const bonus = /bonus[^$]*\$?([0-9,]+)/i.exec(text);
+  const bonus = /bonus[^$]*\$?([0-9,]+(?:\.[0-9]+)?)/i.exec(text);
   if (bonus) {
     comps.push({ type: "bonus", amount: extractAmount(bonus[1]) });
   }
 
-  const equity = /equity[^0-9]*([0-9,]+)\s*(RSUs|shares|options)?/i.exec(text);
+  const equity = /equity[^0-9]*([0-9,]+(?:\.[0-9]+)?)\s*(RSUs|shares|options)?/i.exec(text);
   if (equity) {
     comps.push({
       type: "equity",


### PR DESCRIPTION
## Summary
- ensure offer amount extraction preserves a single decimal and defaults invalid values to 0
- update compensation matching to capture decimal amounts across base, bonus, and equity fields
- add unit test coverage confirming decimal compensation parsing

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d1d051f15483308576cb1f0e6d9fce