### PR TITLE
Fix type mismatches in OpenAI interstitial and data store

### DIFF
--- a/src/components/OpenAIKeyInterstitialContent.tsx
+++ b/src/components/OpenAIKeyInterstitialContent.tsx
@@ -13,7 +13,7 @@ export interface OpenAIKeyInterstitialContentProps {
   value: string;
   onChange: (value: string) => void;
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-  inputRef?: React.RefObject<HTMLInputElement>;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
   buttonLabel?: string;
   logoSrc?: string;
   logoAlt?: string;

--- a/src/utils/talentforge/dataStore.ts
+++ b/src/utils/talentforge/dataStore.ts
@@ -23,6 +23,7 @@ import type {
   ConnectorSyncSnapshot,
   ConnectorSyncState,
   ConnectorSyncStatus,
+  LinkedInProfileDetails,
   LinkedInProfileSnapshot,
 } from "@/types";
 import { AUTO_REPLY_TEMPLATES } from "@/utils/autoReply/templates";
@@ -300,7 +301,7 @@ function normalizeLinkedInProfileSnapshot(value: unknown): LinkedInProfileSnapsh
 
   const profileCandidate = candidate.profile;
   if (profileCandidate && typeof profileCandidate === "object") {
-    const raw = profileCandidate as Record<string, unknown>;
+    const raw = profileCandidate as Partial<LinkedInProfileDetails>;
     const { id, firstName, lastName } = raw;
     if (
       typeof id === "string" &&


### PR DESCRIPTION
## Summary
- allow the OpenAI key interstitial to accept refs that can start as null to match React useRef usage
- normalize LinkedIn profile snapshots using the strongly-typed LinkedInProfileDetails interface

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1d22fb83883309223e71f577c286c