### PR TITLE
Fix ApplicationBoard initial applications ref

### DIFF
--- a/src/components/talentforge/ApplicationBoard.tsx
+++ b/src/components/talentforge/ApplicationBoard.tsx
@@ -395,11 +395,11 @@ function Card({
 }
 
 export default function ApplicationBoard() {
-  const initialApplicationsRef = useRef<JobApplication[]>();
+  const initialApplicationsRef = useRef<JobApplication[] | null>(null);
   if (!initialApplicationsRef.current) {
     initialApplicationsRef.current = getJobApplications();
   }
-  const initialApplications = initialApplicationsRef.current!;
+  const initialApplications = initialApplicationsRef.current ?? [];
 
   const [applications, setApplications] = useState<JobApplication[]>(
     initialApplications,


### PR DESCRIPTION
## Summary
- initialize the ApplicationBoard job applications ref with a null default and provide a non-null fallback to avoid the strict ref type error during builds

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1e141aa88833080fcdff6af50010e