### PR TITLE
Add application filtering controls to ApplicationBoard

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -65,6 +65,11 @@ import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import ApplicationDetailDrawer from "./ApplicationDetailDrawer";
 import CompareOffers from "./offers/CompareOffers";
 import useOfferExports from "@/hooks/talentforge/useOfferExports";
+import {
+  filterApplications,
+  hasActiveFilters,
+  type ApplicationFilters,
+} from "@/utils/talentforge/applicationFilters";
 
 interface Issue {
   severity: "red" | "yellow";
@@ -82,6 +87,10 @@ function formatOfferHistoryTimestamp(value: string): string {
     return value;
   }
   return date.toLocaleString();
+}
+
+function formatStatusLabel(status: ApplicationStatus): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 
@@ -368,6 +377,13 @@ function Card({
 
 export default function ApplicationBoard() {
   const [applications, setApplications] = useState<JobApplication[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<ApplicationFilters["status"]>(
+    "all",
+  );
+  const [companyFilter, setCompanyFilter] = useState("");
+  const [recruiterFilter, setRecruiterFilter] = useState("");
+  const [resumeFilter, setResumeFilter] = useState("");
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [title, setTitle] = useState("");
@@ -470,6 +486,39 @@ export default function ApplicationBoard() {
       setSelectedApplicationId(null);
     }
   }, [detailDrawerOpen, selectedApplication]);
+
+  const filters = useMemo<ApplicationFilters>(() => ({
+    searchText: searchQuery,
+    status: statusFilter,
+    company: companyFilter,
+    recruiterId: recruiterFilter,
+    resumeId: resumeFilter,
+  }), [searchQuery, statusFilter, companyFilter, recruiterFilter, resumeFilter]);
+
+  const filteredApplications = useMemo(
+    () => filterApplications(applications, filters),
+    [applications, filters],
+  );
+
+  const filtersApplied = useMemo(() => hasActiveFilters(filters), [filters]);
+
+  const companies = useMemo(() => {
+    const uniqueCompanies = new Set<string>();
+    applications.forEach((app) => {
+      if (app.role.company) {
+        uniqueCompanies.add(app.role.company);
+      }
+    });
+    return Array.from(uniqueCompanies).sort((a, b) => a.localeCompare(b));
+  }, [applications]);
+
+  const recruiterOptions = useMemo(() => {
+    const options = data.getRecruiters();
+    return [...options].sort((a, b) => a.name.localeCompare(b.name));
+  }, [applications, data]);
+
+  const hasApplications = applications.length > 0;
+  const hasMatches = filteredApplications.length > 0;
 
   const hasMultipleOffers = data.getOffers().length >= 2;
 
@@ -1111,6 +1160,9 @@ export default function ApplicationBoard() {
     if (resumeId && !updated.some((r) => r.id === resumeId)) {
       setResumeId("");
     }
+    if (resumeFilter && !updated.some((r) => r.id === resumeFilter)) {
+      setResumeFilter("");
+    }
   };
 
   const handleResumeModalClose = () => {
@@ -1121,6 +1173,14 @@ export default function ApplicationBoard() {
   const handleManageModalClose = () => {
     setManageResumesOpen(false);
     handleResumesUpdated(getResumes());
+  };
+
+  const handleClearFilters = () => {
+    setSearchQuery("");
+    setStatusFilter("all");
+    setCompanyFilter("");
+    setRecruiterFilter("");
+    setResumeFilter("");
   };
 
   return (
@@ -1164,6 +1224,117 @@ export default function ApplicationBoard() {
           </Button>
         )}
       </Stack>
+      <Paper
+        component="section"
+        aria-label="Filter applications"
+        sx={{ p: 2, mb: 2 }}
+      >
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={2}
+          useFlexGap
+          sx={{ flexWrap: "wrap" }}
+        >
+          <TextField
+            label="Search applications"
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            size="small"
+            sx={{
+              flexGrow: 1,
+              minWidth: { xs: "100%", md: 240 },
+              width: { xs: "100%", md: "auto" },
+            }}
+          />
+          <TextField
+            label="Status"
+            select
+            value={statusFilter}
+            onChange={(event) =>
+              setStatusFilter(event.target.value as ApplicationFilters["status"])
+            }
+            size="small"
+            sx={{
+              minWidth: { xs: "100%", md: 180 },
+              width: { xs: "100%", md: "auto" },
+            }}
+          >
+            <MenuItem value="all">All statuses</MenuItem>
+            {STATUSES.map((status) => (
+              <MenuItem key={status} value={status}>
+                {formatStatusLabel(status)}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Company"
+            select
+            value={companyFilter}
+            onChange={(event) => setCompanyFilter(event.target.value)}
+            size="small"
+            sx={{
+              minWidth: { xs: "100%", md: 180 },
+              width: { xs: "100%", md: "auto" },
+            }}
+          >
+            <MenuItem value="">All companies</MenuItem>
+            {companies.map((company) => (
+              <MenuItem key={company} value={company}>
+                {company}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Recruiter"
+            select
+            value={recruiterFilter}
+            onChange={(event) => setRecruiterFilter(event.target.value)}
+            size="small"
+            sx={{
+              minWidth: { xs: "100%", md: 200 },
+              width: { xs: "100%", md: "auto" },
+            }}
+          >
+            <MenuItem value="">All recruiters</MenuItem>
+            {recruiterOptions.map((recruiter) => (
+              <MenuItem key={recruiter.id} value={recruiter.id}>
+                {recruiter.name}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Resume"
+            select
+            value={resumeFilter}
+            onChange={(event) => setResumeFilter(event.target.value)}
+            size="small"
+            sx={{
+              minWidth: { xs: "100%", md: 200 },
+              width: { xs: "100%", md: "auto" },
+            }}
+            disabled={resumes.length === 0}
+          >
+            <MenuItem value="">All resumes</MenuItem>
+            {resumes.map((resume) => (
+              <MenuItem key={resume.id} value={resume.id}>
+                {resume.title}
+              </MenuItem>
+            ))}
+          </TextField>
+          <Button
+            variant="outlined"
+            onClick={handleClearFilters}
+            disabled={!filtersApplied}
+            sx={{
+              alignSelf: { xs: "stretch", md: "center" },
+              width: { xs: "100%", md: "auto" },
+            }}
+          >
+            Clear filters
+          </Button>
+        </Stack>
+      </Paper>
       <ResumeStepperModal
         open={resumeModalOpen}
         onClose={handleResumeModalClose}
@@ -1189,10 +1360,15 @@ export default function ApplicationBoard() {
         </DialogActions>
       </Dialog>
       <DndContext onDragEnd={handleDragEnd}>
-        {applications.length === 0 ? (
+        {!hasApplications ? (
           <EmptyState
             message="No applications yet"
             helperText="Start tracking your job applications here."
+          />
+        ) : !hasMatches ? (
+          <EmptyState
+            message="No applications match your filters"
+            helperText="Try adjusting the search or filter selections."
           />
         ) : (
           <Box
@@ -1209,9 +1385,9 @@ export default function ApplicationBoard() {
               <Column
                 key={status}
                 id={status}
-                title={status.charAt(0).toUpperCase() + status.slice(1)}
+                title={formatStatusLabel(status)}
               >
-                {applications
+                {filteredApplications
                   .filter((app) => app.status === status)
                   .map((app) => (
                     <Card

--- a/src/tests/talentforge/applicationFilters.test.ts
+++ b/src/tests/talentforge/applicationFilters.test.ts
@@ -1,0 +1,280 @@
+import {
+  filterApplications,
+  hasActiveFilters,
+  type ApplicationFilters,
+} from "@/utils/talentforge/applicationFilters";
+import type { JobApplication, RecruiterEntry, ResumeEntry } from "@/types";
+
+type PartialApplication = Partial<JobApplication> & {
+  role?: Partial<JobApplication["role"]>;
+};
+
+const defaultApplicant: JobApplication["applicant"] = {
+  id: "user-1",
+  name: "Candidate One",
+  email: "candidate@example.com",
+};
+
+const resumeGeneral: ResumeEntry = {
+  id: "resume-1",
+  userId: "user-1",
+  label: "General Resume",
+  title: "General Engineering Resume",
+  url: "https://example.com/resume-1.pdf",
+  content: "Experience in backend systems",
+  parsed: {
+    contact: "Candidate One",
+    experience: [],
+    education: [],
+    skills: [],
+  },
+  tags: ["engineering"],
+  notes: "Tailored for backend roles",
+};
+
+const resumeDesign: ResumeEntry = {
+  id: "resume-2",
+  userId: "user-1",
+  label: "Design Resume",
+  title: "Product Design Resume",
+  url: "https://example.com/resume-2.pdf",
+  content: "Experience in product design",
+  parsed: {
+    contact: "Candidate One",
+    experience: [],
+    education: [],
+    skills: [],
+  },
+  tags: ["design"],
+  notes: "Highlights design projects",
+};
+
+const recruiterAlice: RecruiterEntry = {
+  id: "rec-1",
+  name: "Alice Recruiter",
+  email: "alice@example.com",
+  connector: "LinkedIn",
+  tags: ["design"],
+  notes: "Responsive",
+  threadIds: [],
+};
+
+const recruiterBob: RecruiterEntry = {
+  id: "rec-2",
+  name: "Bob Talent",
+  email: "bob@example.com",
+  connector: "Indeed",
+  tags: ["engineering"],
+  notes: "Prefers email",
+  threadIds: [],
+};
+
+function buildApplication(
+  id: string,
+  overrides: PartialApplication = {},
+): JobApplication {
+  const {
+    role: roleOverride,
+    history: historyOverride,
+    status: statusOverride,
+    applicant: applicantOverride,
+    ...rest
+  } = overrides;
+
+  const status: JobApplication["status"] = statusOverride ?? "applied";
+
+  const role: JobApplication["role"] = {
+    id: `role-${id}`,
+    title: "Software Engineer",
+    company: "Acme Corp",
+    location: "Remote",
+    description: "Work on modern web applications",
+    url: "https://example.com/job",
+    source: "LinkedIn",
+    ...(roleOverride ?? {}),
+  } as JobApplication["role"];
+
+  const applicant = applicantOverride ?? defaultApplicant;
+
+  const history =
+    historyOverride ?? [{ status, changedAt: "2024-01-01T00:00:00Z" }];
+
+  const base: JobApplication = {
+    id,
+    applicant,
+    role,
+    status,
+    history,
+  };
+
+  return { ...base, ...rest } as JobApplication;
+}
+
+const applications: JobApplication[] = [
+  buildApplication("app-1", {
+    status: "interview",
+    role: {
+      id: "role-1",
+      title: "Product Designer",
+      company: "Globex",
+      location: "Remote",
+      description: "Design delightful product experiences",
+    },
+    resumeVariant: resumeDesign,
+    recruiters: [recruiterAlice],
+  }),
+  buildApplication("app-2", {
+    status: "applied",
+    role: {
+      id: "role-2",
+      title: "Backend Engineer",
+      company: "Initech",
+      description: "Build reliable APIs",
+    },
+    resumeVariant: resumeGeneral,
+    recruiters: [recruiterBob],
+  }),
+  buildApplication("app-3", {
+    status: "offer",
+    role: {
+      id: "role-3",
+      title: "Data Scientist",
+      company: "Globex",
+      location: "New York",
+      description: "Analyze product usage data",
+    },
+    resumeVariant: resumeDesign,
+    recruiters: [recruiterAlice, recruiterBob],
+  }),
+];
+
+const baseFilters: ApplicationFilters = {
+  searchText: "",
+  status: "all",
+  company: "",
+  recruiterId: "",
+  resumeId: "",
+};
+
+describe("filterApplications", () => {
+  test("returns every application when no filters are active", () => {
+    const result = filterApplications(applications, baseFilters);
+    expect(result).toEqual(applications);
+  });
+
+  test("matches applications by search text across multiple fields", () => {
+    const filters: ApplicationFilters = {
+      ...baseFilters,
+      searchText: "backend",
+    };
+    const result = filterApplications(applications, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].role.title).toBe("Backend Engineer");
+  });
+
+  test("search is case-insensitive and matches recruiter names", () => {
+    const filters: ApplicationFilters = {
+      ...baseFilters,
+      searchText: "ALICE",
+    };
+    const result = filterApplications(applications, filters);
+    expect(result).toHaveLength(2);
+    expect(result.every((app) => app.recruiters?.some((r) => r.id === "rec-1"))).toBe(
+      true,
+    );
+  });
+
+  test("filters applications by status", () => {
+    const filters: ApplicationFilters = {
+      ...baseFilters,
+      status: "offer",
+    };
+    const result = filterApplications(applications, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("offer");
+  });
+
+  test("filters applications by company", () => {
+    const filters: ApplicationFilters = {
+      ...baseFilters,
+      company: "Globex",
+    };
+    const result = filterApplications(applications, filters);
+    expect(result).toHaveLength(2);
+    expect(result.every((app) => app.role.company === "Globex")).toBe(true);
+  });
+
+  test("filters applications by recruiter", () => {
+    const filters: ApplicationFilters = {
+      ...baseFilters,
+      recruiterId: "rec-2",
+    };
+    const result = filterApplications(applications, filters);
+    expect(result).toHaveLength(2);
+    expect(result.every((app) => app.recruiters?.some((r) => r.id === "rec-2"))).toBe(
+      true,
+    );
+  });
+
+  test("filters applications by resume variant", () => {
+    const filters: ApplicationFilters = {
+      ...baseFilters,
+      resumeId: "resume-1",
+    };
+    const result = filterApplications(applications, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].resumeVariant?.id).toBe("resume-1");
+  });
+
+  test("applies all active filters together", () => {
+    const filters: ApplicationFilters = {
+      searchText: "designer",
+      status: "interview",
+      company: "Globex",
+      recruiterId: "rec-1",
+      resumeId: "resume-2",
+    };
+    const result = filterApplications(applications, filters);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("app-1");
+  });
+});
+
+describe("hasActiveFilters", () => {
+  test("returns false when every filter is unset", () => {
+    expect(hasActiveFilters(baseFilters)).toBe(false);
+  });
+
+  test("returns true when any filter is applied", () => {
+    expect(
+      hasActiveFilters({
+        ...baseFilters,
+        searchText: "Acme",
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveFilters({
+        ...baseFilters,
+        status: "offer",
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveFilters({
+        ...baseFilters,
+        company: "Globex",
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveFilters({
+        ...baseFilters,
+        recruiterId: "rec-1",
+      }),
+    ).toBe(true);
+    expect(
+      hasActiveFilters({
+        ...baseFilters,
+        resumeId: "resume-2",
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/utils/talentforge/applicationFilters.ts
+++ b/src/utils/talentforge/applicationFilters.ts
@@ -1,0 +1,91 @@
+import type { ApplicationStatus, JobApplication } from "@/types";
+
+export type FilterStatus = ApplicationStatus | "all";
+
+export interface ApplicationFilters {
+  searchText: string;
+  status: FilterStatus;
+  company: string;
+  recruiterId: string;
+  resumeId: string;
+}
+
+function buildSearchHaystack(application: JobApplication): string {
+  const recruiterFields = (application.recruiters ?? []).flatMap((recruiter) => [
+    recruiter.name,
+    recruiter.email,
+  ]);
+
+  const resumeFields = application.resumeVariant
+    ? [
+        application.resumeVariant.title,
+        application.resumeVariant.label,
+        application.resumeVariant.notes,
+      ]
+    : [];
+
+  const fields = [
+    application.role.title,
+    application.role.company,
+    application.role.location,
+    application.role.description,
+    ...resumeFields,
+    ...recruiterFields,
+  ];
+
+  return fields
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+}
+
+export function filterApplications(
+  applications: JobApplication[],
+  filters: ApplicationFilters,
+): JobApplication[] {
+  const search = filters.searchText.trim().toLowerCase();
+
+  return applications.filter((application) => {
+    if (filters.status && filters.status !== "all") {
+      if (application.status !== filters.status) {
+        return false;
+      }
+    }
+
+    if (filters.company && application.role.company !== filters.company) {
+      return false;
+    }
+
+    if (filters.recruiterId) {
+      const recruiters = application.recruiters ?? [];
+      if (!recruiters.some((recruiter) => recruiter.id === filters.recruiterId)) {
+        return false;
+      }
+    }
+
+    if (filters.resumeId) {
+      if (application.resumeVariant?.id !== filters.resumeId) {
+        return false;
+      }
+    }
+
+    if (search) {
+      const haystack = buildSearchHaystack(application);
+      if (!haystack.includes(search)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+export function hasActiveFilters(filters: ApplicationFilters): boolean {
+  return (
+    Boolean(filters.searchText.trim()) ||
+    (filters.status && filters.status !== "all") ||
+    Boolean(filters.company) ||
+    Boolean(filters.recruiterId) ||
+    Boolean(filters.resumeId)
+  );
+}


### PR DESCRIPTION
## Summary
- add filter state management and memoized filtering logic to the talent forge application board
- render a responsive filter toolbar and only display cards that match the selected criteria
- extract filtering helpers and cover all filter combinations with new unit tests

## Testing
- npm test -- --runTestsByPath src/tests/talentforge/applicationFilters.test.ts
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d627837c8330a74f5556dc388c5f