### PR TITLE
Add connector snapshot storage and types

### DIFF
--- a/src/tests/talentforge/dataStore.test.ts
+++ b/src/tests/talentforge/dataStore.test.ts
@@ -9,9 +9,19 @@ import {
   saveCurrentCompensation,
   getGoals,
   setGoals,
+  CONNECTOR_SYNC_SNAPSHOT_VERSION,
+  LINKEDIN_PROFILE_SNAPSHOT_VERSION,
+  getConnectorSyncSnapshot,
+  saveConnectorSyncSnapshot,
+  getLinkedInProfileSnapshot,
+  saveLinkedInProfileSnapshot,
 } from "../../utils/talentforge/dataStore";
 import { loadItem, saveItem } from "../../utils/storage";
-import type { ResumeEntry } from "../../types";
+import type {
+  ResumeEntry,
+  ConnectorSyncSnapshot,
+  LinkedInProfileSnapshot,
+} from "../../types";
 
 interface Message {
   replies: { body: string }[];
@@ -86,6 +96,30 @@ describe("dataStore migrations", () => {
     expect(getGoals()).toEqual(["resume", "networking"]);
   });
 
+  test("importFromJson populates connector snapshot defaults", () => {
+    const snapshot = {
+      version: 5,
+      data: {},
+    };
+
+    importFromJson(JSON.stringify(snapshot));
+
+    const connectorSync = loadItem<ConnectorSyncSnapshot>(
+      "connectorSyncSnapshot",
+      CONNECTOR_SYNC_SNAPSHOT_VERSION,
+    )!;
+    expect(connectorSync).toEqual({});
+
+    const linkedinProfile = loadItem<LinkedInProfileSnapshot>(
+      "linkedinProfileSnapshot",
+      LINKEDIN_PROFILE_SNAPSHOT_VERSION,
+    )!;
+    expect(linkedinProfile).toEqual({ listings: [] });
+
+    expect(getConnectorSyncSnapshot()).toEqual({});
+    expect(getLinkedInProfileSnapshot()).toEqual({ listings: [] });
+  });
+
   test("importFromJson adds resume metadata when migrating snapshots", () => {
     jest.useFakeTimers();
     try {
@@ -156,6 +190,48 @@ describe("dataStore migrations", () => {
     const comp = { salary: "100k", benefits: "health", stock: "50" };
     saveCurrentCompensation(comp);
     expect(getCurrentCompensation()).toEqual(comp);
+  });
+
+  test("connector sync snapshot save and load", () => {
+    const snapshot: ConnectorSyncSnapshot = {
+      linkedin: {
+        status: "success",
+        lastAttemptedAt: "2024-02-01T00:00:00.000Z",
+        lastSuccessfulAt: "2024-02-01T00:00:00.000Z",
+      },
+      indeed: {
+        status: "error",
+        lastAttemptedAt: "2024-02-02T00:00:00.000Z",
+        error: "network",
+      },
+    };
+
+    saveConnectorSyncSnapshot(snapshot);
+    expect(getConnectorSyncSnapshot()).toEqual(snapshot);
+  });
+
+  test("linkedin profile snapshot save and load", () => {
+    const snapshot: LinkedInProfileSnapshot = {
+      capturedAt: "2024-02-03T00:00:00.000Z",
+      profile: {
+        id: "ln-1",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        headline: "Pioneer",
+      },
+      listings: [
+        {
+          title: "Engineer",
+          company: "Acme",
+          location: "Remote",
+          url: "https://example.com/1",
+          source: "linkedin",
+        },
+      ],
+    };
+
+    saveLinkedInProfileSnapshot(snapshot);
+    expect(getLinkedInProfileSnapshot()).toEqual(snapshot);
   });
 
   test("setGoals saves normalized selections", () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,4 +2,5 @@ export * from "./talentforge/models";
 export type { JobListing, ApplicationStatus, StatusChange } from "./talentforge/job";
 export * from "./talentforge/resume";
 export * from "./talentforge/types";
+export * from "./talentforge/connectors";
 export type { ApplicationRecord as JobApplication } from "./talentforge/models";

--- a/src/types/talentforge/connectors.ts
+++ b/src/types/talentforge/connectors.ts
@@ -1,0 +1,61 @@
+import type { JobListing } from "./job";
+
+/** Possible statuses for a connector sync operation. */
+export type ConnectorSyncStatus = "idle" | "syncing" | "success" | "error";
+
+/**
+ * Metadata describing the outcome of the most recent connector sync.
+ */
+export interface ConnectorSyncState {
+  /** Current status for the connector's latest sync run. */
+  status: ConnectorSyncStatus;
+  /** ISO timestamp when the latest sync attempt started. */
+  lastAttemptedAt?: string;
+  /** ISO timestamp when the connector last synced successfully. */
+  lastSuccessfulAt?: string;
+  /** Optional error message captured from the latest failure. */
+  error?: string;
+}
+
+/**
+ * Snapshot of sync metadata keyed by connector identifier.
+ */
+export interface ConnectorSyncSnapshot {
+  [connector: string]: ConnectorSyncState | undefined;
+}
+
+/**
+ * Minimal set of fields captured from a LinkedIn profile during sync.
+ */
+export interface LinkedInProfileDetails {
+  /** Unique identifier for the LinkedIn member. */
+  id: string;
+  /** Member's first name. */
+  firstName: string;
+  /** Member's last name. */
+  lastName: string;
+  /** Optional professional headline displayed on LinkedIn. */
+  headline?: string;
+  /** Optional primary location for the member. */
+  location?: string;
+  /** Optional industry designation. */
+  industry?: string;
+  /** Optional summary/about text shown on the profile. */
+  summary?: string;
+  /** Optional approximate connection count. */
+  connections?: number;
+}
+
+/**
+ * Snapshot of LinkedIn profile information retrieved during a connector sync.
+ */
+export interface LinkedInProfileSnapshot {
+  /** ISO timestamp indicating when the snapshot was captured. */
+  capturedAt?: string;
+  /** Optional error captured from the most recent sync attempt. */
+  error?: string;
+  /** Profile details returned by the LinkedIn connector. */
+  profile?: LinkedInProfileDetails;
+  /** Job listings fetched alongside the profile. */
+  listings: JobListing[];
+}

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -20,6 +20,10 @@ import type {
   OfferHistoryEntry,
   OfferComp,
   RecruiterEntry,
+  ConnectorSyncSnapshot,
+  ConnectorSyncState,
+  ConnectorSyncStatus,
+  LinkedInProfileSnapshot,
 } from "@/types";
 import { AUTO_REPLY_TEMPLATES } from "@/utils/autoReply/templates";
 import type { TalentForgeGoalTag } from "./promptRegistry";
@@ -44,6 +48,8 @@ interface StoreSchema {
   onboarding: number;
   openai: string | undefined;
   connectorTokens: Record<string, ConnectorToken>;
+  connectorSyncSnapshot: ConnectorSyncSnapshot;
+  linkedinProfileSnapshot: LinkedInProfileSnapshot;
   autoReplyTemplates: Record<string, string>;
   currentCompensation: CurrentCompensation;
   goals: TalentForgeGoalTag[];
@@ -60,6 +66,8 @@ const KEYS: { [K in keyof StoreSchema]: string } = {
   onboarding: "onboardingStep",
   openai: "talentforge-openai-key",
   connectorTokens: "connectorTokens",
+  connectorSyncSnapshot: "connectorSyncSnapshot",
+  linkedinProfileSnapshot: "linkedinProfileSnapshot",
   autoReplyTemplates: "autoReplyTemplates",
   currentCompensation: "currentCompensation",
   goals: "talentforge-goals",
@@ -83,6 +91,8 @@ export const RECRUITERS_VERSION = 1;
 export const ONBOARDING_VERSION = 1;
 export const OPENAI_VERSION = 1;
 export const CONNECTOR_TOKENS_VERSION = 1;
+export const CONNECTOR_SYNC_SNAPSHOT_VERSION = 1;
+export const LINKEDIN_PROFILE_SNAPSHOT_VERSION = 1;
 export const AUTO_REPLY_TEMPLATES_VERSION = 1;
 export const CURRENT_COMP_VERSION = 1;
 export const GOALS_VERSION = 1;
@@ -97,12 +107,14 @@ const VERSION: { [K in keyof StoreSchema]: number } = {
   onboarding: ONBOARDING_VERSION,
   openai: OPENAI_VERSION,
   connectorTokens: CONNECTOR_TOKENS_VERSION,
+  connectorSyncSnapshot: CONNECTOR_SYNC_SNAPSHOT_VERSION,
+  linkedinProfileSnapshot: LINKEDIN_PROFILE_SNAPSHOT_VERSION,
   autoReplyTemplates: AUTO_REPLY_TEMPLATES_VERSION,
   currentCompensation: CURRENT_COMP_VERSION,
   goals: GOALS_VERSION,
 } as const;
 
-export const SNAPSHOT_VERSION = 5;
+export const SNAPSHOT_VERSION = 6;
 
 // Generic migration helper which applies migrations sequentially until the
 // data reaches `targetVersion`.
@@ -190,6 +202,152 @@ function migrateConnectorTokens(
   );
 }
 
+function isConnectorSyncStatus(value: unknown): value is ConnectorSyncStatus {
+  return value === "idle" || value === "syncing" || value === "success" || value === "error";
+}
+
+function normalizeConnectorSyncState(value: unknown): ConnectorSyncState {
+  const base =
+    value && typeof value === "object"
+      ? (value as Partial<ConnectorSyncState>)
+      : {};
+  const state: ConnectorSyncState = {
+    status: isConnectorSyncStatus(base.status) ? base.status : "idle",
+  };
+  if (typeof base.lastAttemptedAt === "string") {
+    state.lastAttemptedAt = base.lastAttemptedAt;
+  }
+  if (typeof base.lastSuccessfulAt === "string") {
+    state.lastSuccessfulAt = base.lastSuccessfulAt;
+  }
+  if (typeof base.error === "string") {
+    state.error = base.error;
+  }
+  return state;
+}
+
+function normalizeConnectorSyncSnapshot(value: unknown): ConnectorSyncSnapshot {
+  if (!value || typeof value !== "object") return {};
+  const snapshot: ConnectorSyncSnapshot = {};
+  for (const [connector, details] of Object.entries(value as Record<string, unknown>)) {
+    snapshot[connector] = normalizeConnectorSyncState(details);
+  }
+  return snapshot;
+}
+
+function migrateConnectorSyncSnapshot(
+  data: unknown,
+  version: number,
+): ConnectorSyncSnapshot {
+  return migrate<ConnectorSyncSnapshot>(
+    data,
+    version,
+    CONNECTOR_SYNC_SNAPSHOT_VERSION,
+    {
+      0: normalizeConnectorSyncSnapshot,
+    },
+  );
+}
+
+function normalizeJobListings(value: unknown): JobListing[] {
+  if (!Array.isArray(value)) return [];
+  const listings: JobListing[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Record<string, unknown>;
+    const { title, company, location, url, source, description } = record;
+    if (
+      typeof title !== "string" ||
+      typeof company !== "string" ||
+      typeof location !== "string" ||
+      typeof url !== "string" ||
+      typeof source !== "string"
+    ) {
+      continue;
+    }
+    const listing: JobListing = {
+      title,
+      company,
+      location,
+      url,
+      source,
+    };
+    if (typeof description === "string") {
+      listing.description = description;
+    }
+    listings.push(listing);
+  }
+  return listings;
+}
+
+function normalizeLinkedInProfileSnapshot(value: unknown): LinkedInProfileSnapshot {
+  if (!value || typeof value !== "object") {
+    return { listings: [] };
+  }
+
+  const candidate = value as Partial<LinkedInProfileSnapshot> &
+    Record<string, unknown>;
+  const snapshot: LinkedInProfileSnapshot = {
+    listings: normalizeJobListings(candidate.listings),
+  };
+
+  if (typeof candidate.capturedAt === "string") {
+    snapshot.capturedAt = candidate.capturedAt;
+  }
+  if (typeof candidate.error === "string") {
+    snapshot.error = candidate.error;
+  }
+
+  const profileCandidate = candidate.profile;
+  if (profileCandidate && typeof profileCandidate === "object") {
+    const raw = profileCandidate as Record<string, unknown>;
+    const { id, firstName, lastName } = raw;
+    if (
+      typeof id === "string" &&
+      typeof firstName === "string" &&
+      typeof lastName === "string"
+    ) {
+      const profile: NonNullable<LinkedInProfileSnapshot["profile"]> = {
+        id,
+        firstName,
+        lastName,
+      };
+      if (typeof raw.headline === "string") {
+        profile.headline = raw.headline;
+      }
+      if (typeof raw.location === "string") {
+        profile.location = raw.location;
+      }
+      if (typeof raw.industry === "string") {
+        profile.industry = raw.industry;
+      }
+      if (typeof raw.summary === "string") {
+        profile.summary = raw.summary;
+      }
+      if (typeof raw.connections === "number") {
+        profile.connections = raw.connections;
+      }
+      snapshot.profile = profile;
+    }
+  }
+
+  return snapshot;
+}
+
+function migrateLinkedInProfileSnapshot(
+  data: unknown,
+  version: number,
+): LinkedInProfileSnapshot {
+  return migrate<LinkedInProfileSnapshot>(
+    data,
+    version,
+    LINKEDIN_PROFILE_SNAPSHOT_VERSION,
+    {
+      0: normalizeLinkedInProfileSnapshot,
+    },
+  );
+}
+
 function migrateAutoReplyTemplates(
   data: unknown,
   version: number,
@@ -261,6 +419,8 @@ const MIGRATORS: {
   onboarding: migrateOnboarding,
   openai: migrateOpenAI,
   connectorTokens: migrateConnectorTokens,
+  connectorSyncSnapshot: migrateConnectorSyncSnapshot,
+  linkedinProfileSnapshot: migrateLinkedInProfileSnapshot,
   autoReplyTemplates: migrateAutoReplyTemplates,
   currentCompensation: migrateCurrentCompensation,
   goals: migrateGoals,
@@ -276,6 +436,8 @@ const DEFAULTS: { [K in keyof StoreSchema]: StoreSchema[K] } = {
   onboarding: 0,
   openai: undefined,
   connectorTokens: {},
+  connectorSyncSnapshot: {},
+  linkedinProfileSnapshot: { listings: [] as JobListing[] },
   autoReplyTemplates: AUTO_REPLY_TEMPLATES as Record<string, string>,
   currentCompensation: { salary: "", benefits: "", stock: "" },
   goals: [],
@@ -899,6 +1061,26 @@ export function deleteConnectorToken(connector: string): void {
   save("connectorTokens", tokens);
 }
 
+export function getConnectorSyncSnapshot(): ConnectorSyncSnapshot {
+  return load("connectorSyncSnapshot", {});
+}
+
+export function saveConnectorSyncSnapshot(
+  snapshot: ConnectorSyncSnapshot,
+): void {
+  save("connectorSyncSnapshot", snapshot);
+}
+
+export function getLinkedInProfileSnapshot(): LinkedInProfileSnapshot {
+  return load("linkedinProfileSnapshot", { listings: [] });
+}
+
+export function saveLinkedInProfileSnapshot(
+  snapshot: LinkedInProfileSnapshot,
+): void {
+  save("linkedinProfileSnapshot", snapshot);
+}
+
 // Export / Import
 function migrateSnapshot(
   fromVersion: number,
@@ -907,6 +1089,20 @@ function migrateSnapshot(
   const migrated = { ...data };
   if (fromVersion < 2) {
     migrated[KEYS.connectorTokens] = migrated[KEYS.connectorTokens] || {};
+  }
+  if (fromVersion < 6) {
+    if (!(KEYS.connectorSyncSnapshot in migrated)) {
+      migrated[KEYS.connectorSyncSnapshot] = {
+        version: CONNECTOR_SYNC_SNAPSHOT_VERSION,
+        data: {},
+      };
+    }
+    if (!(KEYS.linkedinProfileSnapshot in migrated)) {
+      migrated[KEYS.linkedinProfileSnapshot] = {
+        version: LINKEDIN_PROFILE_SNAPSHOT_VERSION,
+        data: { listings: [] },
+      };
+    }
   }
   if (fromVersion < 5) {
     const legacyGoalsEntry = migrated[LEGACY_GOALS_KEY];
@@ -1067,6 +1263,10 @@ const dataStore = {
   getConnectorToken,
   saveConnectorToken,
   deleteConnectorToken,
+  getConnectorSyncSnapshot,
+  saveConnectorSyncSnapshot,
+  getLinkedInProfileSnapshot,
+  saveLinkedInProfileSnapshot,
   exportToJson,
   importFromJson,
 };

--- a/src/utils/talentforge/snapshot.ts
+++ b/src/utils/talentforge/snapshot.ts
@@ -10,6 +10,8 @@ import {
   getJobApplications,
   getOnboardingStep,
   getOpenAIKey,
+  getConnectorSyncSnapshot,
+  getLinkedInProfileSnapshot,
 } from "./dataStore";
 
 export function exportSnapshot(): string {
@@ -27,5 +29,7 @@ export function importSnapshot(json: string): void {
   getJobApplications();
   getOnboardingStep();
   getOpenAIKey();
+  getConnectorSyncSnapshot();
+  getLinkedInProfileSnapshot();
 }
 


### PR DESCRIPTION
## Summary
- define typed connector sync and LinkedIn profile snapshot structures
- persist new snapshot data in the TalentForge data store with migrations and version bumps
- update snapshot utilities and tests to cover the new connector data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ce5801448330badf83b19547c62c