### PR TITLE
Add application metrics summary and tests

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -23,6 +23,7 @@ import {
   ListItem,
   ListItemText,
 } from "@mui/material";
+import { alpha } from "@mui/material/styles";
 import { Check, Close, Delete, Edit, ExpandMore } from "@mui/icons-material";
 import { v4 as uuid } from "uuid";
 import {
@@ -60,6 +61,11 @@ import ResumeStepperModal from "./ResumeStepperModal";
 import ManageResumesModal from "./ManageResumesModal";
 import ChatWorkspace from "./ChatWorkspace";
 import { STATUSES, getNextStatus } from "@/utils/talentforge/keyboard";
+import {
+  calculateStageMetrics,
+  getMetricDisplay,
+  type StageMetric,
+} from "@/utils/talentforge/metrics";
 import { getPromptTile, type PromptContext } from "@/utils/talentforge/promptRegistry";
 import { useTalentForgeData } from "@/contexts/TalentForgeDataContext";
 import ApplicationDetailDrawer from "./ApplicationDetailDrawer";
@@ -93,28 +99,41 @@ function formatStatusLabel(status: ApplicationStatus): string {
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
-
 function Column({
   id,
   title,
   children,
+  highlight = false,
+  assistiveText,
 }: {
   id: ApplicationStatus;
   title: string;
   children: React.ReactNode;
+  highlight?: boolean;
+  assistiveText?: string;
 }) {
   const { setNodeRef } = useDroppable({ id });
   return (
     <Paper
       ref={setNodeRef}
       role="list"
-      aria-label={title}
+      aria-label={assistiveText ? `${title}. ${assistiveText}` : title}
+      elevation={highlight ? 6 : 1}
       sx={{
         p: 2,
         width: { xs: "100%", sm: 280, lg: 300 },
         minHeight: 400,
-        bgcolor: "background.paper",
+        bgcolor: (theme) =>
+          highlight
+            ? alpha(theme.palette.error.main, 0.08)
+            : theme.palette.background.paper,
         flexShrink: 0,
+        ...(highlight
+          ? {
+              outline: "2px solid",
+              outlineColor: "error.main",
+            }
+          : {}),
       }}
     >
       <Typography variant="h6" gutterBottom>
@@ -376,7 +395,15 @@ function Card({
 }
 
 export default function ApplicationBoard() {
-  const [applications, setApplications] = useState<JobApplication[]>([]);
+  const initialApplicationsRef = useRef<JobApplication[]>();
+  if (!initialApplicationsRef.current) {
+    initialApplicationsRef.current = getJobApplications();
+  }
+  const initialApplications = initialApplicationsRef.current!;
+
+  const [applications, setApplications] = useState<JobApplication[]>(
+    initialApplications,
+  );
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<ApplicationFilters["status"]>(
     "all",
@@ -384,7 +411,7 @@ export default function ApplicationBoard() {
   const [companyFilter, setCompanyFilter] = useState("");
   const [recruiterFilter, setRecruiterFilter] = useState("");
   const [resumeFilter, setResumeFilter] = useState("");
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(initialApplications.length === 0);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [company, setCompany] = useState("");
@@ -515,10 +542,27 @@ export default function ApplicationBoard() {
   const recruiterOptions = useMemo(() => {
     const options = data.getRecruiters();
     return [...options].sort((a, b) => a.name.localeCompare(b.name));
-  }, [applications, data]);
+  }, [data]);
 
   const hasApplications = applications.length > 0;
   const hasMatches = filteredApplications.length > 0;
+
+  const stageMetrics = useMemo(
+    () => calculateStageMetrics(filteredApplications),
+    [filteredApplications],
+  );
+
+  const metricsByStatus = useMemo(
+    () =>
+      stageMetrics.reduce(
+        (acc, metric) => {
+          acc[metric.status] = metric;
+          return acc;
+        },
+        {} as Record<ApplicationStatus, StageMetric>,
+      ),
+    [stageMetrics],
+  );
 
   const hasMultipleOffers = data.getOffers().length >= 2;
 
@@ -1371,42 +1415,107 @@ export default function ApplicationBoard() {
             helperText="Try adjusting the search or filter selections."
           />
         ) : (
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: { xs: "column", md: "row" },
-              alignItems: { xs: "stretch", md: "flex-start" },
-              gap: 2,
-              overflowX: { xs: "visible", md: "auto" },
-              pb: 2,
-            }}
-          >
-            {STATUSES.map((status) => (
-              <Column
-                key={status}
-                id={status}
-                title={formatStatusLabel(status)}
+          <Stack spacing={2} sx={{ pb: 2 }}>
+            <Paper
+              component="section"
+              aria-label="Application pipeline summary"
+              sx={{ p: 2 }}
+            >
+              <Stack
+                direction={{ xs: "column", md: "row" }}
+                spacing={2}
+                useFlexGap
+                sx={{ flexWrap: "wrap" }}
               >
-                {filteredApplications
-                  .filter((app) => app.status === status)
-                  .map((app) => (
-                    <Card
-                      key={app.id}
-                      app={app}
-                      onRunTile={(id, context) => runTile(id, context, app)}
-                      onOpenWorkspace={handleOpenWorkspace}
-                      onOpenDetails={handleOpenDetails}
-                      resumes={resumes}
-                      onAssignResume={handleAssignResume}
-                      onSetInterviewDate={handleInterviewDate}
-                      onSetInterviewLocation={handleInterviewLocation}
-                      onKeyDown={(e) => handleCardKeyDown(e, app)}
-                      activeId={activeId}
-                    />
-                  ))}
-              </Column>
-            ))}
-          </Box>
+                {stageMetrics.map((metric) => {
+                  const {
+                    averageLabel,
+                    thresholdLabel,
+                    conversionLabel,
+                    assistiveText,
+                    countLabel,
+                  } = getMetricDisplay(metric);
+                  return (
+                    <Box
+                      key={metric.status}
+                      role="group"
+                      aria-label={assistiveText}
+                      sx={{
+                        borderRadius: 1,
+                        border: "1px solid",
+                        borderColor: metric.slaBreached ? "error.main" : "divider",
+                        bgcolor: (theme) =>
+                          metric.slaBreached
+                            ? alpha(theme.palette.error.main, 0.08)
+                            : theme.palette.background.paper,
+                        minWidth: { xs: "100%", sm: 220 },
+                        p: 1.5,
+                      }}
+                    >
+                      <Typography variant="subtitle2" component="h3" gutterBottom>
+                        {metric.label}
+                      </Typography>
+                      <Typography variant="body2" component="p">
+                        {countLabel} in stage
+                      </Typography>
+                      <Typography variant="body2" component="p">
+                        Conversion {conversionLabel}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        component="p"
+                        color={metric.slaBreached ? "error.main" : "text.secondary"}
+                      >
+                        Avg dwell {averageLabel ?? "—"}
+                        {thresholdLabel ? ` (SLA ${thresholdLabel})` : ""}
+                      </Typography>
+                    </Box>
+                  );
+                })}
+              </Stack>
+            </Paper>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: { xs: "column", md: "row" },
+                alignItems: { xs: "stretch", md: "flex-start" },
+                gap: 2,
+                overflowX: { xs: "visible", md: "auto" },
+              }}
+            >
+              {STATUSES.map((status) => {
+                const metric = metricsByStatus[status];
+                const metricDisplay = metric ? getMetricDisplay(metric) : null;
+                return (
+                  <Column
+                    key={status}
+                    id={status}
+                    title={formatStatusLabel(status)}
+                    highlight={metric?.slaBreached ?? false}
+                    assistiveText={metricDisplay?.assistiveText}
+                  >
+                    {filteredApplications
+                      .filter((app) => app.status === status)
+                      .map((app) => (
+                        <Card
+                          key={app.id}
+                          app={app}
+                          onRunTile={(id, context) => runTile(id, context, app)}
+                          onOpenWorkspace={handleOpenWorkspace}
+                          onOpenDetails={handleOpenDetails}
+                          resumes={resumes}
+                          onAssignResume={handleAssignResume}
+                          onSetInterviewDate={handleInterviewDate}
+                          onSetInterviewLocation={handleInterviewLocation}
+                          onKeyDown={(e) => handleCardKeyDown(e, app)}
+                          activeId={activeId}
+                        />
+                      ))}
+                  </Column>
+                );
+              })}
+            </Box>
+          </Stack>
         )}
       </DndContext>
       <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>

--- a/src/tests/talentforge/ApplicationBoard.metrics.test.tsx
+++ b/src/tests/talentforge/ApplicationBoard.metrics.test.tsx
@@ -1,0 +1,97 @@
+import { calculateStageMetrics, getMetricDisplay } from '@/utils/talentforge/metrics';
+import type { JobApplication } from '@/types';
+
+const createApplications = (): JobApplication[] => [
+  {
+    id: 'app-1',
+    applicant: {
+      id: 'candidate-1',
+      name: 'Candidate One',
+      email: 'candidate1@example.com',
+    },
+    role: {
+      id: 'role-1',
+      title: 'Frontend Engineer',
+      company: 'Acme Corp',
+      location: 'Remote',
+      description: 'Build modern web experiences.',
+    },
+    status: 'offer',
+    history: [
+      { status: 'applied', changedAt: '2024-01-01T00:00:00.000Z' },
+      { status: 'interview', changedAt: '2024-01-10T00:00:00.000Z' },
+      { status: 'offer', changedAt: '2024-01-15T00:00:00.000Z' },
+    ],
+  },
+  {
+    id: 'app-2',
+    applicant: {
+      id: 'candidate-2',
+      name: 'Candidate Two',
+      email: 'candidate2@example.com',
+    },
+    role: {
+      id: 'role-2',
+      title: 'Product Designer',
+      company: 'Design Co',
+      location: 'Hybrid',
+      description: 'Shape end-to-end product experiences.',
+    },
+    status: 'rejected',
+    history: [
+      { status: 'applied', changedAt: '2024-01-05T00:00:00.000Z' },
+      { status: 'interview', changedAt: '2024-01-12T00:00:00.000Z' },
+      { status: 'rejected', changedAt: '2024-01-20T00:00:00.000Z' },
+    ],
+  },
+  {
+    id: 'app-3',
+    applicant: {
+      id: 'candidate-3',
+      name: 'Candidate Three',
+      email: 'candidate3@example.com',
+    },
+    role: {
+      id: 'role-3',
+      title: 'Data Analyst',
+      company: 'Insights Inc',
+      location: 'Remote',
+      description: 'Surface insights from complex datasets.',
+    },
+    status: 'applied',
+    history: [
+      { status: 'applied', changedAt: '2023-12-20T00:00:00.000Z' },
+    ],
+  },
+];
+
+const NOW = new Date('2024-02-01T00:00:00.000Z').getTime();
+
+describe('Application pipeline metrics', () => {
+  test('calculateStageMetrics snapshot', () => {
+    const metrics = calculateStageMetrics(createApplications(), NOW);
+    const serialized = metrics.map((metric) => ({
+      status: metric.status,
+      currentCount: metric.currentCount,
+      reachedCount: metric.reachedCount,
+      conversionRate: metric.conversionRate,
+      averageDurationDays: metric.averageDurationDays,
+      slaBreached: metric.slaBreached,
+    }));
+    expect(serialized).toMatchSnapshot();
+  });
+
+  test('getMetricDisplay snapshot', () => {
+    const metrics = calculateStageMetrics(createApplications(), NOW);
+    const displays = metrics.map((metric) => getMetricDisplay(metric));
+    expect(displays).toMatchSnapshot();
+  });
+
+  test('applied stage assistive text highlights SLA breach', () => {
+    const metrics = calculateStageMetrics(createApplications(), NOW);
+    const applied = metrics.find((metric) => metric.status === 'applied');
+    expect(applied?.slaBreached).toBe(true);
+    const assistive = applied ? getMetricDisplay(applied).assistiveText : '';
+    expect(assistive).toContain('exceeds SLA');
+  });
+});

--- a/src/tests/talentforge/__snapshots__/ApplicationBoard.metrics.test.tsx.snap
+++ b/src/tests/talentforge/__snapshots__/ApplicationBoard.metrics.test.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Application pipeline metrics calculateStageMetrics snapshot 1`] = `
+[
+  {
+    "averageDurationDays": 19.666666666666668,
+    "conversionRate": 1,
+    "currentCount": 1,
+    "reachedCount": 3,
+    "slaBreached": true,
+    "status": "applied",
+  },
+  {
+    "averageDurationDays": 6.5,
+    "conversionRate": 0.6666666666666666,
+    "currentCount": 0,
+    "reachedCount": 2,
+    "slaBreached": true,
+    "status": "interview",
+  },
+  {
+    "averageDurationDays": 17,
+    "conversionRate": 0.3333333333333333,
+    "currentCount": 1,
+    "reachedCount": 1,
+    "slaBreached": true,
+    "status": "offer",
+  },
+  {
+    "averageDurationDays": 12,
+    "conversionRate": 0.3333333333333333,
+    "currentCount": 1,
+    "reachedCount": 1,
+    "slaBreached": true,
+    "status": "rejected",
+  },
+]
+`;
+
+exports[`Application pipeline metrics getMetricDisplay snapshot 1`] = `
+[
+  {
+    "assistiveText": "Applied stage. 1 in stage. conversion 100%. average dwell 19.7 days. exceeds SLA of 7 days",
+    "averageLabel": "19.7 days",
+    "conversionLabel": "100%",
+    "countLabel": "1",
+    "thresholdLabel": "7 days",
+  },
+  {
+    "assistiveText": "Interview stage. 0 in stage. conversion 67%. average dwell 6.5 days. exceeds SLA of 5 days",
+    "averageLabel": "6.5 days",
+    "conversionLabel": "67%",
+    "countLabel": "0",
+    "thresholdLabel": "5 days",
+  },
+  {
+    "assistiveText": "Offer stage. 1 in stage. conversion 33%. average dwell 17 days. exceeds SLA of 3 days",
+    "averageLabel": "17 days",
+    "conversionLabel": "33%",
+    "countLabel": "1",
+    "thresholdLabel": "3 days",
+  },
+  {
+    "assistiveText": "Rejected stage. 1 in stage. conversion 33%. average dwell 12 days. exceeds SLA of 2 days",
+    "averageLabel": "12 days",
+    "conversionLabel": "33%",
+    "countLabel": "1",
+    "thresholdLabel": "2 days",
+  },
+]
+`;

--- a/src/utils/talentforge/metrics.ts
+++ b/src/utils/talentforge/metrics.ts
@@ -1,0 +1,231 @@
+import type { ApplicationStatus, JobApplication } from "@/types";
+import { STATUSES } from "@/utils/talentforge/keyboard";
+
+export const SLA_THRESHOLDS_DAYS: Readonly<Record<ApplicationStatus, number>> = {
+  applied: 7,
+  interview: 5,
+  offer: 3,
+  rejected: 2,
+};
+
+const MS_IN_DAY = 1000 * 60 * 60 * 24;
+
+const numberFormatter = new Intl.NumberFormat();
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 0,
+  minimumFractionDigits: 0,
+});
+const daysFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0,
+});
+const hoursFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0,
+});
+const minutesFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 0,
+  minimumFractionDigits: 0,
+});
+
+function parseTimestamp(value: string): number | null {
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? null : time;
+}
+
+function formatDuration(days: number): string {
+  if (!Number.isFinite(days) || days < 0) {
+    return "—";
+  }
+  if (days >= 2) {
+    return `${daysFormatter.format(days)} days`;
+  }
+  const hours = days * 24;
+  if (hours >= 2) {
+    return `${hoursFormatter.format(hours)} hours`;
+  }
+  const minutes = Math.round(hours * 60);
+  return `${minutesFormatter.format(minutes)} minutes`;
+}
+
+function getThresholdLabel(status: ApplicationStatus): string | null {
+  const threshold = SLA_THRESHOLDS_DAYS[status];
+  return typeof threshold === "number" ? formatDuration(threshold) : null;
+}
+
+function buildAssistiveSummary(
+  metric: StageMetric,
+  conversionLabel: string,
+  averageLabel: string | null,
+  thresholdLabel: string | null,
+): string {
+  const parts = [`${metric.label} stage`];
+  parts.push(`${numberFormatter.format(metric.currentCount)} in stage`);
+  if (metric.conversionRate !== null) {
+    parts.push(`conversion ${conversionLabel}`);
+  }
+  if (averageLabel) {
+    parts.push(`average dwell ${averageLabel}`);
+  }
+  if (thresholdLabel) {
+    parts.push(
+      metric.slaBreached
+        ? `exceeds SLA of ${thresholdLabel}`
+        : `SLA ${thresholdLabel}`,
+    );
+  }
+  return parts.join(". ");
+}
+
+export interface StageMetric {
+  status: ApplicationStatus;
+  label: string;
+  currentCount: number;
+  reachedCount: number;
+  conversionRate: number | null;
+  averageDurationDays: number | null;
+  slaBreached: boolean;
+}
+
+interface StageMetricAccumulator {
+  status: ApplicationStatus;
+  label: string;
+  currentCount: number;
+  reachedCount: number;
+  totalDurationMs: number;
+  durationSamples: number;
+}
+
+export function calculateStageMetrics(
+  applications: JobApplication[],
+  now: number = Date.now(),
+): StageMetric[] {
+  const metricMap = new Map<ApplicationStatus, StageMetricAccumulator>(
+    STATUSES.map((status) => [
+      status,
+      {
+        status,
+        label: status.charAt(0).toUpperCase() + status.slice(1),
+        currentCount: 0,
+        reachedCount: 0,
+        totalDurationMs: 0,
+        durationSamples: 0,
+      },
+    ]),
+  );
+
+  applications.forEach((app) => {
+    const currentMetric = metricMap.get(app.status);
+    if (currentMetric) {
+      currentMetric.currentCount += 1;
+    }
+
+    const history = [...(app.history ?? [])].sort((a, b) => {
+      const aTime = parseTimestamp(a.changedAt);
+      const bTime = parseTimestamp(b.changedAt);
+      if (aTime === null && bTime === null) return 0;
+      if (aTime === null) return -1;
+      if (bTime === null) return 1;
+      return aTime - bTime;
+    });
+
+    const reachedStatuses = new Set<ApplicationStatus>();
+
+    history.forEach((entry, index) => {
+      const metric = metricMap.get(entry.status);
+      if (!metric) {
+        return;
+      }
+      if (!reachedStatuses.has(entry.status)) {
+        metric.reachedCount += 1;
+        reachedStatuses.add(entry.status);
+      }
+
+      const startTime = parseTimestamp(entry.changedAt);
+      if (startTime === null) {
+        return;
+      }
+
+      let endTime: number | null = null;
+      for (let nextIndex = index + 1; nextIndex < history.length; nextIndex += 1) {
+        const nextTime = parseTimestamp(history[nextIndex].changedAt);
+        if (nextTime !== null) {
+          endTime = nextTime;
+          break;
+        }
+      }
+
+      if (endTime === null && app.status === entry.status) {
+        endTime = now;
+      }
+
+      if (endTime !== null && endTime >= startTime) {
+        metric.totalDurationMs += endTime - startTime;
+        metric.durationSamples += 1;
+      }
+    });
+
+    if (!reachedStatuses.has(app.status)) {
+      const metric = metricMap.get(app.status);
+      if (metric) {
+        metric.reachedCount += 1;
+      }
+    }
+  });
+
+  return STATUSES.map((status) => {
+    const metric = metricMap.get(status)!;
+    const averageDurationDays =
+      metric.durationSamples > 0
+        ? metric.totalDurationMs / metric.durationSamples / MS_IN_DAY
+        : null;
+
+    const threshold = SLA_THRESHOLDS_DAYS[status];
+    const slaBreached =
+      averageDurationDays !== null &&
+      typeof threshold === "number" &&
+      averageDurationDays > threshold;
+
+    return {
+      status,
+      label: metric.label,
+      currentCount: metric.currentCount,
+      reachedCount: metric.reachedCount,
+      conversionRate:
+        applications.length > 0
+          ? metric.reachedCount / applications.length
+          : null,
+      averageDurationDays,
+      slaBreached,
+    };
+  });
+}
+
+export interface StageMetricDisplay {
+  countLabel: string;
+  conversionLabel: string;
+  averageLabel: string | null;
+  thresholdLabel: string | null;
+  assistiveText: string;
+}
+
+export function getMetricDisplay(metric: StageMetric): StageMetricDisplay {
+  const averageLabel =
+    metric.averageDurationDays !== null
+      ? formatDuration(metric.averageDurationDays)
+      : null;
+  const thresholdLabel = getThresholdLabel(metric.status);
+  const conversionLabel =
+    metric.conversionRate === null
+      ? "—"
+      : percentFormatter.format(metric.conversionRate);
+  const assistiveText = buildAssistiveSummary(
+    metric,
+    conversionLabel,
+    averageLabel,
+    thresholdLabel,
+  );
+  const countLabel = numberFormatter.format(metric.currentCount);
+  return { countLabel, conversionLabel, averageLabel, thresholdLabel, assistiveText };
+}


### PR DESCRIPTION
## Summary
- add an application pipeline summary bar with conversion and dwell time metrics
- extract stage metric calculations into a shared utility
- add snapshot tests covering metric output for representative data

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d93dfee4833091f9237b60308a94