### PR TITLE
Fix contact email display in terms dialog

### DIFF
--- a/src/components/talentforge/TermsDialog.tsx
+++ b/src/components/talentforge/TermsDialog.tsx
@@ -76,7 +76,7 @@ By accessing or using TalentForge, you agree to be bound by these Terms of Use. 
 
 ### 8. Contact Us
 
-- If you have any questions about these Terms of Use, please contact us at [richardfrankskr@hotmail.com](mailto:richardfranksjr@hotmail.com).
+- If you have any questions about these Terms of Use, please contact us at [richardfranksjr@hotmail.com](mailto:richardfranksjr@hotmail.com).
 `;
 
 export interface TermsDialogProps


### PR DESCRIPTION
## Summary
- update the visible contact email in the terms dialog to match the existing mailto link

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1d04efdb483308f902eda543258be